### PR TITLE
Fix Ollama None token counts in usage tracking

### DIFF
--- a/video_processor/providers/ollama_provider.py
+++ b/video_processor/providers/ollama_provider.py
@@ -88,8 +88,10 @@ class OllamaProvider(BaseProvider):
             temperature=temperature,
         )
         self._last_usage = {
-            "input_tokens": getattr(response.usage, "prompt_tokens", 0) if response.usage else 0,
-            "output_tokens": getattr(response.usage, "completion_tokens", 0)
+            "input_tokens": (getattr(response.usage, "prompt_tokens", 0) or 0)
+            if response.usage
+            else 0,
+            "output_tokens": (getattr(response.usage, "completion_tokens", 0) or 0)
             if response.usage
             else 0,
         }
@@ -125,8 +127,10 @@ class OllamaProvider(BaseProvider):
             max_tokens=max_tokens,
         )
         self._last_usage = {
-            "input_tokens": getattr(response.usage, "prompt_tokens", 0) if response.usage else 0,
-            "output_tokens": getattr(response.usage, "completion_tokens", 0)
+            "input_tokens": (getattr(response.usage, "prompt_tokens", 0) or 0)
+            if response.usage
+            else 0,
+            "output_tokens": (getattr(response.usage, "completion_tokens", 0) or 0)
             if response.usage
             else 0,
         }


### PR DESCRIPTION
## Summary

- Fixes crash when Ollama returns `None` for token counts in the usage response
- Ollama's OpenAI-compatible API can return `None` instead of `0` for `prompt_tokens`/`completion_tokens`, causing a `TypeError` in the usage tracker

## Test plan

- [x] Verified fix locally — Ollama chat calls now track usage correctly
- [x] All 18 provider tests pass