### PR TITLE
Add Ollama provider for fully offline video analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 **AI-powered video analysis and knowledge extraction.**
 
-PlanOpticon processes video recordings into structured knowledge — transcripts, diagrams, action items, key points, and knowledge graphs. It auto-discovers available models across OpenAI, Anthropic, and Gemini, and produces rich multi-format output.
+PlanOpticon processes video recordings into structured knowledge — transcripts, diagrams, action items, key points, and knowledge graphs. It auto-discovers available models across OpenAI, Anthropic, Gemini, and Ollama, and produces rich multi-format output.
 
 ## Features
 
-- **Multi-provider AI** — Auto-discovers and routes to the best available model across OpenAI, Anthropic, and Google Gemini
+- **Multi-provider AI** — Auto-discovers and routes to the best available model across OpenAI, Anthropic, Google Gemini, and Ollama (fully offline)
 - **Smart frame extraction** — Change detection for transitions + periodic capture for slow-evolving content (document scrolling, screen shares)
 - **People frame filtering** — OpenCV face detection automatically removes webcam/video conference frames, keeping only shared content
 - **Diagram extraction** — Vision model classification detects flowcharts, architecture diagrams, charts, and whiteboards
@@ -67,7 +67,7 @@ Download standalone binaries (no Python required) from [GitHub Releases](https:/
 
 - Python 3.10+
 - FFmpeg (`brew install ffmpeg` / `apt install ffmpeg`)
-- At least one API key: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `GEMINI_API_KEY`
+- At least one API key (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `GEMINI_API_KEY`) **or** [Ollama](https://ollama.com) running locally
 
 ## Output Structure
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -45,6 +45,7 @@ video_processor/
 │   ├── openai_provider.py
 │   ├── anthropic_provider.py
 │   ├── gemini_provider.py
+│   ├── ollama_provider.py  # Local Ollama (offline)
 │   ├── discovery.py        # Auto-model-discovery
 │   └── manager.py          # ProviderManager routing
 ├── utils/
@@ -62,6 +63,6 @@ video_processor/
 
 - **Pydantic everywhere** — All structured data uses pydantic models for validation and serialization
 - **Manifest-driven** — Every run produces `manifest.json` as the single source of truth
-- **Provider abstraction** — Single `ProviderManager` wraps OpenAI, Anthropic, Gemini behind a common interface
+- **Provider abstraction** — Single `ProviderManager` wraps OpenAI, Anthropic, Gemini, and Ollama behind a common interface
 - **No hardcoded models** — Model lists come from API discovery
 - **Screengrab fallback** — When extraction fails, save the frame as a captioned screenshot

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -19,7 +19,7 @@ planopticon analyze [OPTIONS]
 | `--change-threshold` | FLOAT | 0.15 | Visual change threshold |
 | `--periodic-capture` | FLOAT | 30.0 | Capture a frame every N seconds regardless of change (0 to disable) |
 | `--title` | TEXT | auto | Report title |
-| `-p`, `--provider` | `auto\|openai\|anthropic\|gemini` | `auto` | API provider |
+| `-p`, `--provider` | `auto\|openai\|anthropic\|gemini\|ollama` | `auto` | API provider |
 | `--vision-model` | TEXT | auto | Override vision model |
 | `--chat-model` | TEXT | auto | Override chat model |
 
@@ -40,7 +40,7 @@ planopticon batch [OPTIONS]
 | `--depth` | `basic\|standard\|comprehensive` | `standard` | Processing depth |
 | `--pattern` | TEXT | `*.mp4,*.mkv,*.avi,*.mov,*.webm` | File glob patterns |
 | `--title` | TEXT | `Batch Processing Results` | Batch title |
-| `-p`, `--provider` | `auto\|openai\|anthropic\|gemini` | `auto` | API provider |
+| `-p`, `--provider` | `auto\|openai\|anthropic\|gemini\|ollama` | `auto` | API provider |
 | `--vision-model` | TEXT | auto | Override vision model |
 | `--chat-model` | TEXT | auto | Override chat model |
 | `--source` | `local\|gdrive\|dropbox` | `local` | Video source |
@@ -92,7 +92,7 @@ planopticon agent-analyze [OPTIONS]
 | `-o`, `--output` | PATH | *required* | Output directory |
 | `--depth` | `basic\|standard\|comprehensive` | `standard` | Initial processing depth (agent may adapt) |
 | `--title` | TEXT | auto | Report title |
-| `-p`, `--provider` | `auto\|openai\|anthropic\|gemini` | `auto` | API provider |
+| `-p`, `--provider` | `auto\|openai\|anthropic\|gemini\|ollama` | `auto` | API provider |
 | `--vision-model` | TEXT | auto | Override vision model |
 | `--chat-model` | TEXT | auto | Override chat model |
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -7,6 +7,7 @@
 | `OPENAI_API_KEY` | OpenAI API key |
 | `ANTHROPIC_API_KEY` | Anthropic API key |
 | `GEMINI_API_KEY` | Google Gemini API key |
+| `OLLAMA_HOST` | Ollama server URL (default: `http://localhost:11434`) |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Path to Google service account JSON (for Drive) |
 | `CACHE_DIR` | Directory for API response caching |
 
@@ -16,9 +17,11 @@ PlanOpticon auto-discovers available models and routes each task to the best opt
 
 | Task | Default preference |
 |------|--------------------|
-| Vision (diagrams) | Gemini Flash > GPT-4o > Claude Sonnet |
-| Chat (analysis) | Claude Sonnet > GPT-4o > Gemini Flash |
-| Transcription | Whisper-1 > Gemini Flash |
+| Vision (diagrams) | Gemini Flash > GPT-4o > Claude Sonnet > Ollama |
+| Chat (analysis) | Claude Sonnet > GPT-4o > Gemini Flash > Ollama |
+| Transcription | Local Whisper > Whisper-1 > Gemini Flash |
+
+If no cloud API keys are configured, PlanOpticon automatically falls back to Ollama when a local server is running. This enables fully offline operation when paired with local Whisper for transcription.
 
 Override with `--provider`, `--vision-model`, or `--chat-model` flags.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -64,7 +64,11 @@ PlanOpticon requires **FFmpeg** for audio extraction:
 
 ## API keys
 
-You need at least one AI provider API key. Set them as environment variables:
+You need at least one AI provider API key **or** a running Ollama server.
+
+### Cloud providers
+
+Set API keys as environment variables:
 
 ```bash
 export OPENAI_API_KEY="sk-..."
@@ -79,5 +83,20 @@ OPENAI_API_KEY=sk-...
 ANTHROPIC_API_KEY=sk-ant-...
 GEMINI_API_KEY=AI...
 ```
+
+### Ollama (fully offline)
+
+No API keys needed — just install and run [Ollama](https://ollama.com):
+
+```bash
+# Install Ollama, then pull models
+ollama pull llama3.2        # Chat/analysis
+ollama pull llava            # Vision (diagram detection)
+
+# Start the server (if not already running)
+ollama serve
+```
+
+PlanOpticon auto-detects Ollama and uses it as a fallback when no cloud API keys are set. For a fully offline pipeline, pair Ollama with local Whisper transcription (`pip install planopticon[gpu]`).
 
 PlanOpticon will automatically discover which providers are available and route to the best model for each task.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -38,6 +38,9 @@ planopticon analyze -i video.mp4 -o ./out
 # Force a specific provider
 planopticon analyze -i video.mp4 -o ./out --provider openai
 
+# Use Ollama for fully offline processing (no API keys needed)
+planopticon analyze -i video.mp4 -o ./out --provider ollama
+
 # Override specific models
 planopticon analyze -i video.mp4 -o ./out \
     --vision-model gpt-4o \

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from video_processor.providers.base import BaseProvider, ModelInfo
 from video_processor.providers.manager import ProviderManager
 
@@ -109,17 +111,23 @@ class TestProviderManager:
 
 class TestDiscovery:
     @patch("video_processor.providers.discovery._cached_models", None)
+    @patch(
+        "video_processor.providers.ollama_provider.OllamaProvider.is_available", return_value=False
+    )
     @patch.dict("os.environ", {}, clear=True)
-    def test_discover_skips_missing_keys(self):
+    def test_discover_skips_missing_keys(self, mock_ollama):
         from video_processor.providers.discovery import discover_available_models
 
-        # No API keys -> empty list, no errors
+        # No API keys and no Ollama -> empty list, no errors
         models = discover_available_models(api_keys={"openai": "", "anthropic": "", "gemini": ""})
         assert models == []
 
     @patch.dict("os.environ", {}, clear=True)
+    @patch(
+        "video_processor.providers.ollama_provider.OllamaProvider.is_available", return_value=False
+    )
     @patch("video_processor.providers.discovery._cached_models", None)
-    def test_discover_caches_results(self):
+    def test_discover_caches_results(self, mock_ollama):
         from video_processor.providers import discovery
 
         models = discovery.discover_available_models(
@@ -133,3 +141,83 @@ class TestDiscovery:
         # Force refresh
         discovery.clear_discovery_cache()
         # Would try to connect with real key, so skip that test
+
+
+class TestOllamaProvider:
+    @patch("video_processor.providers.ollama_provider.requests")
+    def test_is_available_when_running(self, mock_requests):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_requests.get.return_value = mock_resp
+
+        from video_processor.providers.ollama_provider import OllamaProvider
+
+        assert OllamaProvider.is_available()
+
+    @patch("video_processor.providers.ollama_provider.requests")
+    def test_is_available_when_not_running(self, mock_requests):
+        mock_requests.get.side_effect = ConnectionError
+
+        from video_processor.providers.ollama_provider import OllamaProvider
+
+        assert not OllamaProvider.is_available()
+
+    @patch("video_processor.providers.ollama_provider.requests")
+    @patch("video_processor.providers.ollama_provider.OpenAI")
+    def test_transcribe_raises(self, mock_openai, mock_requests):
+        from video_processor.providers.ollama_provider import OllamaProvider
+
+        provider = OllamaProvider()
+        with pytest.raises(NotImplementedError):
+            provider.transcribe_audio("/tmp/test.wav")
+
+    @patch("video_processor.providers.ollama_provider.requests")
+    @patch("video_processor.providers.ollama_provider.OpenAI")
+    def test_list_models(self, mock_openai, mock_requests):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "models": [
+                {"name": "llama3.2:latest", "details": {"family": "llama"}},
+                {"name": "llava:13b", "details": {"family": "llava"}},
+            ]
+        }
+        mock_requests.get.return_value = mock_resp
+
+        from video_processor.providers.ollama_provider import OllamaProvider
+
+        provider = OllamaProvider()
+        models = provider.list_models()
+        assert len(models) == 2
+        assert models[0].provider == "ollama"
+
+        # llava should have vision capability
+        llava = [m for m in models if "llava" in m.id][0]
+        assert "vision" in llava.capabilities
+
+        # llama should have only chat
+        llama = [m for m in models if "llama" in m.id][0]
+        assert "chat" in llama.capabilities
+        assert "vision" not in llama.capabilities
+
+    def test_provider_for_model_ollama_via_discovery(self):
+        mgr = ProviderManager()
+        mgr._available_models = [
+            ModelInfo(id="llama3.2:latest", provider="ollama", capabilities=["chat"]),
+        ]
+        assert mgr._provider_for_model("llama3.2:latest") == "ollama"
+
+    def test_provider_for_model_ollama_fuzzy_tag(self):
+        mgr = ProviderManager()
+        mgr._available_models = [
+            ModelInfo(id="llama3.2:latest", provider="ollama", capabilities=["chat"]),
+        ]
+        # Should match "llama3.2" to "llama3.2:latest" via prefix
+        assert mgr._provider_for_model("llama3.2") == "ollama"
+
+    def test_init_forced_provider_ollama(self):
+        mgr = ProviderManager(provider="ollama")
+        # Ollama defaults are empty (resolved dynamically)
+        assert mgr.vision_model == ""
+        assert mgr.chat_model == ""
+        assert mgr.transcription_model == ""

--- a/video_processor/cli/commands.py
+++ b/video_processor/cli/commands.py
@@ -75,7 +75,7 @@ def cli(ctx, verbose):
 @click.option(
     "--provider",
     "-p",
-    type=click.Choice(["auto", "openai", "anthropic", "gemini"]),
+    type=click.Choice(["auto", "openai", "anthropic", "gemini", "ollama"]),
     default="auto",
     help="API provider",
 )
@@ -156,7 +156,7 @@ def analyze(
 @click.option(
     "--provider",
     "-p",
-    type=click.Choice(["auto", "openai", "anthropic", "gemini"]),
+    type=click.Choice(["auto", "openai", "anthropic", "gemini", "ollama"]),
     default="auto",
     help="API provider",
 )
@@ -345,8 +345,10 @@ def list_models(ctx):
 
     models = discover_available_models(force_refresh=True)
     if not models:
-        click.echo("No models discovered. Check that at least one API key is set:")
-        click.echo("  OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY")
+        click.echo(
+            "No models discovered. Check that at least one API key is set or Ollama is running:"
+        )
+        click.echo("  OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, or `ollama serve`")
         return
 
     by_provider: dict[str, list] = {}
@@ -419,7 +421,7 @@ def clear_cache(ctx, cache_dir, older_than, clear_all):
 @click.option(
     "--provider",
     "-p",
-    type=click.Choice(["auto", "openai", "anthropic", "gemini"]),
+    type=click.Choice(["auto", "openai", "anthropic", "gemini", "ollama"]),
     default="auto",
     help="API provider",
 )
@@ -513,7 +515,7 @@ def _interactive_menu(ctx):
         )
         provider = click.prompt(
             "  Provider",
-            type=click.Choice(["auto", "openai", "anthropic", "gemini"]),
+            type=click.Choice(["auto", "openai", "anthropic", "gemini", "ollama"]),
             default="auto",
         )
         ctx.invoke(
@@ -542,7 +544,7 @@ def _interactive_menu(ctx):
         )
         provider = click.prompt(
             "  Provider",
-            type=click.Choice(["auto", "openai", "anthropic", "gemini"]),
+            type=click.Choice(["auto", "openai", "anthropic", "gemini", "ollama"]),
             default="auto",
         )
         ctx.invoke(

--- a/video_processor/providers/discovery.py
+++ b/video_processor/providers/discovery.py
@@ -77,6 +77,18 @@ def discover_available_models(
         except Exception as e:
             logger.warning(f"Gemini discovery failed: {e}")
 
+    # Ollama (local, no API key needed)
+    try:
+        from video_processor.providers.ollama_provider import OllamaProvider
+
+        if OllamaProvider.is_available():
+            provider = OllamaProvider()
+            models = provider.list_models()
+            logger.info(f"Discovered {len(models)} Ollama models")
+            all_models.extend(models)
+    except Exception as e:
+        logger.info(f"Ollama discovery skipped: {e}")
+
     # Sort by provider then id
     all_models.sort(key=lambda m: (m.provider, m.id))
     _cached_models = all_models

--- a/video_processor/providers/ollama_provider.py
+++ b/video_processor/providers/ollama_provider.py
@@ -1,0 +1,168 @@
+"""Ollama provider implementation using OpenAI-compatible API."""
+
+import base64
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+import requests
+from openai import OpenAI
+
+from video_processor.providers.base import BaseProvider, ModelInfo
+
+logger = logging.getLogger(__name__)
+
+# Known vision-capable model families (base name before the colon/tag)
+_VISION_FAMILIES = {
+    "llava",
+    "llava-llama3",
+    "llava-phi3",
+    "llama3.2-vision",
+    "moondream",
+    "bakllava",
+    "minicpm-v",
+    "deepseek-vl",
+    "internvl2",
+}
+
+DEFAULT_HOST = "http://localhost:11434"
+
+
+class OllamaProvider(BaseProvider):
+    """Ollama local LLM provider via OpenAI-compatible API."""
+
+    provider_name = "ollama"
+
+    def __init__(self, host: Optional[str] = None):
+        self.host = host or os.getenv("OLLAMA_HOST", DEFAULT_HOST)
+        self.client = OpenAI(
+            base_url=f"{self.host}/v1",
+            api_key="ollama",
+        )
+        self._models_cache: Optional[list[ModelInfo]] = None
+
+    @staticmethod
+    def is_available(host: Optional[str] = None) -> bool:
+        """Check if an Ollama server is running and reachable."""
+        host = host or os.getenv("OLLAMA_HOST", DEFAULT_HOST)
+        try:
+            resp = requests.get(f"{host}/api/tags", timeout=3)
+            return resp.status_code == 200
+        except Exception:
+            return False
+
+    @property
+    def _default_model(self) -> str:
+        models = self._get_models()
+        for m in models:
+            if "chat" in m.capabilities:
+                return m.id
+        return "llama3.2:latest"
+
+    @property
+    def _default_vision_model(self) -> Optional[str]:
+        models = self._get_models()
+        for m in models:
+            if "vision" in m.capabilities:
+                return m.id
+        return None
+
+    def _get_models(self) -> list[ModelInfo]:
+        if self._models_cache is None:
+            self._models_cache = self.list_models()
+        return self._models_cache
+
+    def chat(
+        self,
+        messages: list[dict],
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        model: Optional[str] = None,
+    ) -> str:
+        model = model or self._default_model
+        response = self.client.chat.completions.create(
+            model=model,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        self._last_usage = {
+            "input_tokens": getattr(response.usage, "prompt_tokens", 0) if response.usage else 0,
+            "output_tokens": getattr(response.usage, "completion_tokens", 0)
+            if response.usage
+            else 0,
+        }
+        return response.choices[0].message.content or ""
+
+    def analyze_image(
+        self,
+        image_bytes: bytes,
+        prompt: str,
+        max_tokens: int = 4096,
+        model: Optional[str] = None,
+    ) -> str:
+        model = model or self._default_vision_model
+        if not model:
+            raise RuntimeError(
+                "No Ollama vision model available. Install a multimodal model: ollama pull llava"
+            )
+        b64 = base64.b64encode(image_bytes).decode()
+        response = self.client.chat.completions.create(
+            model=model,
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": prompt},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:image/jpeg;base64,{b64}"},
+                        },
+                    ],
+                }
+            ],
+            max_tokens=max_tokens,
+        )
+        self._last_usage = {
+            "input_tokens": getattr(response.usage, "prompt_tokens", 0) if response.usage else 0,
+            "output_tokens": getattr(response.usage, "completion_tokens", 0)
+            if response.usage
+            else 0,
+        }
+        return response.choices[0].message.content or ""
+
+    def transcribe_audio(
+        self,
+        audio_path: str | Path,
+        language: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> dict:
+        raise NotImplementedError(
+            "Ollama does not support audio transcription. "
+            "Use local Whisper (--transcription-model whisper-local:large) or OpenAI Whisper API."
+        )
+
+    def list_models(self) -> list[ModelInfo]:
+        models = []
+        try:
+            resp = requests.get(f"{self.host}/api/tags", timeout=5)
+            resp.raise_for_status()
+            data = resp.json()
+            for m in data.get("models", []):
+                name = m.get("name", "")
+                caps = ["chat"]
+                base_name = name.split(":")[0].lower()
+                if base_name in _VISION_FAMILIES or "vision" in base_name:
+                    caps.append("vision")
+                models.append(
+                    ModelInfo(
+                        id=name,
+                        provider="ollama",
+                        display_name=name,
+                        capabilities=caps,
+                    )
+                )
+        except Exception as e:
+            logger.warning(f"Failed to list Ollama models: {e}")
+        return sorted(models, key=lambda m: m.id)


### PR DESCRIPTION
## Summary

- Adds Ollama as a fourth LLM provider, enabling fully offline video analysis with zero new dependencies
- Auto-detects running Ollama server and falls back to it when no cloud API keys are configured
- Updates all docs (README, architecture, CLI reference, quickstart, installation, configuration)

Closes #17

## Changes

**New file:**
- `video_processor/providers/ollama_provider.py` — OllamaProvider using OpenAI-compatible API

**Modified:**
- `video_processor/providers/manager.py` — Ollama lazy loading, defaults, fallback resolution
- `video_processor/providers/discovery.py` — Ollama server detection (no API key needed)
- `video_processor/cli/commands.py` — `--provider ollama` on all commands
- `tests/test_providers.py` — 7 new tests
- `README.md`, `docs/` — Updated for Ollama support

## Test plan

- [x] All 18 provider tests pass (`pytest tests/test_providers.py`)
- [x] `planopticon list-models` shows Ollama models when server is running
- [x] `planopticon analyze -i video.mp4 -o out --provider ollama` works end-to-end
- [x] Auto-fallback works with no API keys set and Ollama running