### PR TITLE
feat(graph): FalkorDB Lite integration as optional graph storage backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ pdf = ["weasyprint>=60.0"]
 gpu = ["torch>=2.0.0", "torchvision>=0.15.0"]
 gdrive = ["google-auth>=2.0.0", "google-auth-oauthlib>=1.0.0", "google-api-python-client>=2.0.0"]
 dropbox = ["dropbox>=12.0.0"]
+graph = ["falkordblite>=0.4.0"]
 cloud = [
     "planopticon[gdrive]",
     "planopticon[dropbox]",
@@ -71,6 +72,7 @@ dev = [
 all = [
     "planopticon[pdf]",
     "planopticon[cloud]",
+    "planopticon[graph]",
     "planopticon[dev]",
 ]
 

--- a/tests/test_graph_store.py
+++ b/tests/test_graph_store.py
@@ -1,0 +1,260 @@
+"""Tests for graph storage backends."""
+
+import pytest
+
+from video_processor.integrators.graph_store import InMemoryStore, create_store
+
+
+class TestInMemoryStore:
+    def test_merge_entity_creates_new(self):
+        store = InMemoryStore()
+        store.merge_entity("Python", "technology", ["A programming language"])
+        assert store.get_entity_count() == 1
+        entity = store.get_entity("python")
+        assert entity is not None
+        assert entity["name"] == "Python"
+        assert entity["type"] == "technology"
+        assert "A programming language" in entity["descriptions"]
+
+    def test_merge_entity_case_insensitive_dedup(self):
+        store = InMemoryStore()
+        store.merge_entity("Python", "technology", ["Language"])
+        store.merge_entity("python", "technology", ["Snake-based"])
+        store.merge_entity("PYTHON", "technology", ["Popular"])
+        assert store.get_entity_count() == 1
+        entity = store.get_entity("Python")
+        assert entity is not None
+        assert "Language" in entity["descriptions"]
+        assert "Snake-based" in entity["descriptions"]
+        assert "Popular" in entity["descriptions"]
+
+    def test_add_occurrence(self):
+        store = InMemoryStore()
+        store.merge_entity("Alice", "person", ["Engineer"])
+        store.add_occurrence("Alice", "transcript_0", timestamp=10.5, text="Alice said...")
+        entity = store.get_entity("alice")
+        assert len(entity["occurrences"]) == 1
+        assert entity["occurrences"][0]["source"] == "transcript_0"
+        assert entity["occurrences"][0]["timestamp"] == 10.5
+
+    def test_add_occurrence_nonexistent_entity(self):
+        store = InMemoryStore()
+        store.add_occurrence("Ghost", "transcript_0")
+        # Should not crash, just no-op
+        assert store.get_entity_count() == 0
+
+    def test_add_relationship(self):
+        store = InMemoryStore()
+        store.merge_entity("Alice", "person", [])
+        store.merge_entity("Bob", "person", [])
+        store.add_relationship("Alice", "Bob", "knows", content_source="t0", timestamp=5.0)
+        assert store.get_relationship_count() == 1
+        rels = store.get_all_relationships()
+        assert rels[0]["source"] == "Alice"
+        assert rels[0]["target"] == "Bob"
+        assert rels[0]["type"] == "knows"
+
+    def test_has_entity(self):
+        store = InMemoryStore()
+        assert not store.has_entity("Python")
+        store.merge_entity("Python", "technology", [])
+        assert store.has_entity("Python")
+        assert store.has_entity("python")
+        assert store.has_entity("PYTHON")
+
+    def test_get_entity_not_found(self):
+        store = InMemoryStore()
+        assert store.get_entity("nonexistent") is None
+
+    def test_get_all_entities(self):
+        store = InMemoryStore()
+        store.merge_entity("Alice", "person", ["Engineer"])
+        store.merge_entity("Bob", "person", ["Manager"])
+        entities = store.get_all_entities()
+        assert len(entities) == 2
+        names = {e["name"] for e in entities}
+        assert names == {"Alice", "Bob"}
+
+    def test_to_dict_format(self):
+        store = InMemoryStore()
+        store.merge_entity("Python", "technology", ["A language"])
+        store.merge_entity("Django", "technology", ["A framework"])
+        store.add_relationship("Django", "Python", "uses")
+        store.add_occurrence("Python", "transcript_0", timestamp=1.0, text="mentioned Python")
+
+        data = store.to_dict()
+        assert "nodes" in data
+        assert "relationships" in data
+        assert len(data["nodes"]) == 2
+        assert len(data["relationships"]) == 1
+
+        # Descriptions should be lists (not sets)
+        for node in data["nodes"]:
+            assert isinstance(node["descriptions"], list)
+            assert "id" in node
+            assert "name" in node
+            assert "type" in node
+
+    def test_to_dict_roundtrip(self):
+        """Verify to_dict produces data that can reload into a new store."""
+        store = InMemoryStore()
+        store.merge_entity("Alice", "person", ["Engineer"])
+        store.merge_entity("Bob", "person", ["Manager"])
+        store.add_relationship("Alice", "Bob", "reports_to")
+        store.add_occurrence("Alice", "src", timestamp=1.0, text="hello")
+
+        data = store.to_dict()
+
+        # Reload into a new store
+        store2 = InMemoryStore()
+        for node in data["nodes"]:
+            store2.merge_entity(
+                node["name"], node["type"], node["descriptions"], node.get("source")
+            )
+            for occ in node.get("occurrences", []):
+                store2.add_occurrence(
+                    node["name"], occ["source"], occ.get("timestamp"), occ.get("text")
+                )
+        for rel in data["relationships"]:
+            store2.add_relationship(
+                rel["source"],
+                rel["target"],
+                rel["type"],
+                rel.get("content_source"),
+                rel.get("timestamp"),
+            )
+
+        assert store2.get_entity_count() == 2
+        assert store2.get_relationship_count() == 1
+
+    def test_empty_store(self):
+        store = InMemoryStore()
+        assert store.get_entity_count() == 0
+        assert store.get_relationship_count() == 0
+        assert store.get_all_entities() == []
+        assert store.get_all_relationships() == []
+        data = store.to_dict()
+        assert data == {"nodes": [], "relationships": []}
+
+
+class TestCreateStore:
+    def test_returns_in_memory_without_path(self):
+        store = create_store()
+        assert isinstance(store, InMemoryStore)
+
+    def test_returns_in_memory_with_none_path(self):
+        store = create_store(db_path=None)
+        assert isinstance(store, InMemoryStore)
+
+    def test_fallback_to_in_memory_when_falkordb_unavailable(self, tmp_path):
+        """When falkordblite is not installed, should fall back gracefully."""
+        store = create_store(db_path=tmp_path / "test.db")
+        # Will be FalkorDBStore if installed, InMemoryStore if not
+        # Either way, it should work
+        store.merge_entity("Test", "concept", ["test entity"])
+        assert store.get_entity_count() == 1
+
+
+# Conditional FalkorDB tests
+_falkordb_available = False
+try:
+    import falkordb  # noqa: F401
+
+    _falkordb_available = True
+except ImportError:
+    pass
+
+
+@pytest.mark.skipif(not _falkordb_available, reason="falkordblite not installed")
+class TestFalkorDBStore:
+    def test_create_and_query_entity(self, tmp_path):
+        from video_processor.integrators.graph_store import FalkorDBStore
+
+        store = FalkorDBStore(tmp_path / "test.db")
+        store.merge_entity("Python", "technology", ["A language"])
+        assert store.get_entity_count() == 1
+        entity = store.get_entity("python")
+        assert entity is not None
+        assert entity["name"] == "Python"
+        store.close()
+
+    def test_case_insensitive_merge(self, tmp_path):
+        from video_processor.integrators.graph_store import FalkorDBStore
+
+        store = FalkorDBStore(tmp_path / "test.db")
+        store.merge_entity("Python", "technology", ["Language"])
+        store.merge_entity("python", "technology", ["Snake-based"])
+        assert store.get_entity_count() == 1
+        entity = store.get_entity("python")
+        assert "Language" in entity["descriptions"]
+        assert "Snake-based" in entity["descriptions"]
+        store.close()
+
+    def test_relationships(self, tmp_path):
+        from video_processor.integrators.graph_store import FalkorDBStore
+
+        store = FalkorDBStore(tmp_path / "test.db")
+        store.merge_entity("Alice", "person", [])
+        store.merge_entity("Bob", "person", [])
+        store.add_relationship("Alice", "Bob", "knows")
+        assert store.get_relationship_count() == 1
+        rels = store.get_all_relationships()
+        assert rels[0]["source"] == "Alice"
+        assert rels[0]["target"] == "Bob"
+        store.close()
+
+    def test_occurrences(self, tmp_path):
+        from video_processor.integrators.graph_store import FalkorDBStore
+
+        store = FalkorDBStore(tmp_path / "test.db")
+        store.merge_entity("Alice", "person", ["Engineer"])
+        store.add_occurrence("Alice", "transcript_0", timestamp=10.5, text="Alice said...")
+        entity = store.get_entity("alice")
+        assert len(entity["occurrences"]) == 1
+        assert entity["occurrences"][0]["source"] == "transcript_0"
+        store.close()
+
+    def test_persistence(self, tmp_path):
+        from video_processor.integrators.graph_store import FalkorDBStore
+
+        db_path = tmp_path / "persist.db"
+
+        store1 = FalkorDBStore(db_path)
+        store1.merge_entity("Python", "technology", ["A language"])
+        store1.add_relationship_count = 0  # just to trigger write
+        store1.close()
+
+        store2 = FalkorDBStore(db_path)
+        assert store2.get_entity_count() == 1
+        entity = store2.get_entity("python")
+        assert entity["name"] == "Python"
+        store2.close()
+
+    def test_to_dict_format(self, tmp_path):
+        from video_processor.integrators.graph_store import FalkorDBStore
+
+        store = FalkorDBStore(tmp_path / "test.db")
+        store.merge_entity("Python", "technology", ["A language"])
+        store.merge_entity("Django", "technology", ["A framework"])
+        store.add_relationship("Django", "Python", "uses")
+
+        data = store.to_dict()
+        assert len(data["nodes"]) == 2
+        assert len(data["relationships"]) == 1
+
+        for node in data["nodes"]:
+            assert isinstance(node["descriptions"], list)
+            assert "id" in node
+            assert "name" in node
+
+        store.close()
+
+    def test_has_entity(self, tmp_path):
+        from video_processor.integrators.graph_store import FalkorDBStore
+
+        store = FalkorDBStore(tmp_path / "test.db")
+        assert not store.has_entity("Python")
+        store.merge_entity("Python", "technology", [])
+        assert store.has_entity("Python")
+        assert store.has_entity("python")
+        store.close()

--- a/video_processor/agent/orchestrator.py
+++ b/video_processor/agent/orchestrator.py
@@ -193,7 +193,8 @@ class AgentOrchestrator:
             from video_processor.integrators.knowledge_graph import KnowledgeGraph
 
             transcript = self._results.get("transcribe", {})
-            kg = KnowledgeGraph(provider_manager=self.pm)
+            kg_db_path = dirs["results"] / "knowledge_graph.db"
+            kg = KnowledgeGraph(provider_manager=self.pm, db_path=kg_db_path)
             kg.process_transcript(transcript)
 
             diagram_result = self._results.get("detect_diagrams", {})

--- a/video_processor/cli/commands.py
+++ b/video_processor/cli/commands.py
@@ -256,7 +256,8 @@ def batch(
     dirs = create_batch_output_dirs(output, title)
     manifests = []
     entries = []
-    merged_kg = KnowledgeGraph()
+    merged_kg_db = Path(output) / "knowledge_graph.db"
+    merged_kg = KnowledgeGraph(db_path=merged_kg_db)
 
     for idx, video_path in enumerate(tqdm(videos, desc="Batch processing", unit="video")):
         video_name = video_path.stem
@@ -327,6 +328,7 @@ def batch(
         videos=entries,
         batch_summary_md="batch_summary.md",
         merged_knowledge_graph_json="knowledge_graph.json",
+        merged_knowledge_graph_db="knowledge_graph.db",
     )
     write_batch_manifest(batch_manifest, output)
     click.echo(pm.usage.format_summary())

--- a/video_processor/integrators/graph_store.py
+++ b/video_processor/integrators/graph_store.py
@@ -1,0 +1,389 @@
+"""Graph storage backends for PlanOpticon knowledge graphs."""
+
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+
+class GraphStore(ABC):
+    """Abstract interface for knowledge graph storage backends."""
+
+    @abstractmethod
+    def merge_entity(
+        self,
+        name: str,
+        entity_type: str,
+        descriptions: List[str],
+        source: Optional[str] = None,
+    ) -> None:
+        """Upsert an entity by case-insensitive name."""
+        ...
+
+    @abstractmethod
+    def add_occurrence(
+        self,
+        entity_name: str,
+        source: str,
+        timestamp: Optional[float] = None,
+        text: Optional[str] = None,
+    ) -> None:
+        """Add an occurrence record to an existing entity."""
+        ...
+
+    @abstractmethod
+    def add_relationship(
+        self,
+        source: str,
+        target: str,
+        rel_type: str,
+        content_source: Optional[str] = None,
+        timestamp: Optional[float] = None,
+    ) -> None:
+        """Add a relationship between two entities (both must already exist)."""
+        ...
+
+    @abstractmethod
+    def get_entity(self, name: str) -> Optional[Dict[str, Any]]:
+        """Get an entity by case-insensitive name, or None."""
+        ...
+
+    @abstractmethod
+    def get_all_entities(self) -> List[Dict[str, Any]]:
+        """Return all entities as dicts."""
+        ...
+
+    @abstractmethod
+    def get_all_relationships(self) -> List[Dict[str, Any]]:
+        """Return all relationships as dicts."""
+        ...
+
+    @abstractmethod
+    def get_entity_count(self) -> int: ...
+
+    @abstractmethod
+    def get_relationship_count(self) -> int: ...
+
+    @abstractmethod
+    def has_entity(self, name: str) -> bool:
+        """Check if an entity exists (case-insensitive)."""
+        ...
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Export to JSON-compatible dict matching knowledge_graph.json format."""
+        entities = self.get_all_entities()
+        nodes = []
+        for e in entities:
+            descs = e.get("descriptions", [])
+            if isinstance(descs, set):
+                descs = list(descs)
+            nodes.append(
+                {
+                    "id": e.get("id", e["name"]),
+                    "name": e["name"],
+                    "type": e.get("type", "concept"),
+                    "descriptions": descs,
+                    "occurrences": e.get("occurrences", []),
+                }
+            )
+        return {"nodes": nodes, "relationships": self.get_all_relationships()}
+
+
+class InMemoryStore(GraphStore):
+    """In-memory graph store using Python dicts. Default fallback."""
+
+    def __init__(self) -> None:
+        self._nodes: Dict[str, Dict[str, Any]] = {}  # keyed by name.lower()
+        self._relationships: List[Dict[str, Any]] = []
+
+    def merge_entity(
+        self,
+        name: str,
+        entity_type: str,
+        descriptions: List[str],
+        source: Optional[str] = None,
+    ) -> None:
+        key = name.lower()
+        if key in self._nodes:
+            if descriptions:
+                self._nodes[key]["descriptions"].update(descriptions)
+        else:
+            self._nodes[key] = {
+                "id": name,
+                "name": name,
+                "type": entity_type,
+                "descriptions": set(descriptions),
+                "occurrences": [],
+                "source": source,
+            }
+
+    def add_occurrence(
+        self,
+        entity_name: str,
+        source: str,
+        timestamp: Optional[float] = None,
+        text: Optional[str] = None,
+    ) -> None:
+        key = entity_name.lower()
+        if key in self._nodes:
+            self._nodes[key]["occurrences"].append(
+                {"source": source, "timestamp": timestamp, "text": text}
+            )
+
+    def add_relationship(
+        self,
+        source: str,
+        target: str,
+        rel_type: str,
+        content_source: Optional[str] = None,
+        timestamp: Optional[float] = None,
+    ) -> None:
+        self._relationships.append(
+            {
+                "source": source,
+                "target": target,
+                "type": rel_type,
+                "content_source": content_source,
+                "timestamp": timestamp,
+            }
+        )
+
+    def get_entity(self, name: str) -> Optional[Dict[str, Any]]:
+        return self._nodes.get(name.lower())
+
+    def get_all_entities(self) -> List[Dict[str, Any]]:
+        return list(self._nodes.values())
+
+    def get_all_relationships(self) -> List[Dict[str, Any]]:
+        return list(self._relationships)
+
+    def get_entity_count(self) -> int:
+        return len(self._nodes)
+
+    def get_relationship_count(self) -> int:
+        return len(self._relationships)
+
+    def has_entity(self, name: str) -> bool:
+        return name.lower() in self._nodes
+
+
+class FalkorDBStore(GraphStore):
+    """FalkorDB Lite-backed graph store. Requires falkordblite package."""
+
+    def __init__(self, db_path: Union[str, Path]) -> None:
+        from falkordb import FalkorDB
+
+        self._db_path = str(db_path)
+        self._db = FalkorDB(self._db_path)
+        self._graph = self._db.select_graph("knowledge")
+        self._ensure_indexes()
+
+    def _ensure_indexes(self) -> None:
+        for query in [
+            "CREATE INDEX FOR (e:Entity) ON (e.name_lower)",
+            "CREATE INDEX FOR (e:Entity) ON (e.type)",
+        ]:
+            try:
+                self._graph.query(query)
+            except Exception:
+                pass  # index already exists
+
+    def merge_entity(
+        self,
+        name: str,
+        entity_type: str,
+        descriptions: List[str],
+        source: Optional[str] = None,
+    ) -> None:
+        name_lower = name.lower()
+
+        # Check if entity exists
+        result = self._graph.query(
+            "MATCH (e:Entity {name_lower: $name_lower}) RETURN e.descriptions",
+            params={"name_lower": name_lower},
+        )
+
+        if result.result_set:
+            # Entity exists — merge descriptions
+            existing_descs = result.result_set[0][0] or []
+            merged = list(set(existing_descs + descriptions))
+            self._graph.query(
+                "MATCH (e:Entity {name_lower: $name_lower}) SET e.descriptions = $descs",
+                params={"name_lower": name_lower, "descs": merged},
+            )
+        else:
+            # Create new entity
+            self._graph.query(
+                "CREATE (e:Entity {"
+                "name: $name, name_lower: $name_lower, type: $type, "
+                "descriptions: $descs, source: $source"
+                "})",
+                params={
+                    "name": name,
+                    "name_lower": name_lower,
+                    "type": entity_type,
+                    "descs": descriptions,
+                    "source": source,
+                },
+            )
+
+    def add_occurrence(
+        self,
+        entity_name: str,
+        source: str,
+        timestamp: Optional[float] = None,
+        text: Optional[str] = None,
+    ) -> None:
+        name_lower = entity_name.lower()
+        self._graph.query(
+            "MATCH (e:Entity {name_lower: $name_lower}) "
+            "CREATE (o:Occurrence {source: $source, timestamp: $timestamp, text: $text}) "
+            "CREATE (e)-[:OCCURRED_IN]->(o)",
+            params={
+                "name_lower": name_lower,
+                "source": source,
+                "timestamp": timestamp,
+                "text": text,
+            },
+        )
+
+    def add_relationship(
+        self,
+        source: str,
+        target: str,
+        rel_type: str,
+        content_source: Optional[str] = None,
+        timestamp: Optional[float] = None,
+    ) -> None:
+        self._graph.query(
+            "MATCH (a:Entity {name_lower: $src_lower}) "
+            "MATCH (b:Entity {name_lower: $tgt_lower}) "
+            "CREATE (a)-[:RELATED_TO {"
+            "rel_type: $rel_type, content_source: $content_source, timestamp: $timestamp"
+            "}]->(b)",
+            params={
+                "src_lower": source.lower(),
+                "tgt_lower": target.lower(),
+                "rel_type": rel_type,
+                "content_source": content_source,
+                "timestamp": timestamp,
+            },
+        )
+
+    def get_entity(self, name: str) -> Optional[Dict[str, Any]]:
+        result = self._graph.query(
+            "MATCH (e:Entity {name_lower: $name_lower}) "
+            "RETURN e.name, e.type, e.descriptions, e.source",
+            params={"name_lower": name.lower()},
+        )
+        if not result.result_set:
+            return None
+
+        row = result.result_set[0]
+        entity_name = row[0]
+
+        # Fetch occurrences
+        occ_result = self._graph.query(
+            "MATCH (e:Entity {name_lower: $name_lower})-[:OCCURRED_IN]->(o:Occurrence) "
+            "RETURN o.source, o.timestamp, o.text",
+            params={"name_lower": name.lower()},
+        )
+        occurrences = [
+            {"source": o[0], "timestamp": o[1], "text": o[2]} for o in occ_result.result_set
+        ]
+
+        return {
+            "id": entity_name,
+            "name": entity_name,
+            "type": row[1] or "concept",
+            "descriptions": row[2] or [],
+            "occurrences": occurrences,
+            "source": row[3],
+        }
+
+    def get_all_entities(self) -> List[Dict[str, Any]]:
+        result = self._graph.query(
+            "MATCH (e:Entity) RETURN e.name, e.name_lower, e.type, e.descriptions, e.source"
+        )
+        entities = []
+        for row in result.result_set:
+            name_lower = row[1]
+            # Fetch occurrences for this entity
+            occ_result = self._graph.query(
+                "MATCH (e:Entity {name_lower: $name_lower})-[:OCCURRED_IN]->(o:Occurrence) "
+                "RETURN o.source, o.timestamp, o.text",
+                params={"name_lower": name_lower},
+            )
+            occurrences = [
+                {"source": o[0], "timestamp": o[1], "text": o[2]} for o in occ_result.result_set
+            ]
+            entities.append(
+                {
+                    "id": row[0],
+                    "name": row[0],
+                    "type": row[2] or "concept",
+                    "descriptions": row[3] or [],
+                    "occurrences": occurrences,
+                    "source": row[4],
+                }
+            )
+        return entities
+
+    def get_all_relationships(self) -> List[Dict[str, Any]]:
+        result = self._graph.query(
+            "MATCH (a:Entity)-[r:RELATED_TO]->(b:Entity) "
+            "RETURN a.name, b.name, r.rel_type, r.content_source, r.timestamp"
+        )
+        return [
+            {
+                "source": row[0],
+                "target": row[1],
+                "type": row[2] or "related_to",
+                "content_source": row[3],
+                "timestamp": row[4],
+            }
+            for row in result.result_set
+        ]
+
+    def get_entity_count(self) -> int:
+        result = self._graph.query("MATCH (e:Entity) RETURN count(e)")
+        return result.result_set[0][0] if result.result_set else 0
+
+    def get_relationship_count(self) -> int:
+        result = self._graph.query("MATCH ()-[r:RELATED_TO]->() RETURN count(r)")
+        return result.result_set[0][0] if result.result_set else 0
+
+    def has_entity(self, name: str) -> bool:
+        result = self._graph.query(
+            "MATCH (e:Entity {name_lower: $name_lower}) RETURN count(e)",
+            params={"name_lower": name.lower()},
+        )
+        return result.result_set[0][0] > 0 if result.result_set else False
+
+    def close(self) -> None:
+        """Release references. FalkorDB Lite handles persistence automatically."""
+        self._graph = None
+        self._db = None
+
+
+def create_store(db_path: Optional[Union[str, Path]] = None) -> GraphStore:
+    """Create the best available graph store.
+
+    If db_path is provided and falkordblite is installed, uses FalkorDBStore.
+    Otherwise falls back to InMemoryStore.
+    """
+    if db_path is not None:
+        try:
+            return FalkorDBStore(db_path)
+        except ImportError:
+            logger.info(
+                "falkordblite not installed, falling back to in-memory store. "
+                "Install with: pip install planopticon[graph]"
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to initialize FalkorDB at {db_path}: {e}. Using in-memory store."
+            )
+    return InMemoryStore()

--- a/video_processor/models.py
+++ b/video_processor/models.py
@@ -178,6 +178,7 @@ class VideoManifest(BaseModel):
     analysis_html: Optional[str] = Field(default=None)
     analysis_pdf: Optional[str] = Field(default=None)
     knowledge_graph_json: Optional[str] = Field(default=None)
+    knowledge_graph_db: Optional[str] = Field(default=None)
     key_points_json: Optional[str] = Field(default=None)
     action_items_json: Optional[str] = Field(default=None)
 
@@ -227,3 +228,4 @@ class BatchManifest(BaseModel):
     # Batch-level output paths (relative)
     batch_summary_md: Optional[str] = Field(default=None)
     merged_knowledge_graph_json: Optional[str] = Field(default=None)
+    merged_knowledge_graph_db: Optional[str] = Field(default=None)

--- a/video_processor/output_structure.py
+++ b/video_processor/output_structure.py
@@ -27,6 +27,7 @@ def create_video_output_dirs(output_dir: str | Path, video_name: str) -> Dict[st
             results/
                 analysis.md, .html, .pdf
                 knowledge_graph.json
+                knowledge_graph.db (when falkordblite installed)
                 key_points.json
                 action_items.json
             cache/
@@ -58,6 +59,7 @@ def create_batch_output_dirs(output_dir: str | Path, batch_name: str) -> Dict[st
             manifest.json
             batch_summary.md
             knowledge_graph.json
+            knowledge_graph.db (when falkordblite installed)
             videos/
                 video_1/manifest.json
                 video_2/manifest.json

--- a/video_processor/pipeline.py
+++ b/video_processor/pipeline.py
@@ -193,14 +193,14 @@ def process_single_video(
     pm.usage.start_step("Knowledge graph")
     pipeline_bar.set_description("Pipeline: building knowledge graph")
     kg_json_path = dirs["results"] / "knowledge_graph.json"
+    kg_db_path = dirs["results"] / "knowledge_graph.db"
     if kg_json_path.exists():
         logger.info("Resuming: found knowledge graph on disk, loading")
         kg_data = json.loads(kg_json_path.read_text())
-        kg = KnowledgeGraph(provider_manager=pm)
-        kg = KnowledgeGraph.from_dict(kg_data)
+        kg = KnowledgeGraph.from_dict(kg_data, db_path=kg_db_path)
     else:
         logger.info("Building knowledge graph...")
-        kg = KnowledgeGraph(provider_manager=pm)
+        kg = KnowledgeGraph(provider_manager=pm, db_path=kg_db_path)
         kg.process_transcript(transcript_data)
         if diagrams:
             diagram_dicts = [d.model_dump() for d in diagrams]
@@ -267,6 +267,7 @@ def process_single_video(
         transcript_srt="transcript/transcript.srt",
         analysis_md="results/analysis.md",
         knowledge_graph_json="results/knowledge_graph.json",
+        knowledge_graph_db="results/knowledge_graph.db",
         key_points_json="results/key_points.json",
         action_items_json="results/action_items.json",
         key_points=key_points,


### PR DESCRIPTION
## Summary
- Introduces `GraphStore` abstraction layer with `InMemoryStore` (default) and `FalkorDBStore` backends
- Refactors `KnowledgeGraph` class to delegate storage to `GraphStore`, enabling persistent local graph databases via FalkorDB Lite
- Optional dependency: `pip install planopticon[graph]` — graceful fallback to in-memory store when not installed
- All existing tests pass, JSON output format unchanged

## Changes
- **New:** `video_processor/integrators/graph_store.py` — GraphStore ABC, InMemoryStore, FalkorDBStore, create_store() factory
- **New:** `tests/test_graph_store.py` — 21 tests (14 in-memory, 7 FalkorDB conditionally skipped)
- **Modified:** `knowledge_graph.py` — delegates to GraphStore, backward-compat `nodes`/`relationships` properties
- **Modified:** `pipeline.py`, `commands.py`, `orchestrator.py` — pass `db_path` for graph persistence
- **Modified:** `models.py` — added `knowledge_graph_db` field to manifests
- **Modified:** `pyproject.toml` — added `graph` optional dependency group

## Test plan
- [x] All 242 existing tests pass
- [x] Ruff lint + format clean
- [x] FalkorDB tests conditionally skip when package not installed
- [ ] Install `falkordblite` and verify FalkorDB tests pass + `.db` files created

Closes #44