### PR TITLE
feat(graph): FalkorDB integration + query command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ pdf = ["weasyprint>=60.0"]
 gpu = ["torch>=2.0.0", "torchvision>=0.15.0"]
 gdrive = ["google-auth>=2.0.0", "google-auth-oauthlib>=1.0.0", "google-api-python-client>=2.0.0"]
 dropbox = ["dropbox>=12.0.0"]
-graph = ["falkordblite>=0.4.0", "redis>=4.5,<7"]
+graph = ["falkordblite>=0.4.0", "redis>=4.5"]
 cloud = [
     "planopticon[gdrive]",
     "planopticon[dropbox]",

--- a/video_processor/integrators/graph_store.py
+++ b/video_processor/integrators/graph_store.py
@@ -180,6 +180,12 @@ class FalkorDBStore(GraphStore):
     """FalkorDB Lite-backed graph store. Requires falkordblite package."""
 
     def __init__(self, db_path: Union[str, Path]) -> None:
+        # Patch redis 7.x compat: UnixDomainSocketConnection missing 'port'
+        import redis.connection
+
+        if not hasattr(redis.connection.UnixDomainSocketConnection, "port"):
+            redis.connection.UnixDomainSocketConnection.port = 0
+
         from redislite import FalkorDB
 
         self._db_path = str(db_path)


### PR DESCRIPTION
## Summary
- Add FalkorDB Lite as optional graph storage backend (`planopticon[graph]`)
- Add `planopticon query` command with direct and agentic query modes
- Fix redis 7.x compatibility with redislite (falkordblite 0.8+ pulls redis>=7 transitively via falkordb, breaking the UnixDomainSocketConnection which lacks a `port` attribute)
- Add graph auto-discovery to find KG files in analysis output directories
- Drop `redis<7` pin since it conflicts with falkordblite's own deps

## Test plan
- [ ] `planopticon query --db-path <path>.json stats` works with JSON fallback
- [ ] `planopticon query --db-path <path>.db stats` works with FalkorDB
- [ ] `pip install planopticon[graph]` installs falkordblite without redis conflicts
- [ ] `planopticon query "entities --type technology"` returns filtered results
- [ ] `planopticon query -I` enters interactive REPL mode