### PR TITLE
Add Code of Conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in PlanOpticon a welcoming experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+**Expected behavior:**
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy toward other community members
+
+**Unacceptable behavior:**
+
+- Trolling, insulting or derogatory comments, and personal attacks
+- Public or private unwelcome conduct
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, or to temporarily or permanently ban any contributor for behaviors they deem inappropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and in public spaces when an individual is representing the project or its community.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported by contacting the project team at:
+
+**conduct@weareconflict.com**
+
+All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -125,6 +125,10 @@ Keep the subject line under 72 characters. Use the body to explain *what* and *w
 - **Features:** Open an issue using the [Feature Request](https://github.com/ConflictHQ/PlanOpticon/issues/new?template=feature_request.yml) template.
 - **Questions:** Start a thread in [Discussions](https://github.com/ConflictHQ/PlanOpticon/discussions).
 
+## Code of Conduct
+
+This project follows a [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold it.
+
 ## Security
 
 If you discover a security vulnerability, please do **not** open a public issue. Instead, follow the process described in our [Security Policy](SECURITY.md).


### PR DESCRIPTION
## Summary
- Add Contributor Covenant-based Code of Conduct (`.github/CODE_OF_CONDUCT.md`)
- Link to Code of Conduct from CONTRIBUTING.md