### PR TITLE
docs: comprehensive v0.4.0 documentation site

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        args: [--unsafe]
       - id: check-added-large-files
         args: [--maxkb=500]
       - id: check-merge-conflict

--- a/docs/api/agent.md
+++ b/docs/api/agent.md
@@ -1,0 +1,407 @@
+# Agent API Reference
+
+::: video_processor.agent.agent_loop
+
+::: video_processor.agent.skills.base
+
+::: video_processor.agent.kb_context
+
+---
+
+## Overview
+
+The agent module implements a planning agent that synthesizes knowledge from processed video content into actionable artifacts such as project plans, PRDs, task breakdowns, and roadmaps. The agent operates on knowledge graphs loaded via `KBContext` and uses a skill-based architecture for extensibility.
+
+**Key components:**
+
+- **`PlanningAgent`** -- orchestrates skill selection and execution based on user requests
+- **`AgentContext`** -- shared state passed between skills during execution
+- **`Skill`** (ABC) -- base class for pluggable agent capabilities
+- **`Artifact`** -- output produced by skill execution
+- **`KBContext`** -- loads and merges multiple knowledge graph sources
+
+---
+
+## PlanningAgent
+
+```python
+from video_processor.agent.agent_loop import PlanningAgent
+```
+
+AI agent that synthesizes knowledge into planning artifacts. Uses an LLM to select which skills to execute for a given request, or falls back to keyword matching when no LLM is available.
+
+### Constructor
+
+```python
+def __init__(self, context: AgentContext)
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `context` | `AgentContext` | Shared context containing knowledge graph, query engine, and provider |
+
+### from_kb_paths()
+
+```python
+@classmethod
+def from_kb_paths(
+    cls,
+    kb_paths: List[Path],
+    provider_manager=None,
+) -> PlanningAgent
+```
+
+Factory method that creates an agent from one or more knowledge base file paths. Handles loading and merging knowledge graphs automatically.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `kb_paths` | `List[Path]` | *required* | Paths to `.db` or `.json` knowledge graph files, or directories to search |
+| `provider_manager` | `ProviderManager` | `None` | LLM provider for agent operations |
+
+**Returns:** `PlanningAgent` -- configured agent with loaded knowledge base.
+
+```python
+from pathlib import Path
+from video_processor.agent.agent_loop import PlanningAgent
+from video_processor.providers.manager import ProviderManager
+
+agent = PlanningAgent.from_kb_paths(
+    kb_paths=[Path("results/knowledge_graph.db")],
+    provider_manager=ProviderManager(),
+)
+```
+
+### execute()
+
+```python
+def execute(self, request: str) -> List[Artifact]
+```
+
+Execute a user request by selecting and running appropriate skills.
+
+**Process:**
+
+1. Build a context summary from the knowledge base statistics
+2. Format available skills with their descriptions
+3. Ask the LLM to select skills and parameters (or use keyword matching as fallback)
+4. Execute selected skills in order, accumulating artifacts
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `request` | `str` | Natural language request (e.g., "Generate a project plan") |
+
+**Returns:** `List[Artifact]` -- generated artifacts from skill execution.
+
+**LLM mode:** The LLM receives the knowledge base summary, available skills, and user request, then returns a JSON array of `{"skill": "name", "params": {}}` objects to execute.
+
+**Keyword fallback:** Without an LLM, skills are matched by splitting the skill name into words and checking if any appear in the request text.
+
+```python
+artifacts = agent.execute("Create a PRD and task breakdown")
+for artifact in artifacts:
+    print(f"--- {artifact.name} ({artifact.artifact_type}) ---")
+    print(artifact.content[:500])
+```
+
+### chat()
+
+```python
+def chat(self, message: str) -> str
+```
+
+Interactive chat mode. Maintains conversation history and provides contextual responses about the loaded knowledge base.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `message` | `str` | User message |
+
+**Returns:** `str` -- assistant response.
+
+The chat mode provides the LLM with:
+
+- Knowledge base statistics (entity counts, relationship counts)
+- List of previously generated artifacts
+- Full conversation history
+- Available REPL commands (e.g., `/entities`, `/search`, `/plan`, `/export`)
+
+**Requires** a configured `provider_manager`. Returns a static error message if no LLM is available.
+
+```python
+response = agent.chat("What technologies were discussed in the meetings?")
+print(response)
+
+response = agent.chat("Which of those have the most dependencies?")
+print(response)
+```
+
+---
+
+## AgentContext
+
+```python
+from video_processor.agent.skills.base import AgentContext
+```
+
+Shared state dataclass passed to all skills during execution. Accumulates artifacts and conversation history across the agent session.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `knowledge_graph` | `Any` | `None` | `KnowledgeGraph` instance |
+| `query_engine` | `Any` | `None` | `GraphQueryEngine` instance for querying the KG |
+| `provider_manager` | `Any` | `None` | `ProviderManager` instance for LLM calls |
+| `planning_entities` | `List[Any]` | `[]` | Extracted `PlanningEntity` instances |
+| `user_requirements` | `Dict[str, Any]` | `{}` | User-specified requirements and constraints |
+| `conversation_history` | `List[Dict[str, str]]` | `[]` | Chat message history (`role`, `content` dicts) |
+| `artifacts` | `List[Artifact]` | `[]` | Previously generated artifacts |
+| `config` | `Dict[str, Any]` | `{}` | Additional configuration |
+
+```python
+from video_processor.agent.skills.base import AgentContext
+
+context = AgentContext(
+    knowledge_graph=kg,
+    query_engine=engine,
+    provider_manager=pm,
+    config={"output_format": "markdown"},
+)
+```
+
+---
+
+## Skill (ABC)
+
+```python
+from video_processor.agent.skills.base import Skill
+```
+
+Base class for agent skills. Each skill represents a discrete capability that produces an artifact from the agent context.
+
+**Class attributes:**
+
+| Attribute | Type | Description |
+|---|---|---|
+| `name` | `str` | Skill identifier (e.g., `"project_plan"`, `"prd"`) |
+| `description` | `str` | Human-readable description shown to the LLM for skill selection |
+
+### execute()
+
+```python
+@abstractmethod
+def execute(self, context: AgentContext, **kwargs) -> Artifact
+```
+
+Execute this skill and return an artifact. Receives the shared agent context and any parameters selected by the LLM planner.
+
+### can_execute()
+
+```python
+def can_execute(self, context: AgentContext) -> bool
+```
+
+Check if this skill can execute given the current context. The default implementation requires both `knowledge_graph` and `provider_manager` to be set. Override for skills with different requirements.
+
+**Returns:** `bool`
+
+### Implementing a custom skill
+
+```python
+from video_processor.agent.skills.base import Skill, Artifact, AgentContext, register_skill
+
+class SummarySkill(Skill):
+    name = "summary"
+    description = "Generate a concise summary of the knowledge base"
+
+    def execute(self, context: AgentContext, **kwargs) -> Artifact:
+        stats = context.query_engine.stats()
+        prompt = f"Summarize this knowledge base:\n{stats.to_text()}"
+        content = context.provider_manager.chat(
+            [{"role": "user", "content": prompt}]
+        )
+        return Artifact(
+            name="Knowledge Base Summary",
+            content=content,
+            artifact_type="document",
+            format="markdown",
+        )
+
+    def can_execute(self, context: AgentContext) -> bool:
+        return context.query_engine is not None and context.provider_manager is not None
+
+# Register the skill so the agent can discover it
+register_skill(SummarySkill())
+```
+
+---
+
+## Artifact
+
+```python
+from video_processor.agent.skills.base import Artifact
+```
+
+Dataclass representing the output of a skill execution.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str` | *required* | Human-readable artifact name |
+| `content` | `str` | *required* | Generated content (Markdown, JSON, Mermaid, etc.) |
+| `artifact_type` | `str` | *required* | Type: `"project_plan"`, `"prd"`, `"roadmap"`, `"task_list"`, `"document"`, `"issues"` |
+| `format` | `str` | `"markdown"` | Content format: `"markdown"`, `"json"`, `"mermaid"` |
+| `metadata` | `Dict[str, Any]` | `{}` | Additional metadata |
+
+---
+
+## Skill Registry Functions
+
+### register_skill()
+
+```python
+def register_skill(skill: Skill) -> None
+```
+
+Register a skill instance in the global registry. Skills must be registered before the agent can discover and execute them.
+
+### get_skill()
+
+```python
+def get_skill(name: str) -> Optional[Skill]
+```
+
+Look up a registered skill by name.
+
+**Returns:** `Optional[Skill]` -- the skill instance, or `None` if not found.
+
+### list_skills()
+
+```python
+def list_skills() -> List[Skill]
+```
+
+Return all registered skill instances.
+
+---
+
+## KBContext
+
+```python
+from video_processor.agent.kb_context import KBContext
+```
+
+Loads and merges multiple knowledge graph sources into a unified context for agent consumption. Supports both FalkorDB (`.db`) and JSON (`.json`) formats, and can auto-discover graphs in a directory tree.
+
+### Constructor
+
+```python
+def __init__(self)
+```
+
+Creates an empty context. Use `add_source()` to add knowledge graph paths, then `load()` to initialize.
+
+### add_source()
+
+```python
+def add_source(self, path) -> None
+```
+
+Add a knowledge graph source.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `path` | `str \| Path` | Path to a `.db` file, `.json` file, or directory to search for knowledge graphs |
+
+If `path` is a directory, it is searched recursively for knowledge graph files using `find_knowledge_graphs()`.
+
+**Raises:** `FileNotFoundError` if the path does not exist.
+
+### load()
+
+```python
+def load(self, provider_manager=None) -> KBContext
+```
+
+Load and merge all added sources into a single knowledge graph and query engine.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `provider_manager` | `ProviderManager` | `None` | LLM provider for the knowledge graph and query engine |
+
+**Returns:** `KBContext` -- self, for method chaining.
+
+### Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `knowledge_graph` | `KnowledgeGraph` | The merged knowledge graph (raises `RuntimeError` if not loaded) |
+| `query_engine` | `GraphQueryEngine` | Query engine for the merged graph (raises `RuntimeError` if not loaded) |
+| `sources` | `List[Path]` | List of resolved source paths |
+
+### summary()
+
+```python
+def summary(self) -> str
+```
+
+Generate a brief text summary of the loaded knowledge base, including entity counts by type and relationship counts.
+
+**Returns:** `str` -- multi-line summary text.
+
+### auto_discover()
+
+```python
+@classmethod
+def auto_discover(
+    cls,
+    start_dir: Optional[Path] = None,
+    provider_manager=None,
+) -> KBContext
+```
+
+Factory method that creates a `KBContext` by auto-discovering knowledge graphs near `start_dir` (defaults to current directory).
+
+**Returns:** `KBContext` -- loaded context (may have zero sources if none found).
+
+### Usage examples
+
+```python
+from pathlib import Path
+from video_processor.agent.kb_context import KBContext
+
+# Manual source management
+kb = KBContext()
+kb.add_source(Path("project_a/knowledge_graph.db"))
+kb.add_source(Path("project_b/results/"))  # searches directory
+kb.load(provider_manager=pm)
+
+print(kb.summary())
+# Knowledge base: 3 source(s)
+#   Entities: 142
+#   Relationships: 89
+#   Entity types:
+#     technology: 45
+#     person: 23
+#     concept: 74
+
+# Auto-discover from current directory
+kb = KBContext.auto_discover()
+
+# Use with the agent
+from video_processor.agent.agent_loop import PlanningAgent
+from video_processor.agent.skills.base import AgentContext
+
+context = AgentContext(
+    knowledge_graph=kb.knowledge_graph,
+    query_engine=kb.query_engine,
+    provider_manager=pm,
+)
+agent = PlanningAgent(context)
+```

--- a/docs/api/analyzers.md
+++ b/docs/api/analyzers.md
@@ -5,3 +5,385 @@
 ::: video_processor.analyzers.content_analyzer
 
 ::: video_processor.analyzers.action_detector
+
+---
+
+## Overview
+
+The analyzers module contains the core content extraction logic for PlanOpticon. These analyzers process video frames and transcripts to extract structured knowledge: diagrams, key points, action items, and cross-referenced entities.
+
+All analyzers accept an optional `ProviderManager` instance. When provided, they use LLM capabilities for richer extraction. Without one, they fall back to heuristic/pattern-based methods where possible.
+
+---
+
+## DiagramAnalyzer
+
+```python
+from video_processor.analyzers.diagram_analyzer import DiagramAnalyzer
+```
+
+Vision model-based diagram detection and analysis. Classifies video frames as diagrams, slides, screenshots, or other content, then performs full extraction on high-confidence frames.
+
+### Constructor
+
+```python
+def __init__(
+    self,
+    provider_manager: Optional[ProviderManager] = None,
+    confidence_threshold: float = 0.3,
+)
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `provider_manager` | `Optional[ProviderManager]` | `None` | LLM provider (creates a default if not provided) |
+| `confidence_threshold` | `float` | `0.3` | Minimum confidence to process a frame at all |
+
+### classify_frame()
+
+```python
+def classify_frame(self, image_path: Union[str, Path]) -> dict
+```
+
+Classify a single frame using a vision model. Determines whether the frame contains a diagram, slide, or other visual content worth extracting.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `image_path` | `Union[str, Path]` | Path to the frame image file |
+
+**Returns:** `dict` with the following keys:
+
+| Key | Type | Description |
+|---|---|---|
+| `is_diagram` | `bool` | Whether the frame contains extractable content |
+| `diagram_type` | `str` | One of: `flowchart`, `sequence`, `architecture`, `whiteboard`, `chart`, `table`, `slide`, `screenshot`, `unknown` |
+| `confidence` | `float` | Detection confidence from 0.0 to 1.0 |
+| `content_type` | `str` | Content category: `slide`, `diagram`, `document`, `screen_share`, `whiteboard`, `chart`, `person`, `other` |
+| `brief_description` | `str` | One-sentence description of the frame content |
+
+**Important:** Frames showing people, webcam feeds, or video conference participant views return `confidence: 0.0`. The classifier is tuned to detect only shared/presented content.
+
+```python
+analyzer = DiagramAnalyzer()
+result = analyzer.classify_frame("/path/to/frame_042.jpg")
+if result["confidence"] >= 0.7:
+    print(f"Diagram detected: {result['diagram_type']}")
+```
+
+### analyze_diagram_single_pass()
+
+```python
+def analyze_diagram_single_pass(self, image_path: Union[str, Path]) -> dict
+```
+
+Full single-pass diagram analysis. Extracts description, text content, elements, relationships, Mermaid syntax, and chart data in a single LLM call.
+
+**Returns:** `dict` with the following keys:
+
+| Key | Type | Description |
+|---|---|---|
+| `diagram_type` | `str` | Diagram classification |
+| `description` | `str` | Detailed description of the visual content |
+| `text_content` | `str` | All visible text, preserving structure |
+| `elements` | `list[str]` | Identified elements/components |
+| `relationships` | `list[str]` | Relationships in `"A -> B: label"` format |
+| `mermaid` | `str` | Valid Mermaid diagram syntax |
+| `chart_data` | `dict \| None` | Chart data with `labels`, `values`, `chart_type` (only for data charts) |
+
+Returns an empty `dict` on failure.
+
+### caption_frame()
+
+```python
+def caption_frame(self, image_path: Union[str, Path]) -> str
+```
+
+Get a brief 1-2 sentence caption for a frame. Used as a fallback when full diagram analysis is not warranted.
+
+**Returns:** `str` -- a brief description of the frame content.
+
+### process_frames()
+
+```python
+def process_frames(
+    self,
+    frame_paths: List[Union[str, Path]],
+    diagrams_dir: Optional[Path] = None,
+    captures_dir: Optional[Path] = None,
+) -> Tuple[List[DiagramResult], List[ScreenCapture]]
+```
+
+Process a batch of extracted video frames through the full classification and analysis pipeline.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `frame_paths` | `List[Union[str, Path]]` | *required* | Paths to frame images |
+| `diagrams_dir` | `Optional[Path]` | `None` | Output directory for diagram files (images, mermaid, JSON) |
+| `captures_dir` | `Optional[Path]` | `None` | Output directory for screengrab fallback files |
+
+**Returns:** `Tuple[List[DiagramResult], List[ScreenCapture]]`
+
+**Confidence thresholds:**
+
+| Confidence Range | Action |
+|---|---|
+| >= 0.7 | Full diagram analysis -- extracts elements, relationships, Mermaid syntax |
+| 0.3 to 0.7 | Screengrab fallback -- saves frame with a brief caption |
+| < 0.3 | Skipped entirely |
+
+**Output files (when directories are provided):**
+
+For diagrams (`diagrams_dir`):
+
+- `diagram_N.jpg` -- original frame image
+- `diagram_N.mermaid` -- Mermaid source (if generated)
+- `diagram_N.json` -- full DiagramResult as JSON
+
+For screen captures (`captures_dir`):
+
+- `capture_N.jpg` -- original frame image
+- `capture_N.json` -- ScreenCapture metadata as JSON
+
+```python
+from pathlib import Path
+from video_processor.analyzers.diagram_analyzer import DiagramAnalyzer
+from video_processor.providers.manager import ProviderManager
+
+analyzer = DiagramAnalyzer(
+    provider_manager=ProviderManager(),
+    confidence_threshold=0.3,
+)
+
+frame_paths = list(Path("output/frames").glob("*.jpg"))
+diagrams, captures = analyzer.process_frames(
+    frame_paths,
+    diagrams_dir=Path("output/diagrams"),
+    captures_dir=Path("output/captures"),
+)
+
+print(f"Found {len(diagrams)} diagrams, {len(captures)} screengrabs")
+for d in diagrams:
+    print(f"  [{d.diagram_type.value}] {d.description}")
+```
+
+---
+
+## ContentAnalyzer
+
+```python
+from video_processor.analyzers.content_analyzer import ContentAnalyzer
+```
+
+Cross-references transcript and diagram entities for richer knowledge extraction. Merges entities found in different sources and enriches key points with diagram links.
+
+### Constructor
+
+```python
+def __init__(self, provider_manager: Optional[ProviderManager] = None)
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `provider_manager` | `Optional[ProviderManager]` | `None` | Required for LLM-based fuzzy matching |
+
+### cross_reference()
+
+```python
+def cross_reference(
+    self,
+    transcript_entities: List[Entity],
+    diagram_entities: List[Entity],
+) -> List[Entity]
+```
+
+Merge entities from transcripts and diagrams into a unified list with source attribution.
+
+**Merge strategy:**
+
+1. Index all transcript entities by lowercase name, marked with `source="transcript"`
+2. Merge diagram entities: if a name matches, set `source="both"` and combine descriptions/occurrences; otherwise add as `source="diagram"`
+3. If a `ProviderManager` is available, use LLM fuzzy matching to find additional matches among unmatched entities (e.g., "PostgreSQL" from transcript matching "Postgres" from diagram)
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `transcript_entities` | `List[Entity]` | Entities extracted from transcript |
+| `diagram_entities` | `List[Entity]` | Entities extracted from diagrams |
+
+**Returns:** `List[Entity]` -- merged entity list with `source` attribution.
+
+```python
+from video_processor.analyzers.content_analyzer import ContentAnalyzer
+from video_processor.models import Entity
+
+analyzer = ContentAnalyzer(provider_manager=pm)
+
+transcript_entities = [
+    Entity(name="PostgreSQL", type="technology"),
+    Entity(name="Alice", type="person"),
+]
+diagram_entities = [
+    Entity(name="Postgres", type="technology"),
+    Entity(name="Redis", type="technology"),
+]
+
+merged = analyzer.cross_reference(transcript_entities, diagram_entities)
+# "PostgreSQL" and "Postgres" may be fuzzy-matched and merged
+```
+
+### enrich_key_points()
+
+```python
+def enrich_key_points(
+    self,
+    key_points: List[KeyPoint],
+    diagrams: list,
+    transcript_text: str,
+) -> List[KeyPoint]
+```
+
+Link key points to relevant diagrams by entity overlap. Examines word overlap between key point text and diagram elements/text content.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `key_points` | `List[KeyPoint]` | Key points to enrich |
+| `diagrams` | `list` | List of `DiagramResult` objects or dicts |
+| `transcript_text` | `str` | Full transcript text (reserved for future use) |
+
+**Returns:** `List[KeyPoint]` -- key points with `related_diagrams` indices populated.
+
+A key point is linked to a diagram when they share 2 or more words (excluding short words) between the key point text/details and the diagram's elements/text content.
+
+---
+
+## ActionDetector
+
+```python
+from video_processor.analyzers.action_detector import ActionDetector
+```
+
+Detects action items from transcripts and diagram content using LLM extraction with a regex pattern fallback.
+
+### Constructor
+
+```python
+def __init__(self, provider_manager: Optional[ProviderManager] = None)
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `provider_manager` | `Optional[ProviderManager]` | `None` | Required for LLM-based extraction |
+
+### detect_from_transcript()
+
+```python
+def detect_from_transcript(
+    self,
+    text: str,
+    segments: Optional[List[TranscriptSegment]] = None,
+) -> List[ActionItem]
+```
+
+Detect action items from transcript text.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `text` | `str` | *required* | Transcript text to analyze |
+| `segments` | `Optional[List[TranscriptSegment]]` | `None` | Transcript segments for timestamp attachment |
+
+**Returns:** `List[ActionItem]` -- detected action items with `source="transcript"`.
+
+**Extraction modes:**
+
+- **LLM mode** (when `provider_manager` is set): Sends the transcript to the LLM with a structured extraction prompt. Extracts action, assignee, deadline, priority, and context.
+- **Pattern mode** (fallback): Matches sentences against regex patterns for action-oriented language.
+
+**Pattern matching** detects sentences containing:
+
+- "need/needs to", "should/must/shall"
+- "will/going to", "action item/todo/follow-up"
+- "assigned to/responsible for", "deadline/due by"
+- "let's/let us", "make sure/ensure"
+- "can you/could you/please"
+
+**Timestamp attachment:** When `segments` are provided, each action item is matched to the most relevant transcript segment (by word overlap, minimum 3 matching words), and a timestamp is added to `context`.
+
+### detect_from_diagrams()
+
+```python
+def detect_from_diagrams(self, diagrams: list) -> List[ActionItem]
+```
+
+Extract action items from diagram text content and elements. Processes each diagram's combined text using either LLM or pattern extraction.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `diagrams` | `list` | List of `DiagramResult` objects or dicts |
+
+**Returns:** `List[ActionItem]` -- action items with `source="diagram"`.
+
+### merge_action_items()
+
+```python
+def merge_action_items(
+    self,
+    transcript_items: List[ActionItem],
+    diagram_items: List[ActionItem],
+) -> List[ActionItem]
+```
+
+Merge action items from multiple sources, deduplicating by action text (case-insensitive, whitespace-normalized).
+
+**Returns:** `List[ActionItem]` -- deduplicated merged list.
+
+### Usage example
+
+```python
+from video_processor.analyzers.action_detector import ActionDetector
+from video_processor.providers.manager import ProviderManager
+
+detector = ActionDetector(provider_manager=ProviderManager())
+
+# From transcript
+transcript_items = detector.detect_from_transcript(
+    text="Alice needs to update the API docs by Friday. "
+         "Bob should review the PR before merging.",
+    segments=transcript_segments,
+)
+
+# From diagrams
+diagram_items = detector.detect_from_diagrams(diagram_results)
+
+# Merge and deduplicate
+all_items = detector.merge_action_items(transcript_items, diagram_items)
+
+for item in all_items:
+    print(f"[{item.priority or 'unset'}] {item.action}")
+    if item.assignee:
+        print(f"  Assignee: {item.assignee}")
+    if item.deadline:
+        print(f"  Deadline: {item.deadline}")
+```
+
+### Pattern fallback (no LLM)
+
+```python
+# Works without any API keys
+detector = ActionDetector()  # No provider_manager
+items = detector.detect_from_transcript(
+    "We need to finalize the database schema. "
+    "Please update the deployment scripts."
+)
+# Returns ActionItems matched by regex patterns
+```

--- a/docs/api/auth.md
+++ b/docs/api/auth.md
@@ -1,0 +1,377 @@
+# Auth API Reference
+
+::: video_processor.auth
+
+---
+
+## Overview
+
+The `video_processor.auth` module provides a unified OAuth and authentication strategy for all PlanOpticon source connectors. It supports multiple authentication methods tried in a consistent order:
+
+1. **Saved token** -- load from disk, auto-refresh if expired
+2. **Client Credentials** -- server-to-server OAuth (e.g., Zoom S2S)
+3. **OAuth 2.0 PKCE** -- interactive Authorization Code flow with PKCE
+4. **API key fallback** -- environment variable lookup
+
+Tokens are persisted to `~/.planopticon/` and automatically refreshed on expiry.
+
+---
+
+## AuthConfig
+
+```python
+from video_processor.auth import AuthConfig
+```
+
+Dataclass configuring authentication for a specific service. Defines OAuth endpoints, client credentials, API key fallback, scopes, and token storage.
+
+### Fields
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `service` | `str` | *required* | Service identifier (e.g., `"zoom"`, `"notion"`) |
+| `oauth_authorize_url` | `Optional[str]` | `None` | OAuth authorization endpoint URL |
+| `oauth_token_url` | `Optional[str]` | `None` | OAuth token exchange endpoint URL |
+| `client_id` | `Optional[str]` | `None` | OAuth client ID (direct value) |
+| `client_secret` | `Optional[str]` | `None` | OAuth client secret (direct value) |
+| `client_id_env` | `Optional[str]` | `None` | Environment variable for client ID |
+| `client_secret_env` | `Optional[str]` | `None` | Environment variable for client secret |
+| `api_key_env` | `Optional[str]` | `None` | Environment variable for API key fallback |
+| `scopes` | `List[str]` | `[]` | OAuth scopes to request |
+| `redirect_uri` | `str` | `"urn:ietf:wg:oauth:2.0:oob"` | Redirect URI for auth code flow |
+| `account_id` | `Optional[str]` | `None` | Account ID for client credentials grant (direct value) |
+| `account_id_env` | `Optional[str]` | `None` | Environment variable for account ID |
+| `token_path` | `Optional[Path]` | `None` | Custom token storage path |
+
+### Resolved Properties
+
+These properties resolve values by checking the direct field first, then falling back to the environment variable.
+
+| Property | Return Type | Description |
+|---|---|---|
+| `resolved_client_id` | `Optional[str]` | Client ID from `client_id` or `os.environ[client_id_env]` |
+| `resolved_client_secret` | `Optional[str]` | Client secret from `client_secret` or `os.environ[client_secret_env]` |
+| `resolved_api_key` | `Optional[str]` | API key from `os.environ[api_key_env]` |
+| `resolved_account_id` | `Optional[str]` | Account ID from `account_id` or `os.environ[account_id_env]` |
+| `resolved_token_path` | `Path` | Token file path: `token_path` or `~/.planopticon/{service}_token.json` |
+| `supports_oauth` | `bool` | `True` if both `oauth_authorize_url` and `oauth_token_url` are set |
+
+```python
+from video_processor.auth import AuthConfig
+
+config = AuthConfig(
+    service="notion",
+    oauth_authorize_url="https://api.notion.com/v1/oauth/authorize",
+    oauth_token_url="https://api.notion.com/v1/oauth/token",
+    client_id_env="NOTION_CLIENT_ID",
+    client_secret_env="NOTION_CLIENT_SECRET",
+    api_key_env="NOTION_API_KEY",
+    scopes=["read_content"],
+)
+
+# Check resolved values
+print(config.resolved_client_id)   # From NOTION_CLIENT_ID env var
+print(config.supports_oauth)       # True
+print(config.resolved_token_path)  # ~/.planopticon/notion_token.json
+```
+
+---
+
+## AuthResult
+
+```python
+from video_processor.auth import AuthResult
+```
+
+Dataclass representing the result of an authentication attempt.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `success` | `bool` | *required* | Whether authentication succeeded |
+| `access_token` | `Optional[str]` | `None` | The access token (if successful) |
+| `method` | `Optional[str]` | `None` | Auth method used: `"saved_token"`, `"oauth_pkce"`, `"client_credentials"`, `"api_key"` |
+| `expires_at` | `Optional[float]` | `None` | Token expiration as Unix timestamp |
+| `refresh_token` | `Optional[str]` | `None` | OAuth refresh token (if available) |
+| `error` | `Optional[str]` | `None` | Error message (if failed) |
+
+```python
+result = manager.authenticate()
+if result.success:
+    print(f"Authenticated via {result.method}")
+    print(f"Token: {result.access_token[:20]}...")
+    if result.expires_at:
+        import time
+        remaining = result.expires_at - time.time()
+        print(f"Expires in {remaining/60:.0f} minutes")
+else:
+    print(f"Auth failed: {result.error}")
+```
+
+---
+
+## OAuthManager
+
+```python
+from video_processor.auth import OAuthManager
+```
+
+Manages the full authentication lifecycle for a service. Tries auth methods in priority order and handles token persistence, refresh, and PKCE flow.
+
+### Constructor
+
+```python
+def __init__(self, config: AuthConfig)
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `config` | `AuthConfig` | Authentication configuration for the target service |
+
+### authenticate()
+
+```python
+def authenticate(self) -> AuthResult
+```
+
+Run the full auth chain and return the result. Methods are tried in order:
+
+1. **Saved token** -- checks `~/.planopticon/{service}_token.json`, refreshes if expired
+2. **Client Credentials** -- if `account_id` is set and OAuth is configured, uses the client credentials grant (server-to-server)
+3. **OAuth PKCE** -- if OAuth is configured and client ID is available, opens a browser for interactive authorization with PKCE
+4. **API key** -- falls back to the environment variable specified in `api_key_env`
+
+**Returns:** `AuthResult` -- success/failure with token and method details.
+
+If all methods fail, returns an `AuthResult` with `success=False` and a helpful error message listing which environment variables to set.
+
+### get_token()
+
+```python
+def get_token(self) -> Optional[str]
+```
+
+Convenience method: run `authenticate()` and return just the access token string.
+
+**Returns:** `Optional[str]` -- the access token, or `None` if authentication failed.
+
+### clear_token()
+
+```python
+def clear_token(self) -> None
+```
+
+Remove the saved token file for this service (effectively a logout). The next `authenticate()` call will require re-authentication.
+
+---
+
+## Authentication Flows
+
+### Saved Token (auto-refresh)
+
+Tokens are saved to `~/.planopticon/{service}_token.json` as JSON. On each `authenticate()` call, the saved token is loaded and checked:
+
+- If the token has not expired (`time.time() < expires_at`), it is returned immediately
+- If expired but a refresh token is available, the manager attempts to refresh using the OAuth token endpoint
+- The refreshed token is saved back to disk
+
+### Client Credentials Grant
+
+Used for server-to-server authentication (e.g., Zoom Server-to-Server OAuth). Requires `account_id`, `client_id`, and `client_secret`. Sends a POST to the token endpoint with `grant_type=account_credentials`.
+
+### OAuth 2.0 Authorization Code with PKCE
+
+Interactive flow for user authentication:
+
+1. Generates a PKCE code verifier and S256 challenge
+2. Constructs the authorization URL with client ID, redirect URI, scopes, and PKCE challenge
+3. Opens the URL in the user's browser
+4. Prompts the user to paste the authorization code
+5. Exchanges the code for tokens at the token endpoint
+6. Saves the tokens to disk
+
+### API Key Fallback
+
+If no OAuth flow succeeds, falls back to checking the environment variable specified in `api_key_env`. Returns the value directly as the access token.
+
+---
+
+## KNOWN_CONFIGS
+
+```python
+from video_processor.auth import KNOWN_CONFIGS
+```
+
+Pre-built `AuthConfig` instances for supported services. These cover the most common cloud integrations and can be used directly or as templates for custom configurations.
+
+| Service Key | Service | OAuth Endpoints | Client ID Env | API Key Env |
+|---|---|---|---|---|
+| `"zoom"` | Zoom | `zoom.us/oauth/...` | `ZOOM_CLIENT_ID` | -- |
+| `"notion"` | Notion | `api.notion.com/v1/oauth/...` | `NOTION_CLIENT_ID` | `NOTION_API_KEY` |
+| `"dropbox"` | Dropbox | `dropbox.com/oauth2/...` | `DROPBOX_APP_KEY` | `DROPBOX_ACCESS_TOKEN` |
+| `"github"` | GitHub | `github.com/login/oauth/...` | `GITHUB_CLIENT_ID` | `GITHUB_TOKEN` |
+| `"google"` | Google | `accounts.google.com/o/oauth2/...` | `GOOGLE_CLIENT_ID` | `GOOGLE_API_KEY` |
+| `"microsoft"` | Microsoft | `login.microsoftonline.com/.../oauth2/...` | `MICROSOFT_CLIENT_ID` | -- |
+
+### Zoom
+
+Supports both Server-to-Server (via `ZOOM_ACCOUNT_ID`) and OAuth PKCE flows.
+
+```bash
+# Server-to-Server
+export ZOOM_CLIENT_ID="..."
+export ZOOM_CLIENT_SECRET="..."
+export ZOOM_ACCOUNT_ID="..."
+
+# Or interactive OAuth (omit ZOOM_ACCOUNT_ID)
+export ZOOM_CLIENT_ID="..."
+export ZOOM_CLIENT_SECRET="..."
+```
+
+### Google (Drive, Meet, Workspace)
+
+Supports OAuth PKCE and API key fallback. Scopes include Drive and Docs read-only access.
+
+```bash
+export GOOGLE_CLIENT_ID="..."
+export GOOGLE_CLIENT_SECRET="..."
+# Or for API-key-only access:
+export GOOGLE_API_KEY="..."
+```
+
+### GitHub
+
+Supports OAuth PKCE and personal access token. Requests `repo` and `read:org` scopes.
+
+```bash
+# OAuth
+export GITHUB_CLIENT_ID="..."
+export GITHUB_CLIENT_SECRET="..."
+# Or personal access token
+export GITHUB_TOKEN="ghp_..."
+```
+
+---
+
+## Helper Functions
+
+### get_auth_config()
+
+```python
+def get_auth_config(service: str) -> Optional[AuthConfig]
+```
+
+Get a pre-built `AuthConfig` for a known service.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `service` | `str` | Service name (e.g., `"zoom"`, `"notion"`, `"github"`) |
+
+**Returns:** `Optional[AuthConfig]` -- the config, or `None` if the service is not in `KNOWN_CONFIGS`.
+
+### get_auth_manager()
+
+```python
+def get_auth_manager(service: str) -> Optional[OAuthManager]
+```
+
+Get an `OAuthManager` for a known service. Convenience wrapper that looks up the config and creates the manager in one call.
+
+**Returns:** `Optional[OAuthManager]` -- the manager, or `None` if the service is not known.
+
+---
+
+## Usage Examples
+
+### Quick authentication for a known service
+
+```python
+from video_processor.auth import get_auth_manager
+
+manager = get_auth_manager("zoom")
+if manager:
+    result = manager.authenticate()
+    if result.success:
+        print(f"Authenticated via {result.method}")
+        # Use result.access_token for API calls
+    else:
+        print(f"Failed: {result.error}")
+```
+
+### Custom service configuration
+
+```python
+from video_processor.auth import AuthConfig, OAuthManager
+
+config = AuthConfig(
+    service="my_service",
+    oauth_authorize_url="https://my-service.com/oauth/authorize",
+    oauth_token_url="https://my-service.com/oauth/token",
+    client_id_env="MY_SERVICE_CLIENT_ID",
+    client_secret_env="MY_SERVICE_CLIENT_SECRET",
+    api_key_env="MY_SERVICE_API_KEY",
+    scopes=["read", "write"],
+)
+
+manager = OAuthManager(config)
+token = manager.get_token()  # Returns str or None
+```
+
+### Using auth in a custom source connector
+
+```python
+from pathlib import Path
+from typing import List, Optional
+
+from video_processor.auth import OAuthManager, AuthConfig
+from video_processor.sources.base import BaseSource, SourceFile
+
+class CustomSource(BaseSource):
+    def __init__(self):
+        self._config = AuthConfig(
+            service="custom",
+            api_key_env="CUSTOM_API_KEY",
+        )
+        self._manager = OAuthManager(self._config)
+        self._token: Optional[str] = None
+
+    def authenticate(self) -> bool:
+        self._token = self._manager.get_token()
+        return self._token is not None
+
+    def list_videos(self, **kwargs) -> List[SourceFile]:
+        # Use self._token to query the API
+        ...
+
+    def download(self, file: SourceFile, destination: Path) -> Path:
+        # Use self._token for authenticated downloads
+        ...
+```
+
+### Logout / clear saved token
+
+```python
+from video_processor.auth import get_auth_manager
+
+manager = get_auth_manager("zoom")
+if manager:
+    manager.clear_token()
+    print("Zoom token cleared")
+```
+
+### Token storage location
+
+All tokens are stored under `~/.planopticon/`:
+
+```
+~/.planopticon/
+    zoom_token.json
+    notion_token.json
+    github_token.json
+    google_token.json
+    microsoft_token.json
+    dropbox_token.json
+```
+
+Each file contains a JSON object with `access_token`, `refresh_token` (if applicable), `expires_at`, and client credentials for refresh.

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -1,3 +1,501 @@
 # Models API Reference
 
 ::: video_processor.models
+
+---
+
+## Overview
+
+The `video_processor.models` module defines all Pydantic data models used throughout PlanOpticon for structured output, serialization, and validation. These models represent everything from individual transcript segments to complete batch processing manifests.
+
+All models inherit from `pydantic.BaseModel` and support JSON serialization via `.model_dump_json()` and deserialization via `.model_validate_json()`.
+
+---
+
+## Enumerations
+
+### DiagramType
+
+Types of visual content detected in video frames.
+
+```python
+from video_processor.models import DiagramType
+```
+
+| Value | Description |
+|---|---|
+| `flowchart` | Process flow or decision tree diagrams |
+| `sequence` | Sequence or interaction diagrams |
+| `architecture` | System architecture diagrams |
+| `whiteboard` | Whiteboard drawings or sketches |
+| `chart` | Data charts (bar, line, pie, scatter) |
+| `table` | Tabular data |
+| `slide` | Presentation slides |
+| `screenshot` | Application screenshots or screen shares |
+| `unknown` | Unclassified visual content |
+
+### OutputFormat
+
+Available output formats for processing results.
+
+| Value | Description |
+|---|---|
+| `markdown` | Markdown text |
+| `json` | JSON data |
+| `html` | HTML document |
+| `pdf` | PDF document |
+| `svg` | SVG vector graphic |
+| `png` | PNG raster image |
+
+### PlanningEntityType
+
+Classification types for entities in a planning taxonomy.
+
+| Value | Description |
+|---|---|
+| `goal` | Project goals or objectives |
+| `requirement` | Functional or non-functional requirements |
+| `constraint` | Limitations or constraints |
+| `decision` | Decisions made during planning |
+| `risk` | Identified risks |
+| `assumption` | Planning assumptions |
+| `dependency` | External or internal dependencies |
+| `milestone` | Project milestones |
+| `task` | Actionable tasks |
+| `feature` | Product features |
+
+### PlanningRelationshipType
+
+Relationship types within a planning taxonomy.
+
+| Value | Description |
+|---|---|
+| `requires` | Entity A requires entity B |
+| `blocked_by` | Entity A is blocked by entity B |
+| `has_risk` | Entity A has an associated risk B |
+| `depends_on` | Entity A depends on entity B |
+| `addresses` | Entity A addresses entity B |
+| `has_tradeoff` | Entity A involves a tradeoff with entity B |
+| `delivers` | Entity A delivers entity B |
+| `implements` | Entity A implements entity B |
+| `parent_of` | Entity A is the parent of entity B |
+
+---
+
+## Protocols
+
+### ProgressCallback
+
+A runtime-checkable protocol for receiving pipeline progress updates. Implement this interface to integrate custom progress reporting (e.g., web UI, logging).
+
+```python
+from video_processor.models import ProgressCallback
+
+class MyProgress:
+    def on_step_start(self, step: str, index: int, total: int) -> None:
+        print(f"Starting {step} ({index}/{total})")
+
+    def on_step_complete(self, step: str, index: int, total: int) -> None:
+        print(f"Completed {step} ({index}/{total})")
+
+    def on_progress(self, step: str, percent: float, message: str = "") -> None:
+        print(f"{step}: {percent:.0f}% {message}")
+
+assert isinstance(MyProgress(), ProgressCallback)  # True
+```
+
+**Methods:**
+
+| Method | Parameters | Description |
+|---|---|---|
+| `on_step_start` | `step: str`, `index: int`, `total: int` | Called when a pipeline step begins |
+| `on_step_complete` | `step: str`, `index: int`, `total: int` | Called when a pipeline step finishes |
+| `on_progress` | `step: str`, `percent: float`, `message: str` | Called with incremental progress updates |
+
+---
+
+## Transcript Models
+
+### TranscriptSegment
+
+A single segment of transcribed audio with timing and optional speaker identification.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `start` | `float` | *required* | Start time in seconds |
+| `end` | `float` | *required* | End time in seconds |
+| `text` | `str` | *required* | Transcribed text content |
+| `speaker` | `Optional[str]` | `None` | Speaker identifier (e.g., "Speaker 1") |
+| `confidence` | `Optional[float]` | `None` | Transcription confidence score (0.0 to 1.0) |
+
+```json
+{
+  "start": 12.5,
+  "end": 15.3,
+  "text": "We should migrate to the new API by next quarter.",
+  "speaker": "Alice",
+  "confidence": 0.95
+}
+```
+
+---
+
+## Content Extraction Models
+
+### ActionItem
+
+An action item extracted from transcript or diagram content.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `action` | `str` | *required* | The action to be taken |
+| `assignee` | `Optional[str]` | `None` | Person responsible for the action |
+| `deadline` | `Optional[str]` | `None` | Deadline or timeframe |
+| `priority` | `Optional[str]` | `None` | Priority level (e.g., "high", "medium", "low") |
+| `context` | `Optional[str]` | `None` | Additional context or notes |
+| `source` | `Optional[str]` | `None` | Where this was found: `"transcript"`, `"diagram"`, or `"both"` |
+
+```json
+{
+  "action": "Migrate authentication service to OAuth 2.0",
+  "assignee": "Bob",
+  "deadline": "Q2 2026",
+  "priority": "high",
+  "context": "at 245s",
+  "source": "transcript"
+}
+```
+
+### KeyPoint
+
+A key point extracted from content, optionally linked to diagrams.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `point` | `str` | *required* | The key point text |
+| `topic` | `Optional[str]` | `None` | Topic or category |
+| `details` | `Optional[str]` | `None` | Supporting details |
+| `timestamp` | `Optional[float]` | `None` | Timestamp in video (seconds) |
+| `source` | `Optional[str]` | `None` | Where this was found |
+| `related_diagrams` | `List[int]` | `[]` | Indices of related diagrams in the manifest |
+
+```json
+{
+  "point": "Team decided to use FalkorDB for graph storage",
+  "topic": "Architecture",
+  "details": "Embedded database avoids infrastructure overhead for CLI use",
+  "timestamp": 342.0,
+  "source": "transcript",
+  "related_diagrams": [0, 2]
+}
+```
+
+---
+
+## Diagram Models
+
+### DiagramResult
+
+Result from diagram extraction and analysis. Contains structured data extracted from visual content, along with paths to output files.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `frame_index` | `int` | *required* | Index of the source frame |
+| `timestamp` | `Optional[float]` | `None` | Timestamp in video (seconds) |
+| `diagram_type` | `DiagramType` | `unknown` | Type of diagram detected |
+| `confidence` | `float` | `0.0` | Detection confidence (0.0 to 1.0) |
+| `description` | `Optional[str]` | `None` | Detailed description of the diagram |
+| `text_content` | `Optional[str]` | `None` | All visible text, preserving structure |
+| `elements` | `List[str]` | `[]` | Identified elements or components |
+| `relationships` | `List[str]` | `[]` | Identified relationships (e.g., `"A -> B: connects"`) |
+| `mermaid` | `Optional[str]` | `None` | Mermaid syntax representation |
+| `chart_data` | `Optional[Dict[str, Any]]` | `None` | Extractable chart data (`labels`, `values`, `chart_type`) |
+| `image_path` | `Optional[str]` | `None` | Relative path to original frame image |
+| `svg_path` | `Optional[str]` | `None` | Relative path to rendered SVG |
+| `png_path` | `Optional[str]` | `None` | Relative path to rendered PNG |
+| `mermaid_path` | `Optional[str]` | `None` | Relative path to mermaid source file |
+
+```json
+{
+  "frame_index": 5,
+  "timestamp": 120.0,
+  "diagram_type": "architecture",
+  "confidence": 0.92,
+  "description": "Microservices architecture showing API gateway, auth service, and database layer",
+  "text_content": "API Gateway\nAuth Service\nUser DB\nPostgreSQL",
+  "elements": ["API Gateway", "Auth Service", "User DB", "PostgreSQL"],
+  "relationships": ["API Gateway -> Auth Service: authenticates", "Auth Service -> User DB: queries"],
+  "mermaid": "graph LR\n  A[API Gateway] --> B[Auth Service]\n  B --> C[User DB]",
+  "chart_data": null,
+  "image_path": "diagrams/diagram_0.jpg",
+  "svg_path": null,
+  "png_path": null,
+  "mermaid_path": "diagrams/diagram_0.mermaid"
+}
+```
+
+### ScreenCapture
+
+A screengrab fallback created when diagram extraction fails or confidence is too low for full analysis.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `frame_index` | `int` | *required* | Index of the source frame |
+| `timestamp` | `Optional[float]` | `None` | Timestamp in video (seconds) |
+| `caption` | `Optional[str]` | `None` | Brief description of the content |
+| `image_path` | `Optional[str]` | `None` | Relative path to screenshot image |
+| `confidence` | `float` | `0.0` | Detection confidence that triggered fallback |
+
+```json
+{
+  "frame_index": 8,
+  "timestamp": 195.0,
+  "caption": "Code editor showing a Python function definition",
+  "image_path": "captures/capture_0.jpg",
+  "confidence": 0.45
+}
+```
+
+---
+
+## Knowledge Graph Models
+
+### Entity
+
+An entity in the knowledge graph, representing a person, concept, technology, or other named item extracted from content.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str` | *required* | Entity name |
+| `type` | `str` | `"concept"` | Entity type: `"person"`, `"concept"`, `"technology"`, `"time"`, `"diagram"` |
+| `descriptions` | `List[str]` | `[]` | Accumulated descriptions of this entity |
+| `source` | `Optional[str]` | `None` | Source attribution: `"transcript"`, `"diagram"`, or `"both"` |
+| `occurrences` | `List[Dict[str, Any]]` | `[]` | Occurrences with source, timestamp, and text context |
+
+```json
+{
+  "name": "FalkorDB",
+  "type": "technology",
+  "descriptions": ["Embedded graph database", "Supports Cypher queries"],
+  "source": "both",
+  "occurrences": [
+    {"source": "transcript", "timestamp": 120.0, "text": "We chose FalkorDB for graph storage"},
+    {"source": "diagram", "text": "FalkorDB Lite"}
+  ]
+}
+```
+
+### Relationship
+
+A directed relationship between two entities in the knowledge graph.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `source` | `str` | *required* | Source entity name |
+| `target` | `str` | *required* | Target entity name |
+| `type` | `str` | `"related_to"` | Relationship type (e.g., `"uses"`, `"manages"`, `"related_to"`) |
+| `content_source` | `Optional[str]` | `None` | Content source identifier |
+| `timestamp` | `Optional[float]` | `None` | Timestamp in seconds |
+
+```json
+{
+  "source": "PlanOpticon",
+  "target": "FalkorDB",
+  "type": "uses",
+  "content_source": "transcript",
+  "timestamp": 125.0
+}
+```
+
+### SourceRecord
+
+A content source registered in the knowledge graph for provenance tracking.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `source_id` | `str` | *required* | Unique identifier for this source |
+| `source_type` | `str` | *required* | Source type: `"video"`, `"document"`, `"url"`, `"api"`, `"manual"` |
+| `title` | `str` | *required* | Human-readable title |
+| `path` | `Optional[str]` | `None` | Local file path |
+| `url` | `Optional[str]` | `None` | URL if applicable |
+| `mime_type` | `Optional[str]` | `None` | MIME type of the source |
+| `ingested_at` | `str` | *auto* | ISO format ingestion timestamp (auto-generated) |
+| `metadata` | `Dict[str, Any]` | `{}` | Additional source metadata |
+
+```json
+{
+  "source_id": "vid_abc123",
+  "source_type": "video",
+  "title": "Sprint Planning Meeting - Jan 15",
+  "path": "/recordings/sprint-planning.mp4",
+  "url": null,
+  "mime_type": "video/mp4",
+  "ingested_at": "2026-01-15T10:30:00",
+  "metadata": {"duration": 3600, "resolution": "1920x1080"}
+}
+```
+
+### KnowledgeGraphData
+
+Serializable knowledge graph data containing all nodes, relationships, and source provenance.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `nodes` | `List[Entity]` | `[]` | Graph nodes/entities |
+| `relationships` | `List[Relationship]` | `[]` | Graph relationships |
+| `sources` | `List[SourceRecord]` | `[]` | Content sources for provenance tracking |
+
+---
+
+## Planning Models
+
+### PlanningEntity
+
+An entity classified for planning purposes, with priority and status tracking.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str` | *required* | Entity name |
+| `planning_type` | `PlanningEntityType` | *required* | Planning classification |
+| `description` | `str` | `""` | Detailed description |
+| `priority` | `Optional[str]` | `None` | Priority: `"high"`, `"medium"`, `"low"` |
+| `status` | `Optional[str]` | `None` | Status: `"identified"`, `"confirmed"`, `"resolved"` |
+| `source_entities` | `List[str]` | `[]` | Names of source KG entities this was derived from |
+| `metadata` | `Dict[str, Any]` | `{}` | Additional metadata |
+
+```json
+{
+  "name": "Migrate to OAuth 2.0",
+  "planning_type": "task",
+  "description": "Replace custom auth with OAuth 2.0 across all services",
+  "priority": "high",
+  "status": "identified",
+  "source_entities": ["OAuth", "Authentication Service"],
+  "metadata": {}
+}
+```
+
+---
+
+## Processing and Metadata Models
+
+### ProcessingStats
+
+Statistics about a processing run, including model usage tracking.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `start_time` | `Optional[str]` | `None` | ISO format start time |
+| `end_time` | `Optional[str]` | `None` | ISO format end time |
+| `duration_seconds` | `Optional[float]` | `None` | Total processing time |
+| `frames_extracted` | `int` | `0` | Number of frames extracted from video |
+| `people_frames_filtered` | `int` | `0` | Frames filtered out (contained people/webcam) |
+| `diagrams_detected` | `int` | `0` | Number of diagrams detected |
+| `screen_captures` | `int` | `0` | Number of screen captures saved |
+| `transcript_duration_seconds` | `Optional[float]` | `None` | Duration of transcribed audio |
+| `models_used` | `Dict[str, str]` | `{}` | Map of task to model used (e.g., `{"vision": "gpt-4o"}`) |
+
+### VideoMetadata
+
+Metadata about the source video file.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `title` | `str` | *required* | Video title |
+| `source_path` | `Optional[str]` | `None` | Original video file path |
+| `duration_seconds` | `Optional[float]` | `None` | Video duration in seconds |
+| `resolution` | `Optional[str]` | `None` | Video resolution (e.g., `"1920x1080"`) |
+| `processed_at` | `str` | *auto* | ISO format processing timestamp |
+
+---
+
+## Manifest Models
+
+### VideoManifest
+
+The single source of truth for a video processing run. Contains all output paths, inline structured data, and processing statistics.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `version` | `str` | `"1.0"` | Manifest schema version |
+| `video` | `VideoMetadata` | *required* | Source video metadata |
+| `stats` | `ProcessingStats` | *default* | Processing statistics |
+| `transcript_json` | `Optional[str]` | `None` | Relative path to transcript JSON |
+| `transcript_txt` | `Optional[str]` | `None` | Relative path to transcript text |
+| `transcript_srt` | `Optional[str]` | `None` | Relative path to SRT subtitles |
+| `analysis_md` | `Optional[str]` | `None` | Relative path to analysis Markdown |
+| `analysis_html` | `Optional[str]` | `None` | Relative path to analysis HTML |
+| `analysis_pdf` | `Optional[str]` | `None` | Relative path to analysis PDF |
+| `knowledge_graph_json` | `Optional[str]` | `None` | Relative path to knowledge graph JSON |
+| `knowledge_graph_db` | `Optional[str]` | `None` | Relative path to knowledge graph DB |
+| `key_points_json` | `Optional[str]` | `None` | Relative path to key points JSON |
+| `action_items_json` | `Optional[str]` | `None` | Relative path to action items JSON |
+| `key_points` | `List[KeyPoint]` | `[]` | Inline key points data |
+| `action_items` | `List[ActionItem]` | `[]` | Inline action items data |
+| `diagrams` | `List[DiagramResult]` | `[]` | Inline diagram results |
+| `screen_captures` | `List[ScreenCapture]` | `[]` | Inline screen captures |
+| `frame_paths` | `List[str]` | `[]` | Relative paths to extracted frames |
+
+```python
+from video_processor.models import VideoManifest, VideoMetadata
+
+manifest = VideoManifest(
+    video=VideoMetadata(title="Sprint Planning"),
+    key_points=[...],
+    action_items=[...],
+    diagrams=[...],
+)
+
+# Serialize to JSON
+manifest.model_dump_json(indent=2)
+
+# Load from file
+loaded = VideoManifest.model_validate_json(Path("manifest.json").read_text())
+```
+
+### BatchVideoEntry
+
+Summary of a single video within a batch processing run.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `video_name` | `str` | *required* | Video file name |
+| `manifest_path` | `str` | *required* | Relative path to the video's manifest file |
+| `status` | `str` | `"pending"` | Processing status: `"pending"`, `"completed"`, `"failed"` |
+| `error` | `Optional[str]` | `None` | Error message if processing failed |
+| `diagrams_count` | `int` | `0` | Number of diagrams detected |
+| `action_items_count` | `int` | `0` | Number of action items extracted |
+| `key_points_count` | `int` | `0` | Number of key points extracted |
+| `duration_seconds` | `Optional[float]` | `None` | Processing duration |
+
+### BatchManifest
+
+Manifest for a batch processing run across multiple videos.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `version` | `str` | `"1.0"` | Manifest schema version |
+| `title` | `str` | `"Batch Processing Results"` | Batch title |
+| `processed_at` | `str` | *auto* | ISO format timestamp |
+| `stats` | `ProcessingStats` | *default* | Aggregated processing statistics |
+| `videos` | `List[BatchVideoEntry]` | `[]` | Per-video summaries |
+| `total_videos` | `int` | `0` | Total number of videos in batch |
+| `completed_videos` | `int` | `0` | Successfully processed videos |
+| `failed_videos` | `int` | `0` | Videos that failed processing |
+| `total_diagrams` | `int` | `0` | Total diagrams across all videos |
+| `total_action_items` | `int` | `0` | Total action items across all videos |
+| `total_key_points` | `int` | `0` | Total key points across all videos |
+| `batch_summary_md` | `Optional[str]` | `None` | Relative path to batch summary Markdown |
+| `merged_knowledge_graph_json` | `Optional[str]` | `None` | Relative path to merged KG JSON |
+| `merged_knowledge_graph_db` | `Optional[str]` | `None` | Relative path to merged KG database |
+
+```python
+from video_processor.models import BatchManifest
+
+batch = BatchManifest(
+    title="Weekly Recordings",
+    total_videos=5,
+    completed_videos=4,
+    failed_videos=1,
+)
+```

--- a/docs/api/providers.md
+++ b/docs/api/providers.md
@@ -5,3 +5,499 @@
 ::: video_processor.providers.manager
 
 ::: video_processor.providers.discovery
+
+---
+
+## Overview
+
+The provider system abstracts LLM API calls behind a unified interface. It supports multiple providers (OpenAI, Anthropic, Gemini, Ollama, and OpenAI-compatible services), automatic model discovery, capability-based routing, and usage tracking.
+
+**Key components:**
+
+- **`BaseProvider`** -- abstract interface that all providers implement
+- **`ProviderRegistry`** -- global registry mapping provider names to classes
+- **`ProviderManager`** -- high-level router that picks the best provider for each task
+- **`discover_available_models()`** -- scans all configured providers for available models
+
+---
+
+## BaseProvider (ABC)
+
+```python
+from video_processor.providers.base import BaseProvider
+```
+
+Abstract base class that all provider implementations must subclass. Defines the four core capabilities: chat, vision, audio transcription, and model listing.
+
+**Class attribute:**
+
+| Attribute | Type | Description |
+|---|---|---|
+| `provider_name` | `str` | Identifier for this provider (e.g., `"openai"`, `"anthropic"`) |
+
+### chat()
+
+```python
+def chat(
+    self,
+    messages: list[dict],
+    max_tokens: int = 4096,
+    temperature: float = 0.7,
+    model: Optional[str] = None,
+) -> str
+```
+
+Send a chat completion request.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `messages` | `list[dict]` | *required* | OpenAI-format message list (`role`, `content`) |
+| `max_tokens` | `int` | `4096` | Maximum tokens in the response |
+| `temperature` | `float` | `0.7` | Sampling temperature |
+| `model` | `Optional[str]` | `None` | Override model ID |
+
+**Returns:** `str` -- the assistant's text response.
+
+### analyze_image()
+
+```python
+def analyze_image(
+    self,
+    image_bytes: bytes,
+    prompt: str,
+    max_tokens: int = 4096,
+    model: Optional[str] = None,
+) -> str
+```
+
+Analyze an image with a text prompt using a vision-capable model.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `image_bytes` | `bytes` | *required* | Raw image data (JPEG, PNG, etc.) |
+| `prompt` | `str` | *required* | Analysis instructions |
+| `max_tokens` | `int` | `4096` | Maximum tokens in the response |
+| `model` | `Optional[str]` | `None` | Override model ID |
+
+**Returns:** `str` -- the assistant's analysis text.
+
+### transcribe_audio()
+
+```python
+def transcribe_audio(
+    self,
+    audio_path: str | Path,
+    language: Optional[str] = None,
+    model: Optional[str] = None,
+) -> dict
+```
+
+Transcribe an audio file.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `audio_path` | `str \| Path` | *required* | Path to the audio file |
+| `language` | `Optional[str]` | `None` | Language hint (ISO 639-1 code) |
+| `model` | `Optional[str]` | `None` | Override model ID |
+
+**Returns:** `dict` -- transcription result with keys `text`, `segments`, `duration`, etc.
+
+### list_models()
+
+```python
+def list_models(self) -> list[ModelInfo]
+```
+
+Discover available models from this provider's API.
+
+**Returns:** `list[ModelInfo]` -- available models with capability metadata.
+
+---
+
+## ModelInfo
+
+```python
+from video_processor.providers.base import ModelInfo
+```
+
+Pydantic model describing an available model from a provider.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `id` | `str` | *required* | Model identifier (e.g., `"gpt-4o"`, `"claude-haiku-4-5-20251001"`) |
+| `provider` | `str` | *required* | Provider name (e.g., `"openai"`, `"anthropic"`, `"gemini"`) |
+| `display_name` | `str` | `""` | Human-readable display name |
+| `capabilities` | `List[str]` | `[]` | Model capabilities: `"chat"`, `"vision"`, `"audio"`, `"embedding"` |
+
+```json
+{
+  "id": "gpt-4o",
+  "provider": "openai",
+  "display_name": "GPT-4o",
+  "capabilities": ["chat", "vision"]
+}
+```
+
+---
+
+## ProviderRegistry
+
+```python
+from video_processor.providers.base import ProviderRegistry
+```
+
+Class-level registry for provider classes. Providers register themselves with metadata on import. This registry is used internally by `ProviderManager` but can also be used directly for introspection.
+
+### register()
+
+```python
+@classmethod
+def register(
+    cls,
+    name: str,
+    provider_class: type,
+    env_var: str = "",
+    model_prefixes: Optional[List[str]] = None,
+    default_models: Optional[Dict[str, str]] = None,
+) -> None
+```
+
+Register a provider class with its metadata. Called by each provider module at import time.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str` | *required* | Provider name (e.g., `"openai"`) |
+| `provider_class` | `type` | *required* | The provider class |
+| `env_var` | `str` | `""` | Environment variable for API key |
+| `model_prefixes` | `Optional[List[str]]` | `None` | Model ID prefixes for auto-detection (e.g., `["gpt-", "o1-"]`) |
+| `default_models` | `Optional[Dict[str, str]]` | `None` | Default models per capability (e.g., `{"chat": "gpt-4o", "vision": "gpt-4o"}`) |
+
+### get()
+
+```python
+@classmethod
+def get(cls, name: str) -> type
+```
+
+Return the provider class for a given name. Raises `ValueError` if the provider is not registered.
+
+### get_by_model()
+
+```python
+@classmethod
+def get_by_model(cls, model_id: str) -> Optional[str]
+```
+
+Return the provider name for a model ID based on prefix matching. Returns `None` if no match is found.
+
+### get_default_models()
+
+```python
+@classmethod
+def get_default_models(cls, name: str) -> Dict[str, str]
+```
+
+Return the default models dict for a provider, mapping capability names to model IDs.
+
+### available()
+
+```python
+@classmethod
+def available(cls) -> List[str]
+```
+
+Return names of providers whose required environment variable is set (or providers with no env var requirement, like Ollama).
+
+### all_registered()
+
+```python
+@classmethod
+def all_registered(cls) -> Dict[str, Dict]
+```
+
+Return all registered providers and their metadata dictionaries.
+
+---
+
+## OpenAICompatibleProvider
+
+```python
+from video_processor.providers.base import OpenAICompatibleProvider
+```
+
+Base class for providers using OpenAI-compatible APIs (Together, Fireworks, Cerebras, xAI, Azure). Implements `chat()`, `analyze_image()`, and `list_models()` using the OpenAI client library. `transcribe_audio()` raises `NotImplementedError` by default.
+
+**Constructor:**
+
+```python
+def __init__(self, api_key: Optional[str] = None, base_url: Optional[str] = None)
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `api_key` | `Optional[str]` | `None` | API key (falls back to `self.env_var` environment variable) |
+| `base_url` | `Optional[str]` | `None` | API base URL (falls back to `self.base_url` class attribute) |
+
+**Subclass attributes to override:**
+
+| Attribute | Description |
+|---|---|
+| `provider_name` | Provider identifier string |
+| `base_url` | Default API base URL |
+| `env_var` | Environment variable name for the API key |
+
+**Usage tracking:** After each `chat()` or `analyze_image()` call, the provider stores token counts in `self._last_usage` as `{"input_tokens": int, "output_tokens": int}`. This is consumed by `ProviderManager._track()`.
+
+---
+
+## ProviderManager
+
+```python
+from video_processor.providers.manager import ProviderManager
+```
+
+High-level router that selects the best available provider and model for each API call. Supports explicit model selection, forced provider, or automatic selection based on discovered capabilities.
+
+### Constructor
+
+```python
+def __init__(
+    self,
+    vision_model: Optional[str] = None,
+    chat_model: Optional[str] = None,
+    transcription_model: Optional[str] = None,
+    provider: Optional[str] = None,
+    auto: bool = True,
+)
+```
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `vision_model` | `Optional[str]` | `None` | Override model for vision tasks (e.g., `"gpt-4o"`) |
+| `chat_model` | `Optional[str]` | `None` | Override model for chat/LLM tasks |
+| `transcription_model` | `Optional[str]` | `None` | Override model for transcription |
+| `provider` | `Optional[str]` | `None` | Force all tasks to a single provider |
+| `auto` | `bool` | `True` | If `True` and no model specified, pick the best available |
+
+**Attributes:**
+
+| Attribute | Type | Description |
+|---|---|---|
+| `usage` | `UsageTracker` | Tracks token counts and API costs across all calls |
+
+### Auto-selection preferences
+
+When `auto=True` and no explicit model is set, providers are tried in this order:
+
+**Vision:** Gemini (`gemini-2.5-flash`) > OpenAI (`gpt-4o-mini`) > Anthropic (`claude-haiku-4-5-20251001`)
+
+**Chat:** Anthropic (`claude-haiku-4-5-20251001`) > OpenAI (`gpt-4o-mini`) > Gemini (`gemini-2.5-flash`)
+
+**Transcription:** OpenAI (`whisper-1`) > Gemini (`gemini-2.5-flash`)
+
+If no API-key-based provider is available, Ollama is tried as a fallback.
+
+### chat()
+
+```python
+def chat(
+    self,
+    messages: list[dict],
+    max_tokens: int = 4096,
+    temperature: float = 0.7,
+) -> str
+```
+
+Send a chat completion to the best available provider. Automatically resolves which provider and model to use.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `messages` | `list[dict]` | *required* | OpenAI-format messages |
+| `max_tokens` | `int` | `4096` | Maximum response tokens |
+| `temperature` | `float` | `0.7` | Sampling temperature |
+
+**Returns:** `str` -- assistant response text.
+
+**Raises:** `RuntimeError` if no provider is available for the `chat` capability.
+
+### analyze_image()
+
+```python
+def analyze_image(
+    self,
+    image_bytes: bytes,
+    prompt: str,
+    max_tokens: int = 4096,
+) -> str
+```
+
+Analyze an image using the best available vision provider.
+
+**Returns:** `str` -- analysis text.
+
+**Raises:** `RuntimeError` if no provider is available for the `vision` capability.
+
+### transcribe_audio()
+
+```python
+def transcribe_audio(
+    self,
+    audio_path: str | Path,
+    language: Optional[str] = None,
+    speaker_hints: Optional[list[str]] = None,
+) -> dict
+```
+
+Transcribe audio. Prefers local Whisper (no file size limits, no API costs) when available, falling back to API-based transcription.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `audio_path` | `str \| Path` | *required* | Path to the audio file |
+| `language` | `Optional[str]` | `None` | Language hint |
+| `speaker_hints` | `Optional[list[str]]` | `None` | Speaker names for better recognition |
+
+**Returns:** `dict` -- transcription result with `text`, `segments`, `duration`.
+
+**Local Whisper:** If `transcription_model` is unset or starts with `"whisper-local"`, the manager tries local Whisper first. Use `"whisper-local:large"` to specify a model size.
+
+### get_models_used()
+
+```python
+def get_models_used(self) -> dict[str, str]
+```
+
+Return a dict mapping capability to `"provider/model"` string for tracking purposes.
+
+```python
+pm = ProviderManager()
+print(pm.get_models_used())
+# {"vision": "gemini/gemini-2.5-flash", "chat": "anthropic/claude-haiku-4-5-20251001", ...}
+```
+
+### Usage examples
+
+```python
+from video_processor.providers.manager import ProviderManager
+
+# Auto-select best providers
+pm = ProviderManager()
+
+# Force everything through one provider
+pm = ProviderManager(provider="openai")
+
+# Explicit model selection
+pm = ProviderManager(
+    vision_model="gpt-4o",
+    chat_model="claude-haiku-4-5-20251001",
+    transcription_model="whisper-local:large",
+)
+
+# Chat completion
+response = pm.chat([
+    {"role": "user", "content": "Summarize this meeting transcript..."}
+])
+
+# Image analysis
+with open("diagram.png", "rb") as f:
+    analysis = pm.analyze_image(f.read(), "Describe this architecture diagram")
+
+# Transcription with speaker hints
+result = pm.transcribe_audio(
+    "meeting.mp3",
+    language="en",
+    speaker_hints=["Alice", "Bob", "Charlie"],
+)
+
+# Check usage
+print(pm.usage.summary())
+```
+
+---
+
+## discover_available_models()
+
+```python
+from video_processor.providers.discovery import discover_available_models
+```
+
+```python
+def discover_available_models(
+    api_keys: Optional[dict[str, str]] = None,
+    force_refresh: bool = False,
+) -> list[ModelInfo]
+```
+
+Discover available models from all configured providers. For each provider with a valid API key, calls `list_models()` and returns a unified, sorted list.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `api_keys` | `Optional[dict[str, str]]` | `None` | Override API keys (defaults to environment variables) |
+| `force_refresh` | `bool` | `False` | Force re-discovery, ignoring the session cache |
+
+**Returns:** `list[ModelInfo]` -- all discovered models, sorted by provider then model ID.
+
+**Caching:** Results are cached for the session. Use `force_refresh=True` or `clear_discovery_cache()` to refresh.
+
+```python
+from video_processor.providers.discovery import (
+    discover_available_models,
+    clear_discovery_cache,
+)
+
+# Discover models using environment variables
+models = discover_available_models()
+for m in models:
+    print(f"{m.provider}/{m.id} - {m.capabilities}")
+
+# Force refresh
+models = discover_available_models(force_refresh=True)
+
+# Override API keys
+models = discover_available_models(api_keys={
+    "openai": "sk-...",
+    "anthropic": "sk-ant-...",
+})
+
+# Clear cache
+clear_discovery_cache()
+```
+
+### clear_discovery_cache()
+
+```python
+def clear_discovery_cache() -> None
+```
+
+Clear the cached model list, forcing the next `discover_available_models()` call to re-query providers.
+
+---
+
+## Built-in Providers
+
+The following providers are registered automatically when the provider system initializes:
+
+| Provider | Environment Variable | Capabilities | Default Chat Model |
+|---|---|---|---|
+| `openai` | `OPENAI_API_KEY` | chat, vision, audio | `gpt-4o-mini` |
+| `anthropic` | `ANTHROPIC_API_KEY` | chat, vision | `claude-haiku-4-5-20251001` |
+| `gemini` | `GEMINI_API_KEY` | chat, vision, audio | `gemini-2.5-flash` |
+| `ollama` | *(none -- checks server)* | chat, vision | *(depends on installed models)* |
+| `together` | `TOGETHER_API_KEY` | chat | *(varies)* |
+| `fireworks` | `FIREWORKS_API_KEY` | chat | *(varies)* |
+| `cerebras` | `CEREBRAS_API_KEY` | chat | *(varies)* |
+| `xai` | `XAI_API_KEY` | chat | *(varies)* |
+| `azure` | `AZURE_OPENAI_API_KEY` | chat, vision | *(varies)* |

--- a/docs/api/sources.md
+++ b/docs/api/sources.md
@@ -1,0 +1,281 @@
+# Sources API Reference
+
+::: video_processor.sources.base
+
+---
+
+## Overview
+
+The sources module provides a unified interface for fetching content from cloud services, local applications, and the web. All sources implement the `BaseSource` abstract class, providing consistent `authenticate()`, `list_videos()`, and `download()` methods.
+
+Sources are lazy-loaded to avoid pulling in optional dependencies at import time. You can import any source directly from `video_processor.sources` and the correct module will be loaded on demand.
+
+---
+
+## BaseSource (ABC)
+
+```python
+from video_processor.sources import BaseSource
+```
+
+Abstract base class that all source integrations implement. Defines the standard three-step workflow: authenticate, list, download.
+
+### authenticate()
+
+```python
+@abstractmethod
+def authenticate(self) -> bool
+```
+
+Authenticate with the cloud provider or service. Uses the auth strategy defined for the source (OAuth, API key, local access, etc.).
+
+**Returns:** `bool` -- `True` on successful authentication, `False` on failure.
+
+### list_videos()
+
+```python
+@abstractmethod
+def list_videos(
+    self,
+    folder_id: Optional[str] = None,
+    folder_path: Optional[str] = None,
+    patterns: Optional[List[str]] = None,
+) -> List[SourceFile]
+```
+
+List available video files (or other content, depending on the source).
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `folder_id` | `Optional[str]` | `None` | Provider-specific folder/container identifier |
+| `folder_path` | `Optional[str]` | `None` | Path within the source (e.g., folder name) |
+| `patterns` | `Optional[List[str]]` | `None` | File name glob patterns to filter results |
+
+**Returns:** `List[SourceFile]` -- available files matching the criteria.
+
+### download()
+
+```python
+@abstractmethod
+def download(
+    self,
+    file: SourceFile,
+    destination: Path,
+) -> Path
+```
+
+Download a single file to a local path.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `file` | `SourceFile` | File descriptor from `list_videos()` |
+| `destination` | `Path` | Local destination path |
+
+**Returns:** `Path` -- the local path where the file was saved.
+
+### download_all()
+
+```python
+def download_all(
+    self,
+    files: List[SourceFile],
+    destination_dir: Path,
+) -> List[Path]
+```
+
+Download multiple files to a directory, preserving subfolder structure from `SourceFile.path`. This is a concrete method provided by the base class.
+
+**Parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `files` | `List[SourceFile]` | Files to download |
+| `destination_dir` | `Path` | Base directory for downloads (created if needed) |
+
+**Returns:** `List[Path]` -- local paths of successfully downloaded files. Failed downloads are logged and skipped.
+
+---
+
+## SourceFile
+
+```python
+from video_processor.sources import SourceFile
+```
+
+Pydantic model describing a file available in a cloud source.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `name` | `str` | *required* | File name |
+| `id` | `str` | *required* | Provider-specific file identifier |
+| `size_bytes` | `Optional[int]` | `None` | File size in bytes |
+| `mime_type` | `Optional[str]` | `None` | MIME type (e.g., `"video/mp4"`) |
+| `modified_at` | `Optional[str]` | `None` | Last modified timestamp |
+| `path` | `Optional[str]` | `None` | Path within the source folder (used for subfolder structure in `download_all`) |
+
+```json
+{
+  "name": "sprint-review-2026-03-01.mp4",
+  "id": "abc123def456",
+  "size_bytes": 524288000,
+  "mime_type": "video/mp4",
+  "modified_at": "2026-03-01T14:30:00Z",
+  "path": "recordings/march/sprint-review-2026-03-01.mp4"
+}
+```
+
+---
+
+## Lazy Loading Pattern
+
+All sources are lazy-loaded via `__getattr__` in the package `__init__.py`. This means importing `video_processor.sources` does not pull in any external dependencies (e.g., `google-auth`, `msal`, `notion-client`). The actual module is loaded only when you access the class.
+
+```python
+# This import is instant -- no dependencies loaded
+from video_processor.sources import ZoomSource
+
+# The zoom_source module (and its dependencies) are loaded here
+source = ZoomSource()
+```
+
+---
+
+## Available Sources
+
+### Cloud Recordings
+
+Sources for fetching recorded meetings from video conferencing platforms.
+
+| Source | Class | Auth Method | Description |
+|---|---|---|---|
+| Zoom | `ZoomSource` | OAuth / Server-to-Server | List and download Zoom cloud recordings |
+| Google Meet | `MeetRecordingSource` | OAuth (Google) | List and download Google Meet recordings from Drive |
+| Microsoft Teams | `TeamsRecordingSource` | OAuth (Microsoft) | List and download Teams meeting recordings |
+
+### Cloud Storage and Workspace
+
+Sources for accessing files stored in cloud platforms.
+
+| Source | Class | Auth Method | Description |
+|---|---|---|---|
+| Google Drive | `GoogleDriveSource` | OAuth (Google) | Files from Google Drive |
+| Google Workspace | `GWSSource` | OAuth (Google) | Google Docs, Sheets, Slides |
+| Microsoft 365 | `M365Source` | OAuth (Microsoft) | OneDrive, SharePoint files |
+| Notion | `NotionSource` | OAuth / API key | Notion pages and databases |
+| GitHub | `GitHubSource` | OAuth / API token | Repository files, issues, discussions |
+| Dropbox | `DropboxSource` | OAuth / access token | *(via auth config)* |
+
+### Notes Applications
+
+Sources for local and cloud-based note-taking apps.
+
+| Source | Class | Auth Method | Description |
+|---|---|---|---|
+| Apple Notes | `AppleNotesSource` | Local (macOS) | Notes from Apple Notes.app |
+| Obsidian | `ObsidianSource` | Local filesystem | Markdown files from Obsidian vaults |
+| Logseq | `LogseqSource` | Local filesystem | Pages from Logseq graphs |
+| OneNote | `OneNoteSource` | OAuth (Microsoft) | Microsoft OneNote notebooks |
+| Google Keep | `GoogleKeepSource` | OAuth (Google) | Google Keep notes |
+
+### Web and Content
+
+Sources for fetching content from the web.
+
+| Source | Class | Auth Method | Description |
+|---|---|---|---|
+| YouTube | `YouTubeSource` | API key / OAuth | YouTube video metadata and transcripts |
+| Web | `WebSource` | None | General web page content extraction |
+| RSS | `RSSSource` | None | RSS/Atom feed entries |
+| Podcast | `PodcastSource` | None | Podcast episodes from RSS feeds |
+| arXiv | `ArxivSource` | None | Academic papers from arXiv |
+| Hacker News | `HackerNewsSource` | None | Hacker News posts and comments |
+| Reddit | `RedditSource` | API credentials | Reddit posts and comments |
+| Twitter/X | `TwitterSource` | API credentials | Tweets and threads |
+
+---
+
+## Auth Integration
+
+Most sources use PlanOpticon's unified auth system (see [Auth API](auth.md)). The typical pattern within a source implementation:
+
+```python
+from video_processor.auth import get_auth_manager
+
+class MySource(BaseSource):
+    def __init__(self):
+        self._token = None
+
+    def authenticate(self) -> bool:
+        manager = get_auth_manager("my_service")
+        if manager:
+            token = manager.get_token()
+            if token:
+                self._token = token
+                return True
+        return False
+
+    def list_videos(self, **kwargs) -> list[SourceFile]:
+        if not self._token:
+            raise RuntimeError("Not authenticated. Call authenticate() first.")
+        # Use self._token to call the API
+        ...
+```
+
+---
+
+## Usage Examples
+
+### Listing and downloading Zoom recordings
+
+```python
+from pathlib import Path
+from video_processor.sources import ZoomSource
+
+source = ZoomSource()
+if source.authenticate():
+    recordings = source.list_videos()
+    for rec in recordings:
+        print(f"{rec.name} ({rec.size_bytes} bytes)")
+
+    # Download all to a local directory
+    paths = source.download_all(recordings, Path("./downloads"))
+```
+
+### Fetching from multiple sources
+
+```python
+from pathlib import Path
+from video_processor.sources import GoogleDriveSource, NotionSource
+
+# Google Drive
+gdrive = GoogleDriveSource()
+if gdrive.authenticate():
+    files = gdrive.list_videos(
+        folder_path="Meeting Recordings",
+        patterns=["*.mp4", "*.webm"],
+    )
+    gdrive.download_all(files, Path("./drive-downloads"))
+
+# Notion
+notion = NotionSource()
+if notion.authenticate():
+    pages = notion.list_videos()  # Lists Notion pages
+    for page in pages:
+        print(f"Page: {page.name}")
+```
+
+### YouTube content
+
+```python
+from video_processor.sources import YouTubeSource
+
+yt = YouTubeSource()
+if yt.authenticate():
+    videos = yt.list_videos(folder_path="https://youtube.com/playlist?list=...")
+    for v in videos:
+        print(f"{v.name} - {v.id}")
+```

--- a/docs/architecture/pipeline.md
+++ b/docs/architecture/pipeline.md
@@ -1,6 +1,12 @@
 # Processing Pipeline
 
+PlanOpticon has four main pipelines: **video analysis**, **document ingestion**, **source connector**, and **export**. Each pipeline can operate independently, and they connect through the shared knowledge graph.
+
+---
+
 ## Single video pipeline
+
+The core video analysis pipeline processes a single video file through eight sequential steps with checkpoint/resume support.
 
 ```mermaid
 sequenceDiagram
@@ -11,47 +17,319 @@ sequenceDiagram
     participant Provider
     participant DiagramAnalyzer
     participant KnowledgeGraph
+    participant Exporter
 
     CLI->>Pipeline: process_single_video()
+
+    Note over Pipeline: Step 1: Extract frames
     Pipeline->>FrameExtractor: extract_frames()
     Note over FrameExtractor: Change detection + periodic capture (every 30s)
+    FrameExtractor-->>Pipeline: frame_paths[]
+
+    Note over Pipeline: Step 2: Filter people frames
     Pipeline->>Pipeline: filter_people_frames()
     Note over Pipeline: OpenCV face detection removes webcam/people frames
+
+    Note over Pipeline: Step 3: Extract + transcribe audio
     Pipeline->>AudioExtractor: extract_audio()
     Pipeline->>Provider: transcribe_audio()
-    Pipeline->>DiagramAnalyzer: process_frames()
+    Note over Provider: Supports speaker hints via --speakers flag
 
-    loop Each frame
+    Note over Pipeline: Step 4: Analyze visuals
+    Pipeline->>DiagramAnalyzer: process_frames()
+    loop Each frame (up to 10 standard / 20 comprehensive)
         DiagramAnalyzer->>Provider: classify (vision)
         alt High confidence diagram
             DiagramAnalyzer->>Provider: full analysis
+            Note over Provider: Extract description, text, mermaid, chart data
         else Medium confidence
             DiagramAnalyzer-->>Pipeline: screengrab fallback
         end
     end
 
+    Note over Pipeline: Step 5: Build knowledge graph
+    Pipeline->>KnowledgeGraph: register_source()
     Pipeline->>KnowledgeGraph: process_transcript()
     Pipeline->>KnowledgeGraph: process_diagrams()
+    Note over KnowledgeGraph: Writes knowledge_graph.db (SQLite) + .json
+
+    Note over Pipeline: Step 6: Extract key points + action items
     Pipeline->>Provider: extract key points
     Pipeline->>Provider: extract action items
-    Pipeline->>Pipeline: generate reports
-    Pipeline->>Pipeline: export formats
+
+    Note over Pipeline: Step 7: Generate report
+    Pipeline->>Pipeline: generate markdown report
+    Note over Pipeline: Includes mermaid diagrams, tables, cross-references
+
+    Note over Pipeline: Step 8: Export formats
+    Pipeline->>Exporter: export_all_formats()
+    Note over Exporter: HTML report, PDF, SVG/PNG renderings, chart reproductions
+
     Pipeline-->>CLI: VideoManifest
 ```
 
+### Pipeline steps in detail
+
+| Step | Name | Checkpointable | Description |
+|------|------|----------------|-------------|
+| 1 | Extract frames | Yes | Change detection + periodic capture. Skipped if `frames/frame_*.jpg` exist on disk. |
+| 2 | Filter people frames | No | Inline with step 1. OpenCV face detection removes webcam frames. |
+| 3 | Extract + transcribe audio | Yes | Skipped if `transcript/transcript.json` exists. Speaker hints passed if `--speakers` provided. |
+| 4 | Analyze visuals | Yes | Skipped if `diagrams/` is populated. Evenly samples frames (not just first N). |
+| 5 | Build knowledge graph | Yes | Skipped if `results/knowledge_graph.db` exists. Registers source, processes transcript and diagrams. |
+| 6 | Extract key points + actions | Yes | Skipped if `results/key_points.json` and `results/action_items.json` exist. |
+| 7 | Generate report | Yes | Skipped if `results/analysis.md` exists. |
+| 8 | Export formats | No | Always runs. Renders mermaid to SVG/PNG, reproduces charts, generates HTML/PDF. |
+
+---
+
 ## Batch pipeline
 
-The batch command wraps the single-video pipeline:
+The batch pipeline wraps the single-video pipeline and adds cross-video knowledge graph merging.
 
-1. Scan input directory for matching video files
-2. For each video: `process_single_video()` with error handling
-3. Merge knowledge graphs across all completed videos
-4. Generate batch summary with aggregated stats
-5. Write batch manifest
+```mermaid
+flowchart TD
+    A[Scan input directory] --> B[Match video files by pattern]
+    B --> C{For each video}
+    C --> D[process_single_video]
+    D --> E{Success?}
+    E -->|Yes| F[Collect manifest + KG]
+    E -->|No| G[Log error, continue]
+    F --> H[Next video]
+    G --> H
+    H --> C
+    C -->|All done| I[Merge knowledge graphs]
+    I --> J[Fuzzy matching + conflict resolution]
+    J --> K[Generate batch summary]
+    K --> L[Write batch manifest]
+    L --> M[batch_manifest.json + batch_summary.md + merged KG]
+```
+
+### Knowledge graph merge strategy
+
+During batch merging, `KnowledgeGraph.merge()` applies:
+
+1. **Case-insensitive exact matching** for entity names
+2. **Fuzzy matching** via `SequenceMatcher` (threshold >= 0.85) for near-duplicates
+3. **Type conflict resolution** using a specificity ranking (e.g., `technology` > `concept`)
+4. **Description union** across all sources
+5. **Relationship deduplication** by (source, target, type) tuple
+
+---
+
+## Document ingestion pipeline
+
+The document ingestion pipeline processes files (Markdown, plaintext, PDF) into knowledge graphs without video analysis.
+
+```mermaid
+flowchart TD
+    A[Input: file or directory] --> B{File or directory?}
+    B -->|File| C[get_processor by extension]
+    B -->|Directory| D[Glob for supported extensions]
+    D --> E{Recursive?}
+    E -->|Yes| F[rglob all files]
+    E -->|No| G[glob top-level only]
+    F --> H[For each file]
+    G --> H
+    H --> C
+    C --> I[DocumentProcessor.process]
+    I --> J[DocumentChunk list]
+    J --> K[Register source in KG]
+    K --> L[Add chunks as content]
+    L --> M[KG extracts entities + relationships]
+    M --> N[knowledge_graph.db]
+```
+
+### Supported document types
+
+| Extension | Processor | Notes |
+|-----------|-----------|-------|
+| `.md` | `MarkdownProcessor` | Splits by headings into sections |
+| `.txt` | `PlaintextProcessor` | Splits into fixed-size chunks |
+| `.pdf` | `PdfProcessor` | Requires `pymupdf` or `pdfplumber`. Falls back gracefully between libraries. |
+
+### Adding documents to an existing graph
+
+The `--db-path` flag lets you ingest documents into an existing knowledge graph:
+
+```bash
+planopticon ingest spec.md --db-path existing.db
+planopticon ingest ./docs/ -o ./output --recursive
+```
+
+---
+
+## Source connector pipeline
+
+Source connectors fetch content from cloud services, note-taking apps, and web sources. Each source implements the `BaseSource` ABC with three methods: `authenticate()`, `list_videos()`, and `download()`.
+
+```mermaid
+flowchart TD
+    A[Source command] --> B[Authenticate with provider]
+    B --> C{Auth success?}
+    C -->|No| D[Error: check credentials]
+    C -->|Yes| E[List files in folder]
+    E --> F[Filter by pattern / type]
+    F --> G[Download to local path]
+    G --> H{Analyze or ingest?}
+    H -->|Video| I[process_single_video / batch]
+    H -->|Document| J[ingest_file / ingest_directory]
+    I --> K[Knowledge graph]
+    J --> K
+```
+
+### Available sources
+
+PlanOpticon includes connectors for:
+
+| Category | Sources |
+|----------|---------|
+| Cloud storage | Google Drive, S3, Dropbox |
+| Meeting recordings | Zoom, Google Meet, Microsoft Teams |
+| Productivity suites | Google Workspace (Docs/Sheets/Slides), Microsoft 365 (SharePoint/OneDrive/OneNote) |
+| Note-taking apps | Obsidian, Logseq, Apple Notes, Google Keep, Notion |
+| Web sources | YouTube, Web (URL), RSS, Podcasts |
+| Developer platforms | GitHub, arXiv |
+| Social media | Reddit, Twitter/X, Hacker News |
+
+Each source authenticates via environment variables (API keys, OAuth tokens) specific to the provider.
+
+---
+
+## Planning agent pipeline
+
+The planning agent consumes a knowledge graph and uses registered skills to generate planning artifacts.
+
+```mermaid
+flowchart TD
+    A[Knowledge graph] --> B[Load into AgentContext]
+    B --> C[GraphQueryEngine]
+    C --> D[Taxonomy classification]
+    D --> E[Agent orchestrator]
+    E --> F{Select skill}
+    F --> G[ProjectPlan skill]
+    F --> H[PRD skill]
+    F --> I[Roadmap skill]
+    F --> J[TaskBreakdown skill]
+    F --> K[DocGenerator skill]
+    F --> L[WikiGenerator skill]
+    F --> M[NotesExport skill]
+    F --> N[ArtifactExport skill]
+    F --> O[GitHubIntegration skill]
+    F --> P[RequirementsChat skill]
+    G --> Q[Artifact output]
+    H --> Q
+    I --> Q
+    J --> Q
+    K --> Q
+    L --> Q
+    M --> Q
+    N --> Q
+    O --> Q
+    P --> Q
+    Q --> R[Write to disk / push to service]
+```
+
+### Skill execution flow
+
+1. The `AgentContext` is populated with the knowledge graph, query engine, provider manager, and any planning entities from taxonomy classification
+2. Each `Skill` checks `can_execute()` against the context (requires at minimum a knowledge graph and provider manager)
+3. The skill's `execute()` method generates an `Artifact` with a name, content, type, and format
+4. Artifacts are collected and can be exported to disk or pushed to external services (GitHub issues, wiki pages, etc.)
+
+---
+
+## Export pipeline
+
+The export pipeline converts knowledge graphs and analysis artifacts into various output formats.
+
+```mermaid
+flowchart TD
+    A[knowledge_graph.db] --> B{Export command}
+    B --> C[export markdown]
+    B --> D[export obsidian]
+    B --> E[export notion]
+    B --> F[export exchange]
+    B --> G[wiki generate]
+    B --> H[kg convert]
+    C --> I[7 document types + entity briefs + CSV]
+    D --> J[Obsidian vault with frontmatter + wiki-links]
+    E --> K[Notion-compatible markdown + CSV database]
+    F --> L[PlanOpticonExchange JSON payload]
+    G --> M[GitHub wiki pages + sidebar + home]
+    H --> N[Convert between .db / .json / .graphml / .csv]
+```
+
+All export commands accept a `knowledge_graph.db` (or `.json`) path as input. No API key is required for template-based exports (markdown, obsidian, notion, wiki, exchange, convert). Only the planning agent skills that generate new content require a provider.
+
+---
+
+## How pipelines connect
+
+```mermaid
+flowchart LR
+    V[Video files] --> VP[Video Pipeline]
+    D[Documents] --> DI[Document Ingestion]
+    S[Cloud Sources] --> SC[Source Connectors]
+    SC --> V
+    SC --> D
+    VP --> KG[(knowledge_graph.db)]
+    DI --> KG
+    KG --> QE[Query Engine]
+    KG --> EP[Export Pipeline]
+    KG --> PA[Planning Agent]
+    PA --> AR[Artifacts]
+    AR --> EP
+```
+
+All pipelines converge on the knowledge graph as the central data store. The knowledge graph is the shared interface between ingestion (video or document), querying, exporting, and planning.
+
+---
 
 ## Error handling
 
-- Individual video failures don't stop the batch
-- Failed videos are logged with error details in the manifest
-- Diagram analysis failures fall back to screengrabs
-- LLM extraction failures return empty results gracefully
+Error handling follows consistent patterns across all pipelines:
+
+| Scenario | Behavior |
+|----------|----------|
+| Video fails in batch | Batch continues. Failed video recorded in manifest with error details. |
+| Diagram analysis fails | Falls back to screengrab (captioned screenshot). |
+| LLM extraction fails | Returns empty results gracefully. Key points and action items will be empty arrays. |
+| Document processor not found | Raises `ValueError` with list of supported extensions. |
+| Source authentication fails | Returns `False` from `authenticate()`. CLI prints error message. |
+| Checkpoint file found | Step is skipped entirely and results are loaded from disk. |
+| Progress callback fails | Warning logged. Pipeline continues without progress updates. |
+
+---
+
+## Progress callback system
+
+The pipeline supports a `ProgressCallback` protocol for real-time progress tracking. This is used by the CLI's progress bars and can be implemented by external integrations (web UIs, CI systems, etc.).
+
+```python
+from video_processor.models import ProgressCallback
+
+class MyCallback:
+    def on_step_start(self, step: str, index: int, total: int) -> None:
+        print(f"Starting step {index}/{total}: {step}")
+
+    def on_step_complete(self, step: str, index: int, total: int) -> None:
+        print(f"Completed step {index}/{total}: {step}")
+
+    def on_progress(self, step: str, percent: float, message: str = "") -> None:
+        print(f"  {step}: {percent:.0%} {message}")
+```
+
+Pass the callback to `process_single_video()`:
+
+```python
+from video_processor.pipeline import process_single_video
+
+manifest = process_single_video(
+    input_path="recording.mp4",
+    output_dir="./output",
+    progress_callback=MyCallback(),
+)
+```
+
+The callback methods are called within a try/except wrapper, so a failing callback never interrupts the pipeline. If a callback method raises an exception, a warning is logged and processing continues.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,6 +12,8 @@ pip install -e ".[dev]"
 
 ## Running tests
 
+PlanOpticon has 822+ tests covering providers, pipeline stages, document processors, knowledge graph operations, exporters, skills, and CLI commands.
+
 ```bash
 # Run all tests
 pytest tests/ -v
@@ -21,43 +23,472 @@ pytest tests/ --cov=video_processor --cov-report=html
 
 # Run a specific test file
 pytest tests/test_models.py -v
+
+# Run tests matching a keyword
+pytest tests/ -k "test_knowledge_graph" -v
+
+# Run only fast tests (skip slow integration tests)
+pytest tests/ -m "not slow" -v
+```
+
+### Test conventions
+
+- All tests live in the `tests/` directory, mirroring the `video_processor/` package structure
+- Test files are named `test_<module>.py`
+- Use `pytest` as the test runner -- do not use `unittest.TestCase` unless necessary for specific setup/teardown patterns
+- Mock external API calls. Never make real API calls in tests. Use `unittest.mock.patch` or `pytest-mock` fixtures to mock provider responses.
+- Use `tmp_path` (pytest fixture) for any tests that write files to disk
+- Fixtures shared across test files go in `conftest.py`
+- For testing CLI commands, use `click.testing.CliRunner`
+- For testing provider implementations, mock at the HTTP client level (e.g., patch `requests.post` or the provider's SDK client)
+
+### Mocking patterns
+
+```python
+# Mocking a provider's chat method
+from unittest.mock import MagicMock, patch
+
+def test_key_point_extraction():
+    pm = MagicMock()
+    pm.chat.return_value = '["Point 1", "Point 2"]'
+    result = extract_key_points(pm, "transcript text")
+    assert len(result) == 2
+
+# Mocking an external API at the HTTP level
+@patch("requests.post")
+def test_provider_chat(mock_post):
+    mock_post.return_value.json.return_value = {
+        "choices": [{"message": {"content": "response"}}]
+    }
+    provider = OpenAIProvider(api_key="test")
+    result = provider.chat([{"role": "user", "content": "hello"}])
+    assert result == "response"
 ```
 
 ## Code style
 
 We use:
 
-- **Ruff** for linting
-- **Black** for formatting (100 char line length)
-- **isort** for import sorting
+- **Ruff** for both linting and formatting (100 char line length)
 - **mypy** for type checking
 
+Ruff handles all linting (error, warning, pyflakes, and import sorting rules) and formatting in a single tool. There is no need to run Black or isort separately.
+
 ```bash
+# Lint
 ruff check video_processor/
-black video_processor/
-isort video_processor/
+
+# Format
+ruff format video_processor/
+
+# Auto-fix lint issues
+ruff check video_processor/ --fix
+
+# Type check
 mypy video_processor/ --ignore-missing-imports
 ```
 
+### Ruff configuration
+
+The project's `pyproject.toml` configures ruff as follows:
+
+```toml
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+```
+
+The `I` rule set covers import sorting (equivalent to isort), so imports are automatically organized by ruff.
+
 ## Project structure
 
-See [Architecture Overview](architecture/overview.md) for the module structure.
+```
+PlanOpticon/
+├── video_processor/
+│   ├── cli/                   # Click CLI commands
+│   │   └── commands.py
+│   ├── providers/             # LLM/API provider implementations
+│   │   ├── base.py            # BaseProvider, ProviderRegistry
+│   │   ├── manager.py         # ProviderManager
+│   │   ├── discovery.py       # Auto-discovery of available providers
+│   │   ├── openai_provider.py
+│   │   ├── anthropic_provider.py
+│   │   ├── gemini_provider.py
+│   │   └── ...                # 15+ provider implementations
+│   ├── sources/               # Cloud and web source connectors
+│   │   ├── base.py            # BaseSource, SourceFile
+│   │   ├── google_drive.py
+│   │   ├── zoom_source.py
+│   │   └── ...                # 20+ source implementations
+│   ├── processors/            # Document processors
+│   │   ├── base.py            # DocumentProcessor, registry
+│   │   ├── ingest.py          # File/directory ingestion
+│   │   ├── markdown_processor.py
+│   │   ├── pdf_processor.py
+│   │   └── __init__.py        # Auto-registration of built-in processors
+│   ├── integrators/           # Knowledge graph and analysis
+│   │   ├── knowledge_graph.py # KnowledgeGraph class
+│   │   ├── graph_store.py     # SQLite graph storage
+│   │   ├── graph_query.py     # GraphQueryEngine
+│   │   ├── graph_discovery.py # Auto-find knowledge_graph.db
+│   │   └── taxonomy.py        # Planning taxonomy classifier
+│   ├── agent/                 # Planning agent
+│   │   ├── orchestrator.py    # Agent orchestration
+│   │   └── skills/            # Skill implementations
+│   │       ├── base.py        # Skill ABC, registry, Artifact
+│   │       ├── project_plan.py
+│   │       ├── prd.py
+│   │       ├── roadmap.py
+│   │       ├── task_breakdown.py
+│   │       ├── doc_generator.py
+│   │       ├── wiki_generator.py
+│   │       ├── notes_export.py
+│   │       ├── artifact_export.py
+│   │       ├── github_integration.py
+│   │       ├── requirements_chat.py
+│   │       ├── cli_adapter.py
+│   │       └── __init__.py    # Auto-registration of skills
+│   ├── exporters/             # Output format exporters
+│   │   ├── __init__.py
+│   │   └── markdown.py        # Template-based markdown generation
+│   ├── utils/                 # Shared utilities
+│   │   ├── export.py          # Multi-format export orchestration
+│   │   ├── rendering.py       # Mermaid/chart rendering
+│   │   ├── prompt_templates.py
+│   │   ├── callbacks.py       # Progress callback helpers
+│   │   └── ...
+│   ├── exchange.py            # PlanOpticonExchange format
+│   ├── pipeline.py            # Main video processing pipeline
+│   ├── models.py              # Pydantic data models
+│   └── output_structure.py    # Output directory helpers
+├── tests/                     # 822+ tests
+├── knowledge-base/            # Local-first graph tools
+│   ├── viewer.html            # Self-contained D3.js graph viewer
+│   └── query.py               # Python query script (NetworkX)
+├── docs/                      # MkDocs documentation
+└── pyproject.toml             # Project configuration
+```
+
+See [Architecture Overview](architecture/overview.md) for a more detailed breakdown of module responsibilities.
 
 ## Adding a new provider
 
+Providers self-register via `ProviderRegistry.register()` at module level. When the provider module is imported, it registers itself automatically.
+
 1. Create `video_processor/providers/your_provider.py`
 2. Extend `BaseProvider` from `video_processor/providers/base.py`
-3. Implement `chat()`, `analyze_image()`, `transcribe_audio()`, `list_models()`
-4. Register in `video_processor/providers/discovery.py`
-5. Add tests in `tests/test_providers.py`
+3. Implement the four required methods: `chat()`, `analyze_image()`, `transcribe_audio()`, `list_models()`
+4. Call `ProviderRegistry.register()` at module level
+5. Add the import to `video_processor/providers/manager.py` in the lazy-import block
+6. Add tests in `tests/test_providers.py`
+
+### Example provider skeleton
+
+```python
+"""Your provider implementation."""
+
+from video_processor.providers.base import BaseProvider, ModelInfo, ProviderRegistry
+
+
+class YourProvider(BaseProvider):
+    provider_name = "yourprovider"
+
+    def __init__(self, api_key: str | None = None):
+        import os
+        self.api_key = api_key or os.environ.get("YOUR_API_KEY", "")
+
+    def chat(self, messages, max_tokens=4096, temperature=0.7, model=None):
+        # Implement chat completion
+        ...
+
+    def analyze_image(self, image_bytes, prompt, max_tokens=4096, model=None):
+        # Implement image analysis
+        ...
+
+    def transcribe_audio(self, audio_path, language=None, model=None):
+        # Implement audio transcription (or raise NotImplementedError)
+        ...
+
+    def list_models(self):
+        return [ModelInfo(id="your-model", provider="yourprovider", capabilities=["chat"])]
+
+
+# Self-registration at import time
+ProviderRegistry.register(
+    "yourprovider",
+    YourProvider,
+    env_var="YOUR_API_KEY",
+    model_prefixes=["your-"],
+    default_models={"chat": "your-model"},
+)
+```
+
+### OpenAI-compatible providers
+
+For providers that use the OpenAI API format, extend `OpenAICompatibleProvider` instead of `BaseProvider`. This provides default implementations of `chat()`, `analyze_image()`, and `list_models()` -- you only need to configure the base URL and model mappings.
+
+```python
+from video_processor.providers.base import OpenAICompatibleProvider, ProviderRegistry
+
+class YourProvider(OpenAICompatibleProvider):
+    provider_name = "yourprovider"
+    base_url = "https://api.yourprovider.com/v1"
+    env_var = "YOUR_API_KEY"
+
+ProviderRegistry.register("yourprovider", YourProvider, env_var="YOUR_API_KEY")
+```
 
 ## Adding a new cloud source
 
+Source connectors implement the `BaseSource` ABC from `video_processor/sources/base.py`. Authentication is handled per-source, typically via environment variables.
+
 1. Create `video_processor/sources/your_source.py`
-2. Implement auth flow and file listing/downloading
-3. Add CLI integration in `video_processor/cli/commands.py`
-4. Add tests and docs
+2. Extend `BaseSource`
+3. Implement `authenticate()`, `list_videos()`, and `download()`
+4. Add the class to the lazy-import map in `video_processor/sources/__init__.py`
+5. Add CLI commands in `video_processor/cli/commands.py` if needed
+6. Add tests and documentation
+
+### Example source skeleton
+
+```python
+"""Your source integration."""
+
+import os
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+from video_processor.sources.base import BaseSource, SourceFile
+
+logger = logging.getLogger(__name__)
+
+
+class YourSource(BaseSource):
+    def __init__(self, api_key: Optional[str] = None):
+        self.api_key = api_key or os.environ.get("YOUR_SOURCE_KEY", "")
+
+    def authenticate(self) -> bool:
+        """Validate credentials. Return True on success."""
+        if not self.api_key:
+            logger.error("API key not set. Set YOUR_SOURCE_KEY env var.")
+            return False
+        # Make a test API call to verify credentials
+        ...
+        return True
+
+    def list_videos(
+        self,
+        folder_id: Optional[str] = None,
+        folder_path: Optional[str] = None,
+        patterns: Optional[List[str]] = None,
+    ) -> List[SourceFile]:
+        """List available video files."""
+        ...
+
+    def download(self, file: SourceFile, destination: Path) -> Path:
+        """Download a single file. Return the local path."""
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        # Download file content to destination
+        ...
+        return destination
+```
+
+### Registering in `__init__.py`
+
+Add your source to the `__all__` list and the `_lazy_map` dictionary in `video_processor/sources/__init__.py`:
+
+```python
+__all__ = [
+    ...
+    "YourSource",
+]
+
+_lazy_map = {
+    ...
+    "YourSource": "video_processor.sources.your_source",
+}
+```
+
+## Adding a new skill
+
+Agent skills extend the `Skill` ABC from `video_processor/agent/skills/base.py` and self-register via `register_skill()`.
+
+1. Create `video_processor/agent/skills/your_skill.py`
+2. Extend `Skill` and set `name` and `description` class attributes
+3. Implement `execute()` to return an `Artifact`
+4. Optionally override `can_execute()` for custom precondition checks
+5. Call `register_skill()` at module level
+6. Add the import to `video_processor/agent/skills/__init__.py`
+7. Add tests
+
+### Example skill skeleton
+
+```python
+"""Your custom skill."""
+
+from video_processor.agent.skills.base import AgentContext, Artifact, Skill, register_skill
+
+
+class YourSkill(Skill):
+    name = "your_skill"
+    description = "Generates a custom artifact from the knowledge graph."
+
+    def execute(self, context: AgentContext, **kwargs) -> Artifact:
+        """Generate the artifact."""
+        kg_data = context.knowledge_graph.to_dict()
+        # Build content from knowledge graph data
+        content = f"# Your Artifact\n\n{len(kg_data.get('entities', []))} entities found."
+        return Artifact(
+            name="your_artifact",
+            content=content,
+            artifact_type="document",
+            format="markdown",
+        )
+
+    def can_execute(self, context: AgentContext) -> bool:
+        """Check prerequisites (default requires KG + provider)."""
+        return context.knowledge_graph is not None
+
+
+# Self-registration at import time
+register_skill(YourSkill())
+```
+
+### Registering in `__init__.py`
+
+Add the import to `video_processor/agent/skills/__init__.py` so the skill is loaded (and self-registered) when the skills package is imported:
+
+```python
+from video_processor.agent.skills import (
+    ...
+    your_skill,  # noqa: F401
+)
+```
+
+## Adding a new document processor
+
+Document processors extend the `DocumentProcessor` ABC from `video_processor/processors/base.py` and are registered via `register_processor()`.
+
+1. Create `video_processor/processors/your_processor.py`
+2. Extend `DocumentProcessor`
+3. Set `supported_extensions` class attribute
+4. Implement `process()` (returns `List[DocumentChunk]`) and `can_process()`
+5. Call `register_processor()` at module level
+6. Add the import to `video_processor/processors/__init__.py`
+7. Add tests
+
+### Example processor skeleton
+
+```python
+"""Your document processor."""
+
+from pathlib import Path
+from typing import List
+
+from video_processor.processors.base import (
+    DocumentChunk,
+    DocumentProcessor,
+    register_processor,
+)
+
+
+class YourProcessor(DocumentProcessor):
+    supported_extensions = [".xyz", ".abc"]
+
+    def can_process(self, path: Path) -> bool:
+        return path.suffix.lower() in self.supported_extensions
+
+    def process(self, path: Path) -> List[DocumentChunk]:
+        text = path.read_text()
+        # Split into chunks as appropriate for your format
+        return [
+            DocumentChunk(
+                text=text,
+                source_file=str(path),
+                chunk_index=0,
+                metadata={"format": "xyz"},
+            )
+        ]
+
+
+# Self-registration at import time
+register_processor([".xyz", ".abc"], YourProcessor)
+```
+
+### Registering in `__init__.py`
+
+Add the import to `video_processor/processors/__init__.py`:
+
+```python
+from video_processor.processors import (
+    markdown_processor,  # noqa: F401, E402
+    pdf_processor,       # noqa: F401, E402
+    your_processor,      # noqa: F401, E402
+)
+```
+
+## Adding a new exporter
+
+Exporters live in `video_processor/exporters/` and are typically called from CLI commands. There is no strict ABC for exporters -- they are plain functions that accept knowledge graph data and an output directory.
+
+1. Create `video_processor/exporters/your_exporter.py`
+2. Implement one or more export functions that accept KG data (as a dict) and an output path
+3. Add CLI integration in `video_processor/cli/commands.py` under the `export` group
+4. Add tests
+
+### Example exporter skeleton
+
+```python
+"""Your exporter."""
+
+import json
+from pathlib import Path
+from typing import List
+
+
+def export_your_format(kg_data: dict, output_dir: Path) -> List[Path]:
+    """Export knowledge graph data in your format.
+
+    Args:
+        kg_data: Knowledge graph as a dict (from KnowledgeGraph.to_dict()).
+        output_dir: Directory to write output files.
+
+    Returns:
+        List of created file paths.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    created = []
+
+    output_file = output_dir / "export.xyz"
+    output_file.write_text(json.dumps(kg_data, indent=2))
+    created.append(output_file)
+
+    return created
+```
+
+### Adding the CLI command
+
+Add a subcommand under the `export` group in `video_processor/cli/commands.py`:
+
+```python
+@export.command("your-format")
+@click.argument("db_path", type=click.Path(exists=True))
+@click.option("-o", "--output", type=click.Path(), default=None)
+def export_your_format_cmd(db_path, output):
+    """Export knowledge graph in your format."""
+    from video_processor.exporters.your_exporter import export_your_format
+    from video_processor.integrators.knowledge_graph import KnowledgeGraph
+
+    kg = KnowledgeGraph(db_path=Path(db_path))
+    out_dir = Path(output) if output else Path.cwd() / "your-export"
+    created = export_your_format(kg.to_dict(), out_dir)
+    click.echo(f"Exported {len(created)} files to {out_dir}/")
+```
 
 ## License
 
-MIT License — Copyright (c) 2025 CONFLICT LLC. All rights reserved.
+MIT License -- Copyright (c) 2026 CONFLICT LLC. All rights reserved.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,301 @@
+# FAQ & Troubleshooting
+
+## Frequently Asked Questions
+
+### Do I need an API key?
+
+You need at least one of:
+
+- **Cloud API key**: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `GEMINI_API_KEY`
+- **Local Ollama**: Install [Ollama](https://ollama.com), pull a model, and run `ollama serve`
+
+Some features work without any AI provider:
+
+- `planopticon query stats` — direct knowledge graph queries
+- `planopticon query "entities --type person"` — structured entity lookups
+- `planopticon export markdown` — document generation from existing KG (7 document types, no LLM)
+- `planopticon kg inspect` — knowledge graph statistics
+- `planopticon kg convert` — format conversion
+
+### How much does it cost?
+
+PlanOpticon defaults to cheap models to minimize costs:
+
+| Task | Default model | Approximate cost |
+|------|--------------|-----------------|
+| Chat/analysis | Claude Haiku / GPT-4o-mini | ~$0.25-0.50 per 1M tokens |
+| Vision (diagrams) | Gemini Flash / GPT-4o-mini | ~$0.10-0.50 per 1M tokens |
+| Transcription | Local Whisper (free) / Whisper-1 | $0.006/minute |
+
+A typical 1-hour meeting costs roughly $0.05-0.15 to process with default models. Use `--provider ollama` for zero cost.
+
+### Can I run fully offline?
+
+Yes. Install Ollama and local Whisper:
+
+```bash
+ollama pull llama3.2
+ollama pull llava
+pip install planopticon[gpu]
+planopticon analyze -i video.mp4 -o ./output --provider ollama
+```
+
+No data leaves your machine.
+
+### What video formats are supported?
+
+Any format FFmpeg can decode:
+
+- MP4, MKV, AVI, MOV, WebM, FLV, WMV, M4V
+- Container formats with common codecs (H.264, H.265, VP8, VP9, AV1)
+
+### What document formats can I ingest?
+
+- **PDF** — text extraction via pymupdf or pdfplumber
+- **Markdown** — parsed with heading-based chunking
+- **Plain text** — paragraph-based chunking with overlap
+
+### How does the knowledge graph work?
+
+PlanOpticon extracts entities (people, technologies, concepts, decisions) and relationships from your content. These are stored in a SQLite database (`knowledge_graph.db`) with zero external dependencies. Entities are automatically classified using a planning taxonomy (goals, requirements, risks, tasks, milestones).
+
+When you process multiple sources, entities are merged using fuzzy name matching (0.85 threshold) with type conflict resolution and provenance tracking.
+
+### Can I use PlanOpticon with my existing Obsidian vault?
+
+Yes, in both directions:
+
+```bash
+# Ingest an Obsidian vault into PlanOpticon
+planopticon ingest ~/Obsidian/MyVault --output ./kb --recursive
+
+# Export PlanOpticon knowledge to an Obsidian vault
+planopticon export obsidian --input ./kb --output ~/Obsidian/PlanOpticon
+```
+
+The Obsidian export produces proper YAML frontmatter, wiki-links (`[[Entity Name]]`), and tag pages.
+
+### How do I add my own AI provider?
+
+Create a provider module, extend `BaseProvider`, and register it:
+
+```python
+from video_processor.providers.base import BaseProvider, ProviderRegistry
+
+class MyProvider(BaseProvider):
+    provider_name = "myprovider"
+
+    def chat(self, messages, max_tokens=4096, temperature=0.7, model=None):
+        # Your implementation
+        ...
+
+ProviderRegistry.register(
+    name="myprovider",
+    provider_class=MyProvider,
+    env_var="MY_PROVIDER_API_KEY",
+    model_prefixes=["my-"],
+    default_models={"chat": "my-model-v1", "vision": "", "audio": ""},
+)
+```
+
+See the [Contributing guide](contributing.md) for details.
+
+---
+
+## Troubleshooting
+
+### Authentication errors
+
+#### "No auth method available for zoom"
+
+You need to set credentials before authenticating:
+
+```bash
+export ZOOM_CLIENT_ID="your-client-id"
+export ZOOM_CLIENT_SECRET="your-client-secret"
+planopticon auth zoom
+```
+
+The error message tells you which environment variables to set. Each service requires different credentials — see the [Authentication guide](guide/authentication.md).
+
+#### "Token expired" or "401 Unauthorized"
+
+Your saved token has expired and auto-refresh failed. Re-authenticate:
+
+```bash
+planopticon auth google   # or whatever service
+```
+
+To clear a stale token:
+
+```bash
+planopticon auth google --logout
+planopticon auth google
+```
+
+Tokens are stored in `~/.planopticon/{service}_token.json`.
+
+#### OAuth redirect errors
+
+If the browser-based OAuth flow fails, check:
+
+1. Your client ID and secret are correct
+2. The redirect URI in your OAuth app matches PlanOpticon's default (`urn:ietf:wg:oauth:2.0:oob`)
+3. The OAuth app has the required scopes enabled
+
+### Provider errors
+
+#### "ANTHROPIC_API_KEY not set"
+
+Set at least one provider's API key:
+
+```bash
+export OPENAI_API_KEY="sk-..."
+# or
+export ANTHROPIC_API_KEY="sk-ant-..."
+# or
+export GEMINI_API_KEY="AI..."
+```
+
+Or use a `.env` file in your project directory.
+
+#### "Unexpected role system" (Anthropic)
+
+This was a bug in older versions where system messages were passed in the messages array instead of as a top-level parameter. Update to v0.4.0 or later.
+
+#### "Model not found" or "Invalid model"
+
+Check available models:
+
+```bash
+planopticon list-models
+```
+
+Common model name issues:
+- Anthropic: use `claude-haiku-4-5-20251001`, not `claude-haiku`
+- OpenAI: use `gpt-4o-mini`, not `gpt4o-mini`
+
+#### Rate limiting / 429 errors
+
+PlanOpticon doesn't currently implement automatic retry. If you hit rate limits:
+
+1. Use a different provider: `--provider gemini`
+2. Use cheaper/faster models: `--chat-model gpt-4o-mini`
+3. Reduce processing depth: `--depth basic`
+4. Use Ollama for zero rate limits: `--provider ollama`
+
+### Processing errors
+
+#### "FFmpeg not found"
+
+Install FFmpeg:
+
+```bash
+# macOS
+brew install ffmpeg
+
+# Ubuntu/Debian
+sudo apt-get install ffmpeg libsndfile1
+
+# Windows
+# Download from https://ffmpeg.org/download.html and add to PATH
+```
+
+#### "Audio extraction failed: no audio track found"
+
+The video file has no audio track. PlanOpticon will skip transcription and continue with frame analysis only.
+
+#### "Frame extraction memory error"
+
+For very long videos, frame extraction can use significant memory. Use the `--max-memory-mb` safety valve:
+
+```bash
+planopticon analyze -i long-video.mp4 -o ./output --max-memory-mb 2048
+```
+
+Or reduce the sampling rate:
+
+```bash
+planopticon analyze -i long-video.mp4 -o ./output --sampling-rate 0.25
+```
+
+#### Batch processing — one video fails
+
+Individual video failures don't stop the batch. Failed videos are logged in the batch manifest with error details. Check `batch_manifest.json` for the specific error.
+
+### Knowledge graph issues
+
+#### "No knowledge graph loaded" in companion
+
+The companion auto-discovers knowledge graphs by looking for `knowledge_graph.db` or `knowledge_graph.json` in the current directory and parent directories. Either:
+
+1. `cd` to the directory containing your knowledge graph
+2. Specify the path explicitly: `planopticon companion --kb ./path/to/kb`
+
+#### Empty or sparse knowledge graph
+
+Common causes:
+
+1. **Too few entities extracted**: Try `--depth comprehensive` for deeper analysis
+2. **Short or low-quality transcript**: Check `transcript/transcript.txt` — poor audio produces poor transcription
+3. **Wrong provider**: Some models extract entities better than others. Try `--provider openai --chat-model gpt-4o` for higher quality
+
+#### Duplicate entities after merge
+
+The fuzzy matching threshold is 0.85 (SequenceMatcher ratio). If you're getting duplicates, the names are too different for automatic matching. You can manually inspect and merge:
+
+```bash
+planopticon kg inspect ./knowledge_graph.db
+planopticon query "entities --name python"
+```
+
+### Companion / REPL issues
+
+#### Chat gives generic advice instead of project-specific answers
+
+The companion needs both a knowledge graph and an LLM provider. Check:
+
+```
+planopticon> /status
+```
+
+If it says "KG: not loaded" or "Provider: none", fix those first:
+
+```
+planopticon> /provider openai
+planopticon> /model gpt-4o-mini
+```
+
+#### Companion is slow
+
+The companion makes LLM API calls for chat messages. To speed things up:
+
+1. Use a faster model: `/model gpt-4o-mini` or `/model claude-haiku-4-5-20251001`
+2. Use direct queries instead of chat: `/entities`, `/search`, `/neighbors` don't need an LLM
+3. Use Ollama locally for lower latency: `/provider ollama`
+
+### Export issues
+
+#### Obsidian export has broken links
+
+Make sure your Obsidian vault has wiki-links enabled (Settings > Files & Links > Use [[Wikilinks]]). PlanOpticon exports use wiki-link syntax by default.
+
+#### PDF export fails
+
+PDF export requires the `pdf` extra:
+
+```bash
+pip install planopticon[pdf]
+```
+
+This installs WeasyPrint, which has system dependencies. On macOS:
+
+```bash
+brew install pango
+```
+
+On Ubuntu:
+
+```bash
+sudo apt-get install libpango1.0-dev
+```

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,33 +1,138 @@
 # Configuration
 
-## Environment variables
+## Example `.env` file
+
+Create a `.env` file in your project directory. PlanOpticon loads it automatically.
+
+```bash
+# =============================================================================
+# PlanOpticon Configuration
+# =============================================================================
+# Copy this file to .env and fill in the values you need.
+# You only need ONE AI provider — PlanOpticon auto-detects which are available.
+
+# --- AI Providers (set at least one) ----------------------------------------
+
+# OpenAI — get your key at https://platform.openai.com/api-keys
+OPENAI_API_KEY=sk-...
+
+# Anthropic — get your key at https://console.anthropic.com/settings/keys
+ANTHROPIC_API_KEY=sk-ant-...
+
+# Google Gemini — get your key at https://aistudio.google.com/apikey
+GEMINI_API_KEY=AI...
+
+# Azure OpenAI — from your Azure portal deployment
+# AZURE_OPENAI_API_KEY=...
+# AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
+
+# Together AI — https://api.together.xyz/settings/api-keys
+# TOGETHER_API_KEY=...
+
+# Fireworks AI — https://fireworks.ai/account/api-keys
+# FIREWORKS_API_KEY=...
+
+# Cerebras — https://cloud.cerebras.ai/
+# CEREBRAS_API_KEY=...
+
+# xAI (Grok) — https://console.x.ai/
+# XAI_API_KEY=...
+
+# Ollama (local, no key needed) — just run: ollama serve
+# OLLAMA_HOST=http://localhost:11434
+
+# --- Google (Drive, Docs, Sheets, Meet, YouTube) ----------------------------
+# Option A: OAuth (interactive, recommended for personal use)
+# Create credentials at https://console.cloud.google.com/apis/credentials
+# 1. Create an OAuth 2.0 Client ID (Desktop application)
+# 2. Enable these APIs: Google Drive API, Google Docs API
+GOOGLE_CLIENT_ID=123456789-abc.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=GOCSPX-...
+
+# Option B: Service Account (automated/server-side)
+# GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+
+# --- Zoom (recordings) ------------------------------------------------------
+# Create an OAuth app at https://marketplace.zoom.us/develop/create
+# App type: "General App" with OAuth
+# Scopes: cloud_recording:read:list_user_recordings, cloud_recording:read:recording
+ZOOM_CLIENT_ID=...
+ZOOM_CLIENT_SECRET=...
+# For Server-to-Server (no browser needed):
+# ZOOM_ACCOUNT_ID=...
+
+# --- Microsoft 365 (OneDrive, SharePoint, Teams) ----------------------------
+# Register an app at https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps
+# API permissions: OnlineMeetings.Read, Files.Read (delegated)
+MICROSOFT_CLIENT_ID=...
+MICROSOFT_CLIENT_SECRET=...
+
+# --- Notion ------------------------------------------------------------------
+# Option A: OAuth (create integration at https://www.notion.so/my-integrations)
+# NOTION_CLIENT_ID=...
+# NOTION_CLIENT_SECRET=...
+
+# Option B: API key (simpler, from the same integrations page)
+NOTION_API_KEY=secret_...
+
+# --- GitHub ------------------------------------------------------------------
+# Option A: Personal Access Token (simplest)
+# Create at https://github.com/settings/tokens — needs 'repo' scope
+GITHUB_TOKEN=ghp_...
+
+# Option B: OAuth App (for CI/automation)
+# GITHUB_CLIENT_ID=...
+# GITHUB_CLIENT_SECRET=...
+
+# --- Dropbox -----------------------------------------------------------------
+# Create an app at https://www.dropbox.com/developers/apps
+# DROPBOX_APP_KEY=...
+# DROPBOX_APP_SECRET=...
+# Or use a long-lived access token:
+# DROPBOX_ACCESS_TOKEN=...
+
+# --- General -----------------------------------------------------------------
+# CACHE_DIR=~/.cache/planopticon
+```
+
+## Environment variables reference
 
 ### AI providers
 
-| Variable | Description |
-|----------|-------------|
-| `OPENAI_API_KEY` | OpenAI API key |
-| `ANTHROPIC_API_KEY` | Anthropic API key |
-| `GEMINI_API_KEY` | Google Gemini API key |
-| `AZURE_OPENAI_API_KEY` | Azure OpenAI API key |
-| `AZURE_OPENAI_ENDPOINT` | Azure OpenAI endpoint URL |
-| `TOGETHER_API_KEY` | Together AI API key |
-| `FIREWORKS_API_KEY` | Fireworks AI API key |
-| `CEREBRAS_API_KEY` | Cerebras API key |
-| `XAI_API_KEY` | xAI (Grok) API key |
-| `OLLAMA_HOST` | Ollama server URL (default: `http://localhost:11434`) |
+| Variable | Required | Where to get it |
+|----------|----------|----------------|
+| `OPENAI_API_KEY` | At least one provider | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
+| `ANTHROPIC_API_KEY` | At least one provider | [console.anthropic.com](https://console.anthropic.com/settings/keys) |
+| `GEMINI_API_KEY` | At least one provider | [aistudio.google.com/apikey](https://aistudio.google.com/apikey) |
+| `AZURE_OPENAI_API_KEY` | Optional | Azure portal > your OpenAI resource |
+| `AZURE_OPENAI_ENDPOINT` | With Azure | Azure portal > your OpenAI resource |
+| `TOGETHER_API_KEY` | Optional | [api.together.xyz](https://api.together.xyz/settings/api-keys) |
+| `FIREWORKS_API_KEY` | Optional | [fireworks.ai](https://fireworks.ai/account/api-keys) |
+| `CEREBRAS_API_KEY` | Optional | [cloud.cerebras.ai](https://cloud.cerebras.ai/) |
+| `XAI_API_KEY` | Optional | [console.x.ai](https://console.x.ai/) |
+| `OLLAMA_HOST` | Optional | Default: `http://localhost:11434` |
 
 ### Cloud services
 
-| Variable | Description |
-|----------|-------------|
-| `GOOGLE_APPLICATION_CREDENTIALS` | Path to Google service account JSON (for server-side Drive access) |
-| `ZOOM_CLIENT_ID` | Zoom OAuth app client ID |
-| `ZOOM_CLIENT_SECRET` | Zoom OAuth app client secret |
-| `NOTION_API_KEY` | Notion integration token |
-| `GITHUB_TOKEN` | GitHub personal access token |
-| `MICROSOFT_CLIENT_ID` | Azure AD app client ID (for Microsoft 365) |
-| `MICROSOFT_CLIENT_SECRET` | Azure AD app client secret |
+| Variable | Service | Auth method |
+|----------|---------|-------------|
+| `GOOGLE_CLIENT_ID` | Google (Drive, Docs, Meet) | OAuth |
+| `GOOGLE_CLIENT_SECRET` | Google | OAuth |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Google | Service account |
+| `ZOOM_CLIENT_ID` | Zoom | OAuth |
+| `ZOOM_CLIENT_SECRET` | Zoom | OAuth |
+| `ZOOM_ACCOUNT_ID` | Zoom | Server-to-Server |
+| `MICROSOFT_CLIENT_ID` | Microsoft 365 | OAuth |
+| `MICROSOFT_CLIENT_SECRET` | Microsoft 365 | OAuth |
+| `NOTION_CLIENT_ID` | Notion | OAuth |
+| `NOTION_CLIENT_SECRET` | Notion | OAuth |
+| `NOTION_API_KEY` | Notion | API key |
+| `GITHUB_CLIENT_ID` | GitHub | OAuth |
+| `GITHUB_CLIENT_SECRET` | GitHub | OAuth |
+| `GITHUB_TOKEN` | GitHub | API key |
+| `DROPBOX_APP_KEY` | Dropbox | OAuth |
+| `DROPBOX_APP_SECRET` | Dropbox | OAuth |
+| `DROPBOX_ACCESS_TOKEN` | Dropbox | API key |
 
 ### General
 
@@ -37,7 +142,7 @@
 
 ## Authentication
 
-Most cloud services use OAuth via the `planopticon auth` command. Run it once per service to store credentials locally:
+PlanOpticon uses OAuth for cloud services. Run `planopticon auth` once per service — tokens are saved locally and refreshed automatically.
 
 ```bash
 planopticon auth google      # Google Drive, Docs, Meet, YouTube
@@ -48,9 +153,20 @@ planopticon auth github      # GitHub repos and wikis
 planopticon auth microsoft   # OneDrive, SharePoint, Teams
 ```
 
-Credentials are stored in `~/.config/planopticon/`. Use `planopticon auth SERVICE --logout` to remove them.
+Credentials are stored in `~/.planopticon/`. Use `planopticon auth SERVICE --logout` to remove them.
 
-For Zoom and Microsoft 365, you also need to set the client ID and secret environment variables before running `planopticon auth`.
+### What each service needs
+
+| Service | Minimum setup | Full OAuth setup |
+|---------|--------------|-----------------|
+| Google | `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` | Create OAuth credentials in [Google Cloud Console](https://console.cloud.google.com/apis/credentials) |
+| Zoom | `ZOOM_CLIENT_ID` + `ZOOM_CLIENT_SECRET` | Create a General App at [marketplace.zoom.us](https://marketplace.zoom.us/develop/create) |
+| Microsoft | `MICROSOFT_CLIENT_ID` + `MICROSOFT_CLIENT_SECRET` | Register app in [Azure AD](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps) |
+| Notion | `NOTION_API_KEY` (simplest) | Create integration at [notion.so/my-integrations](https://www.notion.so/my-integrations) |
+| GitHub | `GITHUB_TOKEN` (simplest) | Create token at [github.com/settings/tokens](https://github.com/settings/tokens) |
+| Dropbox | `DROPBOX_APP_KEY` + `DROPBOX_APP_SECRET` | Create app at [dropbox.com/developers](https://www.dropbox.com/developers/apps) |
+
+For detailed OAuth app creation walkthroughs, see the [Authentication guide](../guide/authentication.md).
 
 ## Provider routing
 

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -1,0 +1,525 @@
+# Authentication
+
+PlanOpticon uses a unified authentication system to connect with cloud services for fetching recordings, documents, and other content. The system is **OAuth-first**: it prefers OAuth 2.0 flows for security and token management, but falls back to API keys when OAuth is not configured.
+
+## Auth strategy overview
+
+PlanOpticon supports six cloud services out of the box: Google, Dropbox, Zoom, Notion, GitHub, and Microsoft. Each service uses the same authentication chain, implemented through the `OAuthManager` class. You configure credentials once (via environment variables or directly), and PlanOpticon handles token acquisition, storage, refresh, and fallback automatically.
+
+All authentication state is managed through the `planopticon auth` CLI command, the `/auth` companion REPL command, or programmatically via the Python API.
+
+## The auth chain
+
+When you authenticate with a service, PlanOpticon tries the following methods in order. It stops at the first one that succeeds:
+
+1. **Saved token** -- Checks `~/.planopticon/{service}_token.json` for a previously saved token. If the token has not expired, it is used immediately. If it has expired but a refresh token is available, PlanOpticon attempts an automatic token refresh.
+
+2. **Client Credentials grant** (Server-to-Server) -- If an `account_id` is configured (e.g., `ZOOM_ACCOUNT_ID`), PlanOpticon attempts a client credentials grant. This is a non-interactive flow suitable for automated pipelines and server-side integrations. No browser is required.
+
+3. **OAuth 2.0 Authorization Code with PKCE** (interactive) -- If a client ID is configured and OAuth endpoints are available, PlanOpticon initiates an interactive OAuth PKCE flow. It opens a browser to the service's authorization page, waits for you to paste the authorization code, and exchanges it for tokens. The tokens are saved for future use.
+
+4. **API key fallback** -- If no OAuth method succeeds, PlanOpticon checks for a service-specific API key environment variable (e.g., `GITHUB_TOKEN`, `NOTION_API_KEY`). This is the simplest setup but may have reduced capabilities compared to OAuth.
+
+If none of the four methods succeed, PlanOpticon returns an error with hints about which environment variables to set.
+
+## Token storage
+
+Tokens are persisted as JSON files in `~/.planopticon/`:
+
+```
+~/.planopticon/
+  google_token.json
+  dropbox_token.json
+  zoom_token.json
+  notion_token.json
+  github_token.json
+  microsoft_token.json
+```
+
+Each token file contains:
+
+| Field | Description |
+|-------|-------------|
+| `access_token` | The current access token |
+| `refresh_token` | Refresh token for automatic renewal (if provided by the service) |
+| `expires_at` | Unix timestamp when the token expires (with a 60-second safety margin) |
+| `client_id` | The client ID used for this token (for refresh) |
+| `client_secret` | The client secret used (for refresh) |
+
+The `~/.planopticon/` directory is created automatically on first use. Token files are overwritten on each successful authentication or refresh.
+
+To remove a saved token, use `planopticon auth <service> --logout` or delete the file directly.
+
+## Supported services
+
+### Google
+
+Google authentication provides access to Google Drive and Google Docs for fetching documents, recordings, and other content.
+
+**Scopes requested:**
+
+- `https://www.googleapis.com/auth/drive.readonly`
+- `https://www.googleapis.com/auth/documents.readonly`
+
+**Environment variables:**
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GOOGLE_CLIENT_ID` | For OAuth | OAuth 2.0 Client ID from Google Cloud Console |
+| `GOOGLE_CLIENT_SECRET` | For OAuth | OAuth 2.0 Client Secret |
+| `GOOGLE_API_KEY` | Fallback | API key (limited access, no user-specific data) |
+
+**OAuth app setup:**
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/).
+2. Create a project (or select an existing one).
+3. Navigate to **APIs & Services > Credentials**.
+4. Click **Create Credentials > OAuth client ID**.
+5. Choose **Desktop app** as the application type.
+6. Copy the Client ID and Client Secret.
+7. Under **APIs & Services > Library**, enable the **Google Drive API** and **Google Docs API**.
+8. Set the environment variables:
+
+```bash
+export GOOGLE_CLIENT_ID="your-client-id.apps.googleusercontent.com"
+export GOOGLE_CLIENT_SECRET="your-client-secret"
+```
+
+**Service account fallback:** For automated pipelines, you can use a Google service account instead of OAuth. Generate a service account key JSON file from the Google Cloud Console and set `GOOGLE_APPLICATION_CREDENTIALS` to point to it. The PlanOpticon Google Workspace connector (`planopticon gws`) uses the `gws` CLI which has its own auth flow via `gws auth login`.
+
+### Dropbox
+
+Dropbox authentication provides access to files stored in Dropbox.
+
+**Environment variables:**
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DROPBOX_APP_KEY` | For OAuth | App key from the Dropbox App Console |
+| `DROPBOX_APP_SECRET` | For OAuth | App secret |
+| `DROPBOX_ACCESS_TOKEN` | Fallback | Long-lived access token (for quick setup) |
+
+**OAuth app setup:**
+
+1. Go to the [Dropbox App Console](https://www.dropbox.com/developers/apps).
+2. Click **Create App**.
+3. Choose **Scoped access** and **Full Dropbox** (or **App folder** for restricted access).
+4. Copy the App key and App secret from the **Settings** tab.
+5. Set the environment variables:
+
+```bash
+export DROPBOX_APP_KEY="your-app-key"
+export DROPBOX_APP_SECRET="your-app-secret"
+```
+
+**Access token shortcut:** For quick testing, you can generate an access token directly from the app's Settings page in the Dropbox App Console and set it as `DROPBOX_ACCESS_TOKEN`. This bypasses OAuth entirely but the token may have a limited lifetime.
+
+### Zoom
+
+Zoom authentication provides access to cloud recordings, meeting metadata, and transcripts.
+
+**Environment variables:**
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ZOOM_CLIENT_ID` | For OAuth | OAuth client ID from the Zoom Marketplace |
+| `ZOOM_CLIENT_SECRET` | For OAuth | OAuth client secret |
+| `ZOOM_ACCOUNT_ID` | For S2S | Account ID for Server-to-Server OAuth |
+
+**Server-to-Server (recommended for automation):**
+
+When `ZOOM_ACCOUNT_ID` is set alongside `ZOOM_CLIENT_ID` and `ZOOM_CLIENT_SECRET`, PlanOpticon uses the client credentials grant (Server-to-Server OAuth). This is non-interactive and ideal for CI/CD pipelines and scheduled jobs.
+
+1. Go to the [Zoom Marketplace](https://marketplace.zoom.us/).
+2. Click **Develop > Build App**.
+3. Choose **Server-to-Server OAuth**.
+4. Copy the Account ID, Client ID, and Client Secret.
+5. Add the required scopes: `recording:read:admin` (or `recording:read`).
+6. Set the environment variables:
+
+```bash
+export ZOOM_CLIENT_ID="your-client-id"
+export ZOOM_CLIENT_SECRET="your-client-secret"
+export ZOOM_ACCOUNT_ID="your-account-id"
+```
+
+**User-level OAuth PKCE:**
+
+If `ZOOM_ACCOUNT_ID` is not set, PlanOpticon falls back to the interactive OAuth PKCE flow. This opens a browser window for the user to authorize access.
+
+1. In the Zoom Marketplace, create a **General App** (or **OAuth** app).
+2. Set the redirect URI to `urn:ietf:wg:oauth:2.0:oob` (out-of-band).
+3. Copy the Client ID and Client Secret.
+
+### Notion
+
+Notion authentication provides access to pages, databases, and content in your Notion workspace.
+
+**Environment variables:**
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `NOTION_CLIENT_ID` | For OAuth | OAuth client ID from the Notion Integrations page |
+| `NOTION_CLIENT_SECRET` | For OAuth | OAuth client secret |
+| `NOTION_API_KEY` | Fallback | Internal integration token |
+
+**OAuth app setup:**
+
+1. Go to [My Integrations](https://www.notion.so/my-integrations) in Notion.
+2. Click **New integration**.
+3. Select **Public integration** (required for OAuth).
+4. Copy the OAuth Client ID and Client Secret.
+5. Set the redirect URI.
+6. Set the environment variables:
+
+```bash
+export NOTION_CLIENT_ID="your-client-id"
+export NOTION_CLIENT_SECRET="your-client-secret"
+```
+
+**Internal integration (API key fallback):**
+
+For simpler setups, create an **Internal integration** from the Notion Integrations page. Copy the integration token and set it as `NOTION_API_KEY`. You must also share the relevant Notion pages/databases with the integration.
+
+```bash
+export NOTION_API_KEY="ntn_your-integration-token"
+```
+
+### GitHub
+
+GitHub authentication provides access to repositories, issues, and organization data.
+
+**Scopes requested:**
+
+- `repo`
+- `read:org`
+
+**Environment variables:**
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GITHUB_CLIENT_ID` | For OAuth | OAuth App client ID |
+| `GITHUB_CLIENT_SECRET` | For OAuth | OAuth App client secret |
+| `GITHUB_TOKEN` | Fallback | Personal access token (classic or fine-grained) |
+
+**OAuth app setup:**
+
+1. Go to **GitHub > Settings > Developer Settings > OAuth Apps**.
+2. Click **New OAuth App**.
+3. Set the Authorization callback URL to `urn:ietf:wg:oauth:2.0:oob`.
+4. Copy the Client ID and generate a Client Secret.
+5. Set the environment variables:
+
+```bash
+export GITHUB_CLIENT_ID="your-client-id"
+export GITHUB_CLIENT_SECRET="your-client-secret"
+```
+
+**Personal access token (recommended for most users):**
+
+The simplest approach is to create a Personal Access Token:
+
+1. Go to **GitHub > Settings > Developer Settings > Personal Access Tokens**.
+2. Generate a token with `repo` and `read:org` scopes.
+3. Set it as `GITHUB_TOKEN`:
+
+```bash
+export GITHUB_TOKEN="ghp_your-token"
+```
+
+### Microsoft
+
+Microsoft authentication provides access to Microsoft 365 resources via the Microsoft Graph API, including OneDrive, SharePoint, and Teams recordings.
+
+**Scopes requested:**
+
+- `https://graph.microsoft.com/OnlineMeetings.Read`
+- `https://graph.microsoft.com/Files.Read`
+
+**Environment variables:**
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `MICROSOFT_CLIENT_ID` | For OAuth | Application (client) ID from Azure AD |
+| `MICROSOFT_CLIENT_SECRET` | For OAuth | Client secret from Azure AD |
+
+**Azure AD app registration:**
+
+1. Go to the [Azure Portal](https://portal.azure.com/).
+2. Navigate to **Azure Active Directory > App registrations**.
+3. Click **New registration**.
+4. Name the application (e.g., "PlanOpticon").
+5. Under **Supported account types**, select the appropriate option for your organization.
+6. Set the redirect URI to `urn:ietf:wg:oauth:2.0:oob` with platform **Mobile and desktop applications**.
+7. After registration, go to **Certificates & secrets** and create a new client secret.
+8. Under **API permissions**, add:
+    - `OnlineMeetings.Read`
+    - `Files.Read`
+9. Grant admin consent if required by your organization.
+10. Set the environment variables:
+
+```bash
+export MICROSOFT_CLIENT_ID="your-application-id"
+export MICROSOFT_CLIENT_SECRET="your-client-secret"
+```
+
+**Microsoft 365 CLI:** The `planopticon m365` commands use the `@pnp/cli-microsoft365` npm package, which has its own authentication flow via `m365 login`. This is separate from the OAuth flow described above.
+
+## CLI usage
+
+### `planopticon auth`
+
+Authenticate with a cloud service or manage saved tokens.
+
+```
+planopticon auth SERVICE [--logout]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `SERVICE` | One of: `google`, `dropbox`, `zoom`, `notion`, `github`, `microsoft` |
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--logout` | Clear the saved token for the specified service |
+
+**Examples:**
+
+```bash
+# Authenticate with Google (triggers OAuth flow or uses saved token)
+planopticon auth google
+
+# Authenticate with Zoom
+planopticon auth zoom
+
+# Clear saved GitHub token
+planopticon auth github --logout
+```
+
+On success, the command prints the authentication method used:
+
+```
+Google authentication successful (oauth_pkce).
+```
+
+or
+
+```
+Github authentication successful (api_key).
+```
+
+### Companion REPL `/auth`
+
+Inside the interactive companion REPL (`planopticon -C` or `planopticon -I`), you can authenticate with services using the `/auth` command:
+
+```
+/auth SERVICE
+```
+
+Without arguments, `/auth` lists all available services:
+
+```
+> /auth
+Usage: /auth SERVICE
+Available: dropbox, github, google, microsoft, notion, zoom
+```
+
+With a service name, it runs the same auth chain as the CLI command:
+
+```
+> /auth github
+Github authentication successful (api_key).
+```
+
+## Environment variables reference
+
+The following table summarizes all environment variables used by the authentication system:
+
+| Service | OAuth Client ID | OAuth Client Secret | API Key / Token | Account ID |
+|---------|----------------|--------------------|--------------------|------------|
+| Google | `GOOGLE_CLIENT_ID` | `GOOGLE_CLIENT_SECRET` | `GOOGLE_API_KEY` | -- |
+| Dropbox | `DROPBOX_APP_KEY` | `DROPBOX_APP_SECRET` | `DROPBOX_ACCESS_TOKEN` | -- |
+| Zoom | `ZOOM_CLIENT_ID` | `ZOOM_CLIENT_SECRET` | -- | `ZOOM_ACCOUNT_ID` |
+| Notion | `NOTION_CLIENT_ID` | `NOTION_CLIENT_SECRET` | `NOTION_API_KEY` | -- |
+| GitHub | `GITHUB_CLIENT_ID` | `GITHUB_CLIENT_SECRET` | `GITHUB_TOKEN` | -- |
+| Microsoft | `MICROSOFT_CLIENT_ID` | `MICROSOFT_CLIENT_SECRET` | -- | -- |
+
+## Python API
+
+### AuthConfig
+
+The `AuthConfig` dataclass defines the authentication configuration for a service. It holds OAuth endpoints, credential references, scopes, and token storage paths.
+
+```python
+from video_processor.auth import AuthConfig
+
+config = AuthConfig(
+    service="myservice",
+    oauth_authorize_url="https://example.com/oauth/authorize",
+    oauth_token_url="https://example.com/oauth/token",
+    client_id_env="MYSERVICE_CLIENT_ID",
+    client_secret_env="MYSERVICE_CLIENT_SECRET",
+    api_key_env="MYSERVICE_API_KEY",
+    scopes=["read", "write"],
+)
+```
+
+**Key fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `service` | `str` | Service identifier (used for token filename) |
+| `oauth_authorize_url` | `Optional[str]` | OAuth authorization endpoint |
+| `oauth_token_url` | `Optional[str]` | OAuth token endpoint |
+| `client_id` / `client_id_env` | `Optional[str]` | Client ID value or env var name |
+| `client_secret` / `client_secret_env` | `Optional[str]` | Client secret value or env var name |
+| `api_key_env` | `Optional[str]` | Environment variable for API key fallback |
+| `scopes` | `List[str]` | OAuth scopes to request |
+| `redirect_uri` | `str` | Redirect URI (default: `urn:ietf:wg:oauth:2.0:oob`) |
+| `account_id` / `account_id_env` | `Optional[str]` | Account ID for client credentials grant |
+| `token_path` | `Optional[Path]` | Override token storage path |
+
+**Resolved properties:**
+
+- `resolved_client_id` -- Returns the client ID from the direct value or environment variable.
+- `resolved_client_secret` -- Returns the client secret from the direct value or environment variable.
+- `resolved_api_key` -- Returns the API key from the environment variable.
+- `resolved_account_id` -- Returns the account ID from the direct value or environment variable.
+- `resolved_token_path` -- Returns the token file path (default: `~/.planopticon/{service}_token.json`).
+- `supports_oauth` -- Returns `True` if both OAuth endpoints are configured.
+
+### OAuthManager
+
+The `OAuthManager` class manages the full authentication lifecycle for a service.
+
+```python
+from video_processor.auth import OAuthManager, AuthConfig
+
+config = AuthConfig(
+    service="notion",
+    oauth_authorize_url="https://api.notion.com/v1/oauth/authorize",
+    oauth_token_url="https://api.notion.com/v1/oauth/token",
+    client_id_env="NOTION_CLIENT_ID",
+    client_secret_env="NOTION_CLIENT_SECRET",
+    api_key_env="NOTION_API_KEY",
+    scopes=["read_content"],
+)
+manager = OAuthManager(config)
+
+# Full auth chain -- returns AuthResult
+result = manager.authenticate()
+if result.success:
+    print(f"Authenticated via {result.method}")
+    print(f"Token: {result.access_token[:20]}...")
+
+# Convenience method -- returns just the token string or None
+token = manager.get_token()
+
+# Clear saved token (logout)
+manager.clear_token()
+```
+
+**AuthResult fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | `bool` | Whether authentication succeeded |
+| `access_token` | `Optional[str]` | The access token (if successful) |
+| `method` | `Optional[str]` | One of: `saved_token`, `oauth_pkce`, `client_credentials`, `api_key` |
+| `expires_at` | `Optional[float]` | Token expiry as a Unix timestamp |
+| `refresh_token` | `Optional[str]` | Refresh token (if provided) |
+| `error` | `Optional[str]` | Error message (if unsuccessful) |
+
+### Pre-built configs
+
+PlanOpticon ships with pre-built `AuthConfig` instances for all six supported services. Access them via convenience functions:
+
+```python
+from video_processor.auth import get_auth_config, get_auth_manager
+
+# Get just the config
+config = get_auth_config("zoom")
+
+# Get a ready-to-use manager
+manager = get_auth_manager("github")
+token = manager.get_token()
+```
+
+### Building custom connectors
+
+To add authentication for a new service, create an `AuthConfig` with the service's OAuth endpoints and credential environment variables:
+
+```python
+from video_processor.auth import AuthConfig, OAuthManager
+
+config = AuthConfig(
+    service="slack",
+    oauth_authorize_url="https://slack.com/oauth/v2/authorize",
+    oauth_token_url="https://slack.com/api/oauth.v2.access",
+    client_id_env="SLACK_CLIENT_ID",
+    client_secret_env="SLACK_CLIENT_SECRET",
+    api_key_env="SLACK_BOT_TOKEN",
+    scopes=["channels:read", "channels:history"],
+)
+
+manager = OAuthManager(config)
+result = manager.authenticate()
+```
+
+The token will be saved to `~/.planopticon/slack_token.json` and automatically refreshed on subsequent calls.
+
+## Troubleshooting
+
+### "No auth method available for {service}"
+
+This means none of the four auth methods succeeded. Check that:
+
+- The required environment variables are set and non-empty.
+- For OAuth: both the client ID and client secret (or app key/secret) are set.
+- For API key fallback: the correct environment variable is set.
+
+The error message includes hints about which variables to set.
+
+### Token refresh fails
+
+If automatic token refresh fails, PlanOpticon falls back to the next auth method in the chain. Common causes:
+
+- The refresh token has been revoked (e.g., you changed your password or revoked app access).
+- The OAuth app's client secret has changed.
+- The service requires re-authorization after a certain period.
+
+To resolve, clear the token and re-authenticate:
+
+```bash
+planopticon auth google --logout
+planopticon auth google
+```
+
+### OAuth PKCE flow does not open a browser
+
+If the browser does not open automatically, PlanOpticon prints the authorization URL to the terminal. Copy and paste it into your browser manually. After authorizing, paste the authorization code back into the terminal prompt.
+
+### "requests not installed"
+
+The OAuth flows require the `requests` library. It is included as a dependency of PlanOpticon, but if you installed PlanOpticon in a minimal environment, install it manually:
+
+```bash
+pip install requests
+```
+
+### Permission denied on token file
+
+PlanOpticon needs write access to `~/.planopticon/`. If the directory or token files have restrictive permissions, adjust them:
+
+```bash
+chmod 700 ~/.planopticon
+chmod 600 ~/.planopticon/*_token.json
+```
+
+### Microsoft authentication uses the `/common` tenant
+
+The default Microsoft OAuth configuration uses the `common` tenant endpoint (`login.microsoftonline.com/common/...`), which supports both personal Microsoft accounts and Azure AD organizational accounts. If your organization requires a specific tenant, you can create a custom `AuthConfig` with the tenant-specific URLs.

--- a/docs/guide/batch.md
+++ b/docs/guide/batch.md
@@ -12,7 +12,7 @@ Batch mode:
 
 1. Scans the input directory for video files matching the pattern
 2. Processes each video through the full single-video pipeline
-3. Merges knowledge graphs across all videos (case-insensitive entity dedup)
+3. Merges knowledge graphs across all videos with fuzzy matching and conflict resolution
 4. Generates a batch summary with aggregated stats and action items
 5. Writes a batch manifest linking to per-video results
 
@@ -32,13 +32,21 @@ planopticon batch -i ./recordings -o ./output --pattern "*.mp4,*.mov"
 output/
 ├── batch_manifest.json       # Batch-level manifest
 ├── batch_summary.md          # Aggregated summary
-├── knowledge_graph.json      # Merged KG across all videos
+├── knowledge_graph.db        # Merged KG across all videos (SQLite, primary)
+├── knowledge_graph.json      # Merged KG across all videos (JSON export)
 └── videos/
     ├── meeting-01/
     │   ├── manifest.json
     │   ├── transcript/
     │   ├── diagrams/
+    │   ├── captures/
     │   └── results/
+    │       ├── analysis.md
+    │       ├── analysis.html
+    │       ├── knowledge_graph.db
+    │       ├── knowledge_graph.json
+    │       ├── key_points.json
+    │       └── action_items.json
     └── meeting-02/
         ├── manifest.json
         └── ...
@@ -46,14 +54,32 @@ output/
 
 ## Knowledge graph merging
 
-When the same entity appears across multiple videos, PlanOpticon merges them:
+When the same entity appears across multiple videos, PlanOpticon merges them using a multi-strategy approach:
 
-- Case-insensitive name matching
-- Descriptions are unioned
-- Occurrences are concatenated with source tracking
-- Relationships are deduplicated
+### Entity deduplication
 
-The merged knowledge graph is saved at the batch root and included in the batch summary as a mermaid diagram.
+- **Case-insensitive exact matching** -- `"kubernetes"` and `"Kubernetes"` are recognized as the same entity
+- **Fuzzy name matching** -- Uses `SequenceMatcher` with a threshold of 0.85 to unify near-duplicate entities (e.g., `"K8s"` and `"k8s cluster"` may be matched depending on context)
+- **Descriptions are unioned** -- All unique descriptions from each video are combined
+- **Occurrences are concatenated with source tracking** -- Each occurrence retains its source video reference
+
+### Relationship deduplication
+
+- Relationships are deduplicated by (source, target, type) tuple
+- Descriptions from duplicate relationships are merged
+
+### Type conflict resolution
+
+When the same entity appears with different types across videos, PlanOpticon uses a specificity ranking to resolve the conflict. More specific types are preferred over general ones:
+
+- `technology` > `concept`
+- `person` > `concept`
+- `organization` > `concept`
+- And so on through the full type hierarchy
+
+This ensures that an entity initially classified as a generic `concept` in one video gets upgraded to `technology` if it is identified more specifically in another.
+
+The merged knowledge graph is saved at the batch root in both SQLite (`knowledge_graph.db`) and JSON (`knowledge_graph.json`) formats, and is included in the batch summary as a Mermaid diagram.
 
 ## Error handling
 
@@ -65,4 +91,88 @@ If a video fails to process, the batch continues. Failed videos are recorded in 
   "status": "failed",
   "error": "Audio extraction failed: no audio track found"
 }
+```
+
+The batch manifest tracks completion status:
+
+```json
+{
+  "title": "Sprint Reviews",
+  "total_videos": 5,
+  "completed_videos": 4,
+  "failed_videos": 1,
+  "total_diagrams": 12,
+  "total_action_items": 23,
+  "total_key_points": 45,
+  "videos": [...],
+  "batch_summary_md": "batch_summary.md",
+  "merged_knowledge_graph_json": "knowledge_graph.json",
+  "merged_knowledge_graph_db": "knowledge_graph.db"
+}
+```
+
+## Using batch results
+
+### Query the merged knowledge graph
+
+After batch processing completes, the merged knowledge graph at the batch root contains entities and relationships from all successfully processed videos. You can query it just like a single-video knowledge graph:
+
+```bash
+# Show stats for the merged graph
+planopticon query --db output/knowledge_graph.db
+
+# List all people mentioned across all videos
+planopticon query --db output/knowledge_graph.db "entities --type person"
+
+# See what connects to an entity across all videos
+planopticon query --db output/knowledge_graph.db "neighbors Alice"
+
+# Ask natural language questions about the combined content
+planopticon query --db output/knowledge_graph.db "What technologies were discussed across all meetings?"
+
+# Interactive REPL for exploration
+planopticon query --db output/knowledge_graph.db -I
+```
+
+### Export merged results
+
+All export commands work with the merged knowledge graph:
+
+```bash
+# Generate documents from merged KG
+planopticon export markdown output/knowledge_graph.db -o ./docs
+
+# Export as Obsidian vault
+planopticon export obsidian output/knowledge_graph.db -o ./vault
+
+# Generate a project-wide exchange file
+planopticon export exchange output/knowledge_graph.db --name "Sprint Reviews Q4"
+
+# Generate a GitHub wiki
+planopticon wiki generate output/knowledge_graph.db -o ./wiki
+```
+
+### Classify for planning
+
+Run taxonomy classification on the merged graph to categorize entities across all videos:
+
+```bash
+planopticon kg classify output/knowledge_graph.db
+```
+
+### Use with the planning agent
+
+The planning agent can consume the merged knowledge graph for cross-video analysis and planning:
+
+```bash
+planopticon agent --db output/knowledge_graph.db
+```
+
+### Incremental batch processing
+
+If you add new videos to the recordings directory, you can re-run the batch command. Videos that have already been processed (with output directories present) will be detected via checkpoint/resume within each video's pipeline, making incremental processing efficient.
+
+```bash
+# Add new recordings to the folder, then re-run
+planopticon batch -i ./recordings -o ./output --title "Sprint Reviews"
 ```

--- a/docs/guide/companion.md
+++ b/docs/guide/companion.md
@@ -1,0 +1,531 @@
+# Interactive Companion REPL
+
+The PlanOpticon Companion is an interactive Read-Eval-Print Loop (REPL) that provides a conversational interface to PlanOpticon's full feature set. It combines workspace awareness, knowledge graph querying, LLM-powered chat, and planning agent skills into a single session.
+
+Use the Companion when you want to explore a knowledge graph interactively, ask natural-language questions about extracted content, generate planning artifacts on the fly, or switch between providers and models without restarting.
+
+---
+
+## Launching the Companion
+
+There are three equivalent ways to start the Companion.
+
+### As a subcommand
+
+```bash
+planopticon companion
+```
+
+### With the `--chat` / `-C` flag
+
+```bash
+planopticon --chat
+planopticon -C
+```
+
+These flags launch the Companion directly from the top-level CLI, without invoking a subcommand.
+
+### With options
+
+The `companion` subcommand accepts options for specifying knowledge base paths, LLM provider, and model:
+
+```bash
+# Point at a specific knowledge base
+planopticon companion --kb ./results
+
+# Use a specific provider
+planopticon companion -p anthropic
+
+# Use a specific model
+planopticon companion --chat-model gpt-4o
+
+# Combine options
+planopticon companion --kb ./results -p openai --chat-model gpt-4o
+```
+
+| Option | Description |
+|---|---|
+| `--kb PATH` | Path to a knowledge graph file or directory (repeatable) |
+| `-p, --provider NAME` | LLM provider: `auto`, `openai`, `anthropic`, `gemini`, `ollama`, `azure`, `together`, `fireworks`, `cerebras`, `xai` |
+| `--chat-model NAME` | Override the default chat model for the selected provider |
+
+---
+
+## Auto-discovery
+
+On startup, the Companion automatically scans the workspace for relevant files:
+
+**Knowledge graphs.** The Companion uses `find_nearest_graph()` to locate the closest `knowledge_graph.db` or `knowledge_graph.json` file. It searches the current directory, common output subdirectories (`results/`, `output/`, `knowledge-base/`), recursively downward (up to 4 levels), and upward through parent directories. SQLite `.db` files are preferred over `.json` files.
+
+**Videos.** The current directory is scanned for files with `.mp4`, `.mkv`, and `.webm` extensions.
+
+**Documents.** The current directory is scanned for files with `.md`, `.pdf`, and `.docx` extensions.
+
+**LLM provider.** If `--provider` is set to `auto` (the default), the Companion attempts to initialise a provider using any available API key in the environment (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, etc.).
+
+All discovered context is displayed in the welcome banner:
+
+```
+  PlanOpticon Companion
+  Interactive planning REPL
+
+  Knowledge graph: knowledge_graph.db  (42 entities, 87 relationships)
+  Videos: meeting-2024-01-15.mp4, sprint-review.mp4
+  Docs: requirements.md, architecture.pdf
+  LLM provider: openai (model: gpt-4o)
+
+  Type /help for commands, or ask a question.
+```
+
+If no knowledge graph is found, the banner shows "No knowledge graph loaded." Commands that require a KG will return an appropriate message rather than failing silently.
+
+---
+
+## Slash Commands
+
+The Companion supports 18 slash commands. Type `/help` at the prompt to see the full list.
+
+### /help
+
+Display all available commands with brief descriptions.
+
+```
+planopticon> /help
+Available commands:
+  /help                  Show this help
+  /status                Workspace status
+  /skills                List available skills
+  /entities [--type T]   List KG entities
+  /search TERM           Search entities by name
+  /neighbors ENTITY      Show entity relationships
+  /export FORMAT         Export KG (markdown, obsidian, notion, csv)
+  /analyze PATH          Analyze a video/doc
+  /ingest PATH           Ingest a file into the KG
+  /auth SERVICE          Authenticate with a cloud service
+  /provider [NAME]       List or switch LLM provider
+  /model [NAME]          Show or switch chat model
+  /run SKILL             Run a skill by name
+  /plan                  Run project_plan skill
+  /prd                   Run PRD skill
+  /tasks                 Run task_breakdown skill
+  /quit, /exit           Exit companion
+
+Any other input is sent to the chat agent (requires LLM).
+```
+
+### /status
+
+Show a summary of the current workspace state: loaded knowledge graph (with entity and relationship counts, broken down by entity type), number of discovered videos and documents, and whether an LLM provider is active.
+
+```
+planopticon> /status
+Workspace status:
+  KG: /home/user/project/results/knowledge_graph.db (42 entities, 87 relationships)
+    technology: 15
+    person: 12
+    concept: 10
+    organization: 5
+  Videos: 2 found
+  Docs: 3 found
+  Provider: active
+```
+
+### /skills
+
+List all registered planning agent skills with their names and descriptions. These are the skills that can be invoked via `/run`.
+
+```
+planopticon> /skills
+Available skills:
+  project_plan: Generate a structured project plan from knowledge graph
+  prd: Generate a product requirements document (PRD) / feature spec
+  roadmap: Generate a product/project roadmap
+  task_breakdown: Break down goals into tasks with dependencies
+  github_issues: Generate GitHub issues from task breakdown
+  requirements_chat: Interactive requirements gathering via guided questions
+  doc_generator: Generate technical documentation, ADRs, or meeting notes
+  artifact_export: Export artifacts in agent-ready formats
+  cli_adapter: Push artifacts to external tools via their CLIs
+  notes_export: Export knowledge graph as structured notes (Obsidian, Notion)
+  wiki_generator: Generate a GitHub wiki from knowledge graph and artifacts
+```
+
+### /entities [--type TYPE]
+
+List entities from the loaded knowledge graph. Optionally filter by entity type.
+
+```
+planopticon> /entities
+Found 42 entities
+  [technology] Python -- General-purpose programming language
+  [person] Alice -- Lead engineer on the project
+  [concept] Microservices -- Architectural pattern discussed
+  ...
+
+planopticon> /entities --type person
+Found 12 entities
+  [person] Alice -- Lead engineer on the project
+  [person] Bob -- Product manager
+  ...
+```
+
+!!! note
+    This command requires a loaded knowledge graph. If none is loaded, it returns "No knowledge graph loaded."
+
+### /search TERM
+
+Search entities by name substring (case-insensitive).
+
+```
+planopticon> /search python
+Found 3 entities
+  [technology] Python -- General-purpose programming language
+  [technology] Python Flask -- Web framework for Python
+  [concept] Python packaging -- Discussion of pip and packaging tools
+```
+
+### /neighbors ENTITY
+
+Show all entities and relationships connected to a given entity. This performs a breadth-first traversal (depth 1) from the named entity.
+
+```
+planopticon> /neighbors Alice
+Found 4 entities and 5 relationships
+  [person] Alice -- Lead engineer on the project
+  [technology] Python -- General-purpose programming language
+  [organization] Acme Corp -- Employer
+  [concept] Authentication -- Auth system design
+  Alice --[works_with]--> Python
+  Alice --[employed_by]--> Acme Corp
+  Alice --[proposed]--> Authentication
+  Bob --[collaborates_with]--> Alice
+  Authentication --[discussed_by]--> Alice
+```
+
+### /export FORMAT
+
+Request an export of the knowledge graph. Supported formats: `markdown`, `obsidian`, `notion`, `csv`. This command prints the equivalent CLI command to run.
+
+```
+planopticon> /export obsidian
+Export 'obsidian' requested. Use the CLI command:
+  planopticon export obsidian /home/user/project/results/knowledge_graph.db
+```
+
+### /analyze PATH
+
+Request analysis of a video or document file. Validates the file exists and prints the equivalent CLI command.
+
+```
+planopticon> /analyze meeting.mp4
+Analyze requested for meeting.mp4. Use the CLI:
+  planopticon analyze -i /home/user/project/meeting.mp4
+```
+
+### /ingest PATH
+
+Request ingestion of a file into the knowledge graph. Validates the file exists and prints the equivalent CLI command.
+
+```
+planopticon> /ingest notes.md
+Ingest requested for notes.md. Use the CLI:
+  planopticon ingest /home/user/project/notes.md
+```
+
+### /auth [SERVICE]
+
+Authenticate with a cloud service. When called without arguments, lists all available services. When called with a service name, triggers the authentication flow.
+
+```
+planopticon> /auth
+Usage: /auth SERVICE
+Available: dropbox, github, google, microsoft, notion, zoom
+
+planopticon> /auth zoom
+Zoom authenticated (oauth)
+```
+
+### /provider [NAME]
+
+List available LLM providers and their status, or switch to a different provider.
+
+When called without arguments (or with `list`), shows all known providers with their availability status:
+
+- **ready** -- API key found in environment
+- **local** -- runs locally (Ollama)
+- **no key** -- no API key configured
+
+The currently active provider is marked.
+
+```
+planopticon> /provider
+Available providers:
+  openai: ready (active)
+  anthropic: ready
+  gemini: no key
+  ollama: local
+  azure: no key
+  together: no key
+  fireworks: no key
+  cerebras: no key
+  xai: no key
+
+Current: openai
+```
+
+To switch providers at runtime:
+
+```
+planopticon> /provider anthropic
+Switched to provider: anthropic
+```
+
+Switching the provider reinitialises the provider manager and the planning agent. The chat model is reset to the provider's default. If initialisation fails, an error message is shown.
+
+### /model [NAME]
+
+Show the current chat model, or switch to a different one.
+
+```
+planopticon> /model
+Current model: default
+Usage: /model MODEL_NAME
+
+planopticon> /model claude-sonnet-4-20250514
+Switched to model: claude-sonnet-4-20250514
+```
+
+Switching the model reinitialises both the provider manager and the planning agent.
+
+### /run SKILL
+
+Run any registered skill by name. The skill receives the current agent context (knowledge graph, query engine, provider, and any previously generated artifacts) and returns an artifact.
+
+```
+planopticon> /run roadmap
+--- Roadmap (roadmap) ---
+# Roadmap
+
+## Vision & Strategy
+...
+```
+
+If the skill cannot execute (missing KG or provider), an error message is returned. Use `/skills` to see all available skill names.
+
+### /plan
+
+Shortcut for `/run project_plan`. Generates a structured project plan from the loaded knowledge graph.
+
+```
+planopticon> /plan
+--- Project Plan (project_plan) ---
+# Project Plan
+
+## Executive Summary
+...
+```
+
+### /prd
+
+Shortcut for `/run prd`. Generates a product requirements document.
+
+```
+planopticon> /prd
+--- Product Requirements Document (prd) ---
+# Product Requirements Document
+
+## Problem Statement
+...
+```
+
+### /tasks
+
+Shortcut for `/run task_breakdown`. Breaks goals and features into tasks with dependencies, priorities, and effort estimates. The output is JSON.
+
+```
+planopticon> /tasks
+--- Task Breakdown (task_list) ---
+[
+  {
+    "id": "T1",
+    "title": "Set up authentication service",
+    "description": "Implement OAuth2 flow with JWT tokens",
+    "depends_on": [],
+    "priority": "high",
+    "estimate": "1w",
+    "assignee_role": "backend engineer"
+  },
+  ...
+]
+```
+
+### /quit and /exit
+
+Exit the Companion REPL.
+
+```
+planopticon> /quit
+Bye.
+```
+
+---
+
+## Exiting the Companion
+
+In addition to `/quit` and `/exit`, you can exit by:
+
+- Typing `quit`, `exit`, `bye`, or `q` as bare words (without the `/` prefix)
+- Pressing `Ctrl+C` or `Ctrl+D`
+
+All of these end the session with a "Bye." message.
+
+---
+
+## Chat Mode
+
+Any input that does not start with `/` and is not a bare exit word is sent to the chat agent as a natural-language message. This requires a configured LLM provider.
+
+```
+planopticon> What technologies were discussed in the meeting?
+Based on the knowledge graph, the following technologies were discussed:
+
+1. **Python** -- mentioned in the context of backend development
+2. **React** -- proposed for the frontend redesign
+3. **PostgreSQL** -- discussed as the primary database
+...
+```
+
+The chat agent maintains conversation history across the session. It has full awareness of:
+
+- The loaded knowledge graph (entity and relationship counts, types)
+- Any artifacts generated during the session (via `/plan`, `/prd`, `/tasks`, `/run`)
+- All available slash commands (which it may suggest when relevant)
+- The full PlanOpticon CLI command set
+
+If no LLM provider is configured, chat mode returns an error with instructions:
+
+```
+planopticon> What was discussed?
+Chat requires an LLM provider. Set one of:
+  OPENAI_API_KEY
+  ANTHROPIC_API_KEY
+  GEMINI_API_KEY
+Or pass --provider / --chat-model.
+```
+
+---
+
+## Runtime Provider and Model Switching
+
+One of the Companion's key features is the ability to switch LLM providers and models without restarting the session. This is useful for:
+
+- Comparing outputs across different models
+- Falling back to a local model (Ollama) when API keys expire
+- Using a cheaper model for exploratory queries and a more capable one for artifact generation
+
+When you switch providers or models via `/provider` or `/model`, the Companion:
+
+1. Updates the internal provider name and/or model name
+2. Reinitialises the `ProviderManager`
+3. Reinitialises the `PlanningAgent` with a fresh `AgentContext` that retains the loaded knowledge graph and query engine
+
+Conversation history is preserved across provider switches.
+
+---
+
+## Example Session
+
+The following walkthrough shows a typical Companion session, from launch through exploration to artifact generation.
+
+```bash
+$ planopticon companion --kb ./results
+```
+
+```
+  PlanOpticon Companion
+  Interactive planning REPL
+
+  Knowledge graph: knowledge_graph.db  (58 entities, 124 relationships)
+  Videos: sprint-review-2024-03.mp4
+  Docs: architecture.md, requirements.pdf
+  LLM provider: openai (model: default)
+
+  Type /help for commands, or ask a question.
+
+planopticon> /status
+Workspace status:
+  KG: /home/user/project/results/knowledge_graph.db (58 entities, 124 relationships)
+    technology: 20
+    person: 15
+    concept: 13
+    organization: 8
+    time: 2
+  Videos: 1 found
+  Docs: 2 found
+  Provider: active
+
+planopticon> /entities --type person
+Found 15 entities
+  [person] Alice -- Lead architect
+  [person] Bob -- Product manager
+  [person] Carol -- Frontend lead
+  ...
+
+planopticon> /neighbors Alice
+Found 6 entities and 8 relationships
+  [person] Alice -- Lead architect
+  [technology] Kubernetes -- Container orchestration platform
+  [concept] Microservices -- Proposed architecture pattern
+  ...
+  Alice --[proposed]--> Microservices
+  Alice --[expert_in]--> Kubernetes
+  ...
+
+planopticon> What were the main decisions made in the sprint review?
+Based on the knowledge graph, the sprint review covered several key decisions:
+
+1. **Adopt microservices architecture** -- Alice proposed and the team agreed
+   to move from the monolith to a microservices pattern.
+2. **Use Kubernetes for orchestration** -- Selected over Docker Swarm.
+3. **Prioritize authentication module** -- Bob identified this as the highest
+   priority for the next sprint.
+
+planopticon> /provider anthropic
+Switched to provider: anthropic
+
+planopticon> /model claude-sonnet-4-20250514
+Switched to model: claude-sonnet-4-20250514
+
+planopticon> /plan
+--- Project Plan (project_plan) ---
+# Project Plan
+
+## Executive Summary
+This project plan outlines the migration from a monolithic architecture
+to a microservices-based system, as discussed in the sprint review...
+
+## Goals & Objectives
+...
+
+planopticon> /tasks
+--- Task Breakdown (task_list) ---
+[
+  {
+    "id": "T1",
+    "title": "Design service boundaries",
+    "description": "Define microservice boundaries based on domain analysis",
+    "depends_on": [],
+    "priority": "high",
+    "estimate": "3d",
+    "assignee_role": "architect"
+  },
+  ...
+]
+
+planopticon> /export obsidian
+Export 'obsidian' requested. Use the CLI command:
+  planopticon export obsidian /home/user/project/results/knowledge_graph.db
+
+planopticon> quit
+Bye.
+```

--- a/docs/guide/document-ingestion.md
+++ b/docs/guide/document-ingestion.md
@@ -1,0 +1,434 @@
+# Document Ingestion
+
+Document ingestion lets you process files -- PDFs, Markdown, and plaintext -- into a knowledge graph. PlanOpticon extracts text from documents, chunks it into manageable pieces, runs LLM-powered entity and relationship extraction, and stores the results in a FalkorDB knowledge graph. This is the same knowledge graph format produced by video analysis, so you can combine video and document insights in a single graph.
+
+## Supported formats
+
+| Extension | Processor | Description |
+|-----------|-----------|-------------|
+| `.pdf` | `PdfProcessor` | Extracts text page by page using pymupdf or pdfplumber |
+| `.md`, `.markdown` | `MarkdownProcessor` | Splits on headings into sections |
+| `.txt`, `.text`, `.log`, `.csv` | `PlaintextProcessor` | Splits on paragraph boundaries |
+
+Additional formats can be added by implementing the `DocumentProcessor` base class and registering it (see [Extending with custom processors](#extending-with-custom-processors) below).
+
+## CLI usage
+
+### `planopticon ingest`
+
+```
+planopticon ingest INPUT_PATH [OPTIONS]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `INPUT_PATH` | Path to a file or directory to ingest (must exist) |
+
+**Options:**
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--output` | `-o` | Current directory | Output directory for the knowledge graph |
+| `--db-path` | | None | Path to an existing `knowledge_graph.db` to merge into |
+| `--recursive / --no-recursive` | `-r` | `--recursive` | Recurse into subdirectories (directory ingestion only) |
+| `--provider` | `-p` | `auto` | LLM provider for entity extraction (`openai`, `anthropic`, `gemini`, `ollama`, `azure`, `together`, `fireworks`, `cerebras`, `xai`) |
+| `--chat-model` | | None | Override the model used for LLM entity extraction |
+
+### Single file ingestion
+
+Process a single document and create a new knowledge graph:
+
+```bash
+planopticon ingest spec.md
+```
+
+This creates `knowledge_graph.db` and `knowledge_graph.json` in the current directory.
+
+Specify an output directory:
+
+```bash
+planopticon ingest report.pdf -o ./results
+```
+
+This creates `./results/knowledge_graph.db` and `./results/knowledge_graph.json`.
+
+### Directory ingestion
+
+Process all supported files in a directory:
+
+```bash
+planopticon ingest ./docs/
+```
+
+By default, this recurses into subdirectories. To process only the top-level directory:
+
+```bash
+planopticon ingest ./docs/ --no-recursive
+```
+
+PlanOpticon automatically filters for supported file extensions. Unsupported files are silently skipped.
+
+### Merging into an existing knowledge graph
+
+To add document content to an existing knowledge graph (e.g., one created from video analysis), use `--db-path`:
+
+```bash
+# First, analyze a video
+planopticon analyze meeting.mp4 -o ./results
+
+# Then, ingest supplementary documents into the same graph
+planopticon ingest ./meeting-notes/ --db-path ./results/knowledge_graph.db
+```
+
+The ingested entities and relationships are merged with the existing graph. Duplicate entities are consolidated automatically by the knowledge graph engine.
+
+### Choosing an LLM provider
+
+Entity and relationship extraction requires an LLM. By default, PlanOpticon auto-detects available providers based on your environment variables. You can override this:
+
+```bash
+# Use Anthropic for extraction
+planopticon ingest docs/ -p anthropic
+
+# Use a specific model
+planopticon ingest docs/ -p openai --chat-model gpt-4o
+
+# Use a local Ollama model
+planopticon ingest docs/ -p ollama --chat-model llama3
+```
+
+### Output
+
+After ingestion, PlanOpticon prints a summary:
+
+```
+Knowledge graph: ./knowledge_graph.db
+  spec.md: 12 chunks
+  architecture.md: 8 chunks
+  requirements.txt: 3 chunks
+
+Ingestion complete:
+  Files processed: 3
+  Total chunks: 23
+  Entities extracted: 47
+  Relationships: 31
+  Knowledge graph: ./knowledge_graph.db
+```
+
+Both `.db` (SQLite/FalkorDB) and `.json` formats are saved automatically.
+
+## How each processor works
+
+### PDF processor
+
+The `PdfProcessor` extracts text from PDF files on a per-page basis. It tries two extraction libraries in order:
+
+1. **pymupdf** (preferred) -- Fast, reliable text extraction. Install with `pip install pymupdf`.
+2. **pdfplumber** (fallback) -- Alternative extractor. Install with `pip install pdfplumber`.
+
+If neither library is installed, the processor raises an `ImportError` with installation instructions.
+
+Each page becomes a separate `DocumentChunk` with:
+
+- `text`: The extracted text content of the page
+- `page`: The 1-based page number
+- `metadata.extraction_method`: Which library was used (`pymupdf` or `pdfplumber`)
+
+To install PDF support:
+
+```bash
+pip install 'planopticon[pdf]'
+# or
+pip install pymupdf
+# or
+pip install pdfplumber
+```
+
+### Markdown processor
+
+The `MarkdownProcessor` splits Markdown files on heading boundaries (lines starting with `#` through `######`). Each heading and its content until the next heading becomes a separate chunk.
+
+**Splitting behavior:**
+
+- If the file contains headings, each heading section becomes a chunk. The `section` field records the heading text.
+- Content before the first heading is captured as a `(preamble)` chunk.
+- If the file contains no headings, it falls back to paragraph-based chunking (same as plaintext).
+
+For example, a file with this structure:
+
+```markdown
+Some intro text.
+
+# Architecture
+
+The system uses a microservices architecture...
+
+## Components
+
+There are three main components...
+
+# Deployment
+
+Deployment is handled via...
+```
+
+Produces four chunks: `(preamble)`, `Architecture`, `Components`, and `Deployment`.
+
+### Plaintext processor
+
+The `PlaintextProcessor` handles `.txt`, `.text`, `.log`, and `.csv` files. It splits text on paragraph boundaries (double newlines) and groups paragraphs into chunks with a configurable maximum size.
+
+**Chunking parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `max_chunk_size` | 2000 characters | Maximum size of each chunk |
+| `overlap` | 200 characters | Number of characters from the end of one chunk to repeat at the start of the next |
+
+The overlap ensures that entities or context that spans a paragraph boundary are not lost. Chunks are created by accumulating paragraphs until the next paragraph would exceed `max_chunk_size`, at which point the current chunk is flushed and a new one begins.
+
+## The ingestion pipeline
+
+Document ingestion follows this pipeline:
+
+```
+File on disk
+    |
+    v
+Processor selection (by file extension)
+    |
+    v
+Text extraction (PDF pages / Markdown sections / plaintext paragraphs)
+    |
+    v
+DocumentChunk objects (text + metadata)
+    |
+    v
+Source registration (provenance tracking in the KG)
+    |
+    v
+KG content addition (LLM entity/relationship extraction per chunk)
+    |
+    v
+Knowledge graph storage (.db + .json)
+```
+
+### Step 1: Processor selection
+
+PlanOpticon maintains a registry of processors keyed by file extension. When you call `ingest_file()`, it looks up the appropriate processor using `get_processor(path)`. If no processor is registered for the file extension, a `ValueError` is raised.
+
+### Step 2: Text extraction
+
+The selected processor reads the file and produces a list of `DocumentChunk` objects. Each chunk contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `text` | `str` | The extracted text content |
+| `source_file` | `str` | Path to the source file |
+| `chunk_index` | `int` | Sequential index of this chunk within the file |
+| `page` | `Optional[int]` | Page number (PDF only, 1-based) |
+| `section` | `Optional[str]` | Section heading (Markdown only) |
+| `metadata` | `Dict[str, Any]` | Additional metadata (e.g., extraction method) |
+
+### Step 3: Source registration
+
+Each ingested file is registered as a source in the knowledge graph with provenance metadata:
+
+- `source_id`: A SHA-256 hash of the absolute file path (first 12 characters), unless you provide a custom ID
+- `source_type`: Always `"document"`
+- `title`: The file stem (filename without extension)
+- `path`: The file path
+- `mime_type`: Detected MIME type
+- `ingested_at`: ISO-8601 timestamp
+- `metadata`: Chunk count and file extension
+
+### Step 4: Entity and relationship extraction
+
+Each chunk's text is passed to `knowledge_graph.add_content()`, which uses the configured LLM provider to extract entities and relationships. The content source is tagged with the document name and either the page number or section name:
+
+- `document:report.pdf:page:3`
+- `document:spec.md:section:Architecture`
+- `document:notes.txt` (no page or section)
+
+### Step 5: Storage
+
+The knowledge graph is saved in both `.db` (SQLite-backed FalkorDB) and `.json` formats.
+
+## Combining with video analysis
+
+A common workflow is to analyze a video recording and then ingest related documents into the same knowledge graph:
+
+```bash
+# Step 1: Analyze the meeting recording
+planopticon analyze meeting-recording.mp4 -o ./project-kg
+
+# Step 2: Ingest the meeting agenda
+planopticon ingest agenda.md --db-path ./project-kg/knowledge_graph.db
+
+# Step 3: Ingest the project spec
+planopticon ingest project-spec.pdf --db-path ./project-kg/knowledge_graph.db
+
+# Step 4: Ingest a whole docs folder
+planopticon ingest ./reference-docs/ --db-path ./project-kg/knowledge_graph.db
+
+# Step 5: Query the combined graph
+planopticon query --db-path ./project-kg/knowledge_graph.db
+```
+
+The resulting knowledge graph contains entities and relationships from all sources -- video transcripts, meeting agendas, specs, and reference documents -- with full provenance tracking so you can trace any entity back to its source.
+
+## Python API
+
+### Ingesting a single file
+
+```python
+from pathlib import Path
+from video_processor.integrators.knowledge_graph import KnowledgeGraph
+from video_processor.processors.ingest import ingest_file
+
+kg = KnowledgeGraph(db_path=Path("knowledge_graph.db"))
+chunk_count = ingest_file(Path("document.pdf"), kg)
+print(f"Processed {chunk_count} chunks")
+
+kg.save(Path("knowledge_graph.db"))
+```
+
+### Ingesting a directory
+
+```python
+from pathlib import Path
+from video_processor.integrators.knowledge_graph import KnowledgeGraph
+from video_processor.processors.ingest import ingest_directory
+
+kg = KnowledgeGraph(db_path=Path("knowledge_graph.db"))
+results = ingest_directory(
+    Path("./docs"),
+    kg,
+    recursive=True,
+    extensions=[".md", ".pdf"],  # Optional: filter by extension
+)
+
+for filepath, chunks in results.items():
+    print(f"  {filepath}: {chunks} chunks")
+
+kg.save(Path("knowledge_graph.db"))
+```
+
+### Listing supported extensions
+
+```python
+from video_processor.processors.base import list_supported_extensions
+
+extensions = list_supported_extensions()
+print(extensions)
+# ['.csv', '.log', '.markdown', '.md', '.pdf', '.text', '.txt']
+```
+
+### Working with processors directly
+
+```python
+from pathlib import Path
+from video_processor.processors.base import get_processor
+
+processor = get_processor(Path("report.pdf"))
+if processor:
+    chunks = processor.process(Path("report.pdf"))
+    for chunk in chunks:
+        print(f"Page {chunk.page}: {chunk.text[:100]}...")
+```
+
+## Extending with custom processors
+
+To add support for a new file format, implement the `DocumentProcessor` abstract class and register it:
+
+```python
+from pathlib import Path
+from typing import List
+from video_processor.processors.base import (
+    DocumentChunk,
+    DocumentProcessor,
+    register_processor,
+)
+
+
+class HtmlProcessor(DocumentProcessor):
+    supported_extensions = [".html", ".htm"]
+
+    def can_process(self, path: Path) -> bool:
+        return path.suffix.lower() in self.supported_extensions
+
+    def process(self, path: Path) -> List[DocumentChunk]:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(path.read_text(), "html.parser")
+        text = soup.get_text(separator="\n")
+        return [
+            DocumentChunk(
+                text=text,
+                source_file=str(path),
+                chunk_index=0,
+            )
+        ]
+
+
+register_processor(HtmlProcessor.supported_extensions, HtmlProcessor)
+```
+
+After registration, `planopticon ingest` will automatically handle `.html` and `.htm` files.
+
+## Companion REPL
+
+Inside the interactive companion REPL, you can ingest files using the `/ingest` command:
+
+```
+> /ingest ./meeting-notes.md
+Ingested meeting-notes.md: 5 chunks
+```
+
+This adds content to the currently loaded knowledge graph.
+
+## Common workflows
+
+### Build a project knowledge base from scratch
+
+```bash
+# Ingest all project docs
+planopticon ingest ./project-docs/ -o ./knowledge-base
+
+# Query what was captured
+planopticon query --db-path ./knowledge-base/knowledge_graph.db
+
+# Export as an Obsidian vault
+planopticon export obsidian ./knowledge-base/knowledge_graph.db -o ./vault
+```
+
+### Incrementally build a knowledge graph
+
+```bash
+# Start with initial docs
+planopticon ingest ./sprint-1-docs/ -o ./kg
+
+# Add more docs over time
+planopticon ingest ./sprint-2-docs/ --db-path ./kg/knowledge_graph.db
+planopticon ingest ./sprint-3-docs/ --db-path ./kg/knowledge_graph.db
+
+# The graph grows with each ingestion
+planopticon query --db-path ./kg/knowledge_graph.db stats
+```
+
+### Ingest from Google Workspace or Microsoft 365
+
+PlanOpticon provides integrated commands that fetch cloud documents and ingest them in one step:
+
+```bash
+# Google Workspace
+planopticon gws ingest --folder-id FOLDER_ID -o ./results
+
+# Microsoft 365 / SharePoint
+planopticon m365 ingest --web-url https://contoso.sharepoint.com/sites/proj \
+    --folder-url /sites/proj/Shared\ Documents
+```
+
+These commands handle authentication, document download, text extraction, and knowledge graph creation automatically.

--- a/docs/guide/export.md
+++ b/docs/guide/export.md
@@ -1,0 +1,756 @@
+# Export
+
+PlanOpticon provides multiple ways to export knowledge graph data into formats suitable for documentation, note-taking, collaboration, and interchange. All export commands work offline from a `knowledge_graph.db` file -- no API key is needed for template-based exports.
+
+## Overview of export options
+
+| Format | Command | API Key | Description |
+|--------|---------|---------|-------------|
+| Markdown documents | `planopticon export markdown` | No | 7 document types: summary, meeting notes, glossary, and more |
+| Obsidian vault | `planopticon export obsidian` | No | YAML frontmatter, `[[wiki-links]]`, tag pages, Map of Content |
+| Notion-compatible | `planopticon export notion` | No | Callout blocks, CSV database for bulk import |
+| PlanOpticonExchange JSON | `planopticon export exchange` | No | Canonical interchange format for merging and sharing |
+| GitHub wiki | `planopticon wiki generate` | No | Home, Sidebar, entity pages, type indexes |
+| GitHub wiki push | `planopticon wiki push` | Git auth | Push generated wiki to a GitHub repo |
+
+## Markdown document generator
+
+The markdown exporter produces structured documents from knowledge graph data using pure template-based generation. No LLM calls are made -- the output is deterministic and based entirely on the entities and relationships in the graph.
+
+### CLI usage
+
+```
+planopticon export markdown DB_PATH [OPTIONS]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `DB_PATH` | Path to a `knowledge_graph.db` file |
+
+**Options:**
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--output` | `-o` | `./export` | Output directory |
+| `--type` | | `all` | Document types to generate (repeatable). Choices: `summary`, `meeting-notes`, `glossary`, `relationship-map`, `status-report`, `entity-index`, `csv`, `all` |
+
+**Examples:**
+
+```bash
+# Generate all document types
+planopticon export markdown knowledge_graph.db
+
+# Generate only summary and glossary
+planopticon export markdown kg.db -o ./docs --type summary --type glossary
+
+# Generate meeting notes and CSV
+planopticon export markdown kg.db --type meeting-notes --type csv
+```
+
+### Document types
+
+#### summary (Executive Summary)
+
+A high-level overview of the knowledge graph. Contains:
+
+- Total entity and relationship counts
+- Entity breakdown by type (table with counts and example names)
+- Key entities ranked by number of connections (top 10)
+- Relationship type breakdown with counts
+
+This is useful for getting a quick overview of what a knowledge base contains.
+
+#### meeting-notes (Meeting Notes)
+
+Formats knowledge graph data as structured meeting notes. Organizes entities into planning-relevant categories:
+
+- **Discussion Topics**: Entities of type `concept`, `technology`, or `topic` with their descriptions
+- **Participants**: Entities of type `person`
+- **Decisions & Constraints**: Entities of type `decision` or `constraint`
+- **Action Items**: Entities of type `goal`, `feature`, or `milestone`, shown as checkboxes. If an entity has an `assigned_to` or `owned_by` relationship, the owner is shown as `@name`
+- **Open Questions / Loose Ends**: Entities with one or fewer relationships (excluding people), indicating topics that may need follow-up
+
+Includes a generation timestamp.
+
+#### glossary (Glossary)
+
+An alphabetically sorted dictionary of all entities in the knowledge graph. Each entry shows:
+
+- Entity name (bold)
+- Entity type (italic, in parentheses)
+- First description
+
+Format:
+
+```
+**Entity Name** *(type)*
+: Description text here.
+```
+
+#### relationship-map (Relationship Map)
+
+A comprehensive view of all relationships in the graph, organized by relationship type. Each type gets its own section with a table of source-target pairs.
+
+Also includes a **Mermaid diagram** of the top 20 most-connected entities, rendered as a `graph LR` flowchart with labeled edges. This diagram can be rendered natively in GitHub, GitLab, Obsidian, and many other Markdown viewers.
+
+#### status-report (Status Report)
+
+A project-oriented status report that highlights planning entities:
+
+- **Overview**: Counts of entities, relationships, features, milestones, requirements, and risks/constraints
+- **Milestones**: Entities of type `milestone` with descriptions
+- **Features**: Table of entities of type `feature` with descriptions (truncated to 60 characters)
+- **Risks & Constraints**: Entities of type `risk` or `constraint`
+
+Includes a generation timestamp.
+
+#### entity-index (Entity Index)
+
+A master index of all entities grouped by type. Each type section lists entities alphabetically with their first description. Shows total entity count and number of types.
+
+#### csv (CSV Export)
+
+A CSV file suitable for spreadsheet import. Columns:
+
+| Column | Description |
+|--------|-------------|
+| Name | Entity name |
+| Type | Entity type |
+| Description | First description |
+| Related To | Semicolon-separated list of entities this entity has outgoing relationships to |
+| Source | First occurrence source |
+
+### Entity briefs
+
+In addition to the selected document types, the `generate_all()` function automatically creates individual entity brief pages in an `entities/` subdirectory. Each brief contains:
+
+- Entity name and type
+- Summary (all descriptions)
+- Outgoing relationships (table of target entities and relationship types)
+- Incoming relationships (table of source entities and relationship types)
+- Source occurrences with timestamps and context text
+
+## Obsidian vault export
+
+The Obsidian exporter creates a complete vault structure with YAML frontmatter, `[[wiki-links]]` for entity cross-references, and Obsidian-compatible metadata.
+
+### CLI usage
+
+```
+planopticon export obsidian DB_PATH [OPTIONS]
+```
+
+**Options:**
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--output` | `-o` | `./obsidian-vault` | Output vault directory |
+
+**Example:**
+
+```bash
+planopticon export obsidian knowledge_graph.db -o ./my-vault
+```
+
+### Generated structure
+
+```
+my-vault/
+  _Index.md              # Map of Content (MOC)
+  Tag - Person.md        # One tag page per entity type
+  Tag - Technology.md
+  Tag - Concept.md
+  Alice.md               # Individual entity notes
+  Python.md
+  Microservices.md
+  ...
+```
+
+### Entity notes
+
+Each entity gets a dedicated note with:
+
+**YAML frontmatter:**
+
+```yaml
+---
+type: technology
+tags:
+  - technology
+aliases:
+  - Python 3
+  - CPython
+date: 2026-03-07
+---
+```
+
+The frontmatter includes:
+
+- `type`: The entity type
+- `tags`: Entity type as a tag (for Obsidian tag-based filtering)
+- `aliases`: Any known aliases for the entity (if available)
+- `date`: The export date
+
+**Body content:**
+
+- `# Entity Name` heading
+- Description paragraphs
+- `## Relationships` section with `[[wiki-links]]` to related entities:
+    ```
+    - **uses**: [[FastAPI]]
+    - **depends_on**: [[PostgreSQL]]
+    ```
+- `## Referenced by` section with incoming relationships:
+    ```
+    - **implements** from [[Backend Service]]
+    ```
+
+### Index note (Map of Content)
+
+The `_Index.md` file serves as a Map of Content (MOC), listing all entities grouped by type with `[[wiki-links]]`:
+
+```markdown
+---
+type: index
+tags:
+  - MOC
+date: 2026-03-07
+---
+
+# Index
+
+**47** entities | **31** relationships
+
+## Concept
+
+- [[Microservices]]
+- [[REST API]]
+
+## Person
+
+- [[Alice]]
+- [[Bob]]
+```
+
+### Tag pages
+
+One tag page is created per entity type (e.g., `Tag - Person.md`, `Tag - Technology.md`). Each page has frontmatter tagging it with the entity type and lists all entities of that type with descriptions.
+
+## Notion-compatible markdown export
+
+The Notion exporter creates Markdown files with Notion-style callout blocks and a CSV database file for bulk import into Notion.
+
+### CLI usage
+
+```
+planopticon export notion DB_PATH [OPTIONS]
+```
+
+**Options:**
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--output` | `-o` | `./notion-export` | Output directory |
+
+**Example:**
+
+```bash
+planopticon export notion knowledge_graph.db -o ./notion-export
+```
+
+### Generated structure
+
+```
+notion-export/
+  Overview.md              # Knowledge graph overview page
+  entities_database.csv    # CSV for Notion database import
+  Alice.md                 # Individual entity pages
+  Python.md
+  ...
+```
+
+### Entity pages
+
+Each entity page uses Notion-style callout syntax for metadata:
+
+```markdown
+# Python
+
+> :computer: **Type:** technology
+
+## Description
+
+A high-level programming language...
+
+> :memo: **Properties**
+> - **version:** 3.11
+> - **paradigm:** multi-paradigm
+
+## Relationships
+
+| Target | Relationship |
+|--------|-------------|
+| FastAPI | uses |
+| Django | framework_for |
+
+## Referenced by
+
+| Source | Relationship |
+|--------|-------------|
+| Backend Service | implements |
+```
+
+### CSV database
+
+The `entities_database.csv` file contains all entities in a format suitable for Notion's CSV database import:
+
+| Column | Description |
+|--------|-------------|
+| Name | Entity name |
+| Type | Entity type |
+| Description | First two descriptions, semicolon-separated |
+| Related To | Comma-separated list of outgoing relationship targets |
+
+### Overview page
+
+The `Overview.md` page provides a summary with entity counts and a grouped listing of all entities by type.
+
+## GitHub wiki generator
+
+The wiki generator creates a complete set of GitHub wiki pages from a knowledge graph, including navigation (Home page and Sidebar) and cross-linked entity pages.
+
+### CLI usage
+
+**Generate wiki pages locally:**
+
+```
+planopticon wiki generate DB_PATH [OPTIONS]
+```
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--output` | `-o` | `./wiki` | Output directory for wiki pages |
+| `--title` | | `Knowledge Base` | Wiki title (shown on Home page) |
+
+**Push wiki pages to GitHub:**
+
+```
+planopticon wiki push WIKI_DIR REPO [OPTIONS]
+```
+
+| Argument | Description |
+|----------|-------------|
+| `WIKI_DIR` | Path to the directory containing generated wiki `.md` files |
+| `REPO` | GitHub repository in `owner/repo` format |
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--message` | `-m` | `Update wiki` | Git commit message |
+
+**Examples:**
+
+```bash
+# Generate wiki pages
+planopticon wiki generate knowledge_graph.db -o ./wiki
+
+# Generate with a custom title
+planopticon wiki generate kg.db -o ./wiki --title "Project Wiki"
+
+# Push to GitHub
+planopticon wiki push ./wiki ConflictHQ/PlanOpticon
+
+# Push with a custom commit message
+planopticon wiki push ./wiki owner/repo -m "Add entity pages"
+```
+
+### Generated pages
+
+The wiki generator creates the following pages:
+
+| Page | Description |
+|------|-------------|
+| `Home.md` | Main wiki page with entity counts, type links, and artifact links |
+| `_Sidebar.md` | Navigation sidebar with links to Home, entity type indexes, and artifacts |
+| `{Type}.md` | One index page per entity type with a table of entities and descriptions |
+| `{Entity}.md` | Individual entity pages with type, descriptions, relationships, and sources |
+
+### Entity pages
+
+Each entity page contains:
+
+- Entity name as the top heading
+- **Type** label
+- **Descriptions** section (bullet list)
+- **Relationships** table with wiki-style links to target entities
+- **Referenced By** table with links to source entities
+- **Sources** section listing occurrences with timestamps and context
+
+All entity and type names are cross-linked using GitHub wiki-compatible links (`[Name](Sanitized-Name)`).
+
+### Push behavior
+
+The `wiki push` command:
+
+1. Clones the existing GitHub wiki repository (`https://github.com/{repo}.wiki.git`).
+2. If the wiki does not exist yet, initializes a new Git repository.
+3. Copies all `.md` files from the wiki directory into the clone.
+4. Commits the changes.
+5. Pushes to the remote (tries `master` first, then `main`).
+
+This requires Git authentication with push access to the repository. The wiki must be enabled in the GitHub repository settings.
+
+## PlanOpticonExchange JSON format
+
+The PlanOpticonExchange is the canonical interchange format for PlanOpticon data. Every command produces it, and every export adapter can consume it. It provides a structured, versioned JSON representation of a complete knowledge graph with project metadata.
+
+### CLI usage
+
+```
+planopticon export exchange DB_PATH [OPTIONS]
+```
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--output` | `-o` | `./exchange.json` | Output JSON file path |
+| `--name` | | `Untitled` | Project name for the exchange payload |
+| `--description` | | (empty) | Project description |
+
+**Examples:**
+
+```bash
+# Basic export
+planopticon export exchange knowledge_graph.db
+
+# With project metadata
+planopticon export exchange kg.db -o exchange.json --name "My Project" --description "Sprint 3 analysis"
+```
+
+### Schema
+
+The exchange format has the following top-level structure:
+
+```json
+{
+  "version": "1.0",
+  "project": {
+    "name": "My Project",
+    "description": "Sprint 3 analysis",
+    "created_at": "2026-03-07T10:30:00.000000",
+    "updated_at": "2026-03-07T10:30:00.000000",
+    "tags": ["sprint-3", "backend"]
+  },
+  "entities": [
+    {
+      "name": "Python",
+      "type": "technology",
+      "descriptions": ["A high-level programming language"],
+      "source": "transcript",
+      "occurrences": [
+        {
+          "source": "meeting.mp4",
+          "timestamp": "00:05:23",
+          "text": "We should use Python for the backend"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "source": "Python",
+      "target": "Backend Service",
+      "type": "used_by",
+      "content_source": "transcript:meeting.mp4",
+      "timestamp": 323.0
+    }
+  ],
+  "artifacts": [
+    {
+      "name": "Project Plan",
+      "content": "# Project Plan\n\n...",
+      "artifact_type": "project_plan",
+      "format": "markdown",
+      "metadata": {}
+    }
+  ],
+  "sources": [
+    {
+      "source_id": "abc123",
+      "source_type": "video",
+      "title": "Sprint Planning Meeting",
+      "path": "/recordings/meeting.mp4",
+      "url": null,
+      "mime_type": "video/mp4",
+      "ingested_at": "2026-03-07T10:00:00.000000",
+      "metadata": {}
+    }
+  ]
+}
+```
+
+**Top-level fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | `str` | Schema version (currently `"1.0"`) |
+| `project` | `ProjectMeta` | Project-level metadata |
+| `entities` | `List[Entity]` | Knowledge graph entities |
+| `relationships` | `List[Relationship]` | Knowledge graph relationships |
+| `artifacts` | `List[ArtifactMeta]` | Generated artifacts (plans, PRDs, etc.) |
+| `sources` | `List[SourceRecord]` | Content source provenance records |
+
+### Merging exchange files
+
+The exchange format supports merging, with automatic deduplication:
+
+- Entities are deduplicated by name
+- Relationships are deduplicated by the tuple `(source, target, type)`
+- Artifacts are deduplicated by name
+- Sources are deduplicated by `source_id`
+
+```python
+from video_processor.exchange import PlanOpticonExchange
+
+# Load two exchange files
+ex1 = PlanOpticonExchange.from_file("sprint-1.json")
+ex2 = PlanOpticonExchange.from_file("sprint-2.json")
+
+# Merge ex2 into ex1
+ex1.merge(ex2)
+
+# Save the combined result
+ex1.to_file("combined.json")
+```
+
+The `project.updated_at` timestamp is updated automatically on merge.
+
+### Python API
+
+**Create from a knowledge graph:**
+
+```python
+from video_processor.exchange import PlanOpticonExchange
+from video_processor.integrators.knowledge_graph import KnowledgeGraph
+
+kg = KnowledgeGraph(db_path="knowledge_graph.db")
+kg_data = kg.to_dict()
+
+exchange = PlanOpticonExchange.from_knowledge_graph(
+    kg_data,
+    project_name="My Project",
+    project_description="Analysis of sprint planning meetings",
+    tags=["planning", "backend"],
+)
+```
+
+**Save and load:**
+
+```python
+# Save to file
+exchange.to_file("exchange.json")
+
+# Load from file
+loaded = PlanOpticonExchange.from_file("exchange.json")
+```
+
+**Get JSON Schema:**
+
+```python
+schema = PlanOpticonExchange.json_schema()
+```
+
+This returns the full JSON Schema for validation and documentation purposes.
+
+## Python API for all exporters
+
+### Markdown document generation
+
+```python
+from pathlib import Path
+from video_processor.exporters.markdown import (
+    generate_all,
+    generate_executive_summary,
+    generate_meeting_notes,
+    generate_glossary,
+    generate_relationship_map,
+    generate_status_report,
+    generate_entity_index,
+    generate_csv_export,
+    generate_entity_brief,
+    DOCUMENT_TYPES,
+)
+from video_processor.integrators.knowledge_graph import KnowledgeGraph
+
+kg = KnowledgeGraph(db_path=Path("knowledge_graph.db"))
+kg_data = kg.to_dict()
+
+# Generate all document types at once
+created_files = generate_all(kg_data, Path("./export"))
+
+# Generate specific document types
+created_files = generate_all(
+    kg_data,
+    Path("./export"),
+    doc_types=["summary", "glossary", "csv"],
+)
+
+# Generate individual documents (returns markdown string)
+summary = generate_executive_summary(kg_data)
+notes = generate_meeting_notes(kg_data, title="Sprint Planning")
+glossary = generate_glossary(kg_data)
+rel_map = generate_relationship_map(kg_data)
+status = generate_status_report(kg_data, title="Q1 Status")
+index = generate_entity_index(kg_data)
+csv_text = generate_csv_export(kg_data)
+
+# Generate a brief for a single entity
+entity = kg_data["nodes"][0]
+relationships = kg_data["relationships"]
+brief = generate_entity_brief(entity, relationships)
+```
+
+### Obsidian export
+
+```python
+from pathlib import Path
+from video_processor.agent.skills.notes_export import export_to_obsidian
+from video_processor.integrators.knowledge_graph import KnowledgeGraph
+
+kg = KnowledgeGraph(db_path=Path("knowledge_graph.db"))
+kg_data = kg.to_dict()
+
+created_files = export_to_obsidian(kg_data, Path("./obsidian-vault"))
+print(f"Created {len(created_files)} files")
+```
+
+### Notion export
+
+```python
+from pathlib import Path
+from video_processor.agent.skills.notes_export import export_to_notion_md
+from video_processor.integrators.knowledge_graph import KnowledgeGraph
+
+kg = KnowledgeGraph(db_path=Path("knowledge_graph.db"))
+kg_data = kg.to_dict()
+
+created_files = export_to_notion_md(kg_data, Path("./notion-export"))
+```
+
+### Wiki generation
+
+```python
+from pathlib import Path
+from video_processor.agent.skills.wiki_generator import (
+    generate_wiki,
+    write_wiki,
+    push_wiki,
+)
+from video_processor.integrators.knowledge_graph import KnowledgeGraph
+
+kg = KnowledgeGraph(db_path=Path("knowledge_graph.db"))
+kg_data = kg.to_dict()
+
+# Generate pages as a dict of {filename: content}
+pages = generate_wiki(kg_data, title="Project Wiki")
+
+# Write to disk
+written = write_wiki(pages, Path("./wiki"))
+
+# Push to GitHub (requires git auth)
+success = push_wiki(Path("./wiki"), "owner/repo", message="Update wiki")
+```
+
+## Companion REPL
+
+Inside the interactive companion REPL, use the `/export` command:
+
+```
+> /export markdown
+Export 'markdown' requested. Use the CLI command:
+  planopticon export markdown ./knowledge_graph.db
+
+> /export obsidian
+Export 'obsidian' requested. Use the CLI command:
+  planopticon export obsidian ./knowledge_graph.db
+```
+
+The REPL provides guidance on the CLI command to run; actual export is performed via the CLI.
+
+## Common workflows
+
+### Analyze videos and export to Obsidian
+
+```bash
+# Analyze meeting recordings
+planopticon analyze meeting-1.mp4 -o ./results
+planopticon analyze meeting-2.mp4 --db-path ./results/knowledge_graph.db
+
+# Ingest supplementary docs
+planopticon ingest ./specs/ --db-path ./results/knowledge_graph.db
+
+# Export to Obsidian vault
+planopticon export obsidian ./results/knowledge_graph.db -o ~/Obsidian/ProjectVault
+
+# Open in Obsidian and explore the graph view
+```
+
+### Generate project documentation
+
+```bash
+# Generate all markdown documents
+planopticon export markdown knowledge_graph.db -o ./docs
+
+# The output includes:
+#   docs/summary.md           - Executive summary
+#   docs/meeting-notes.md     - Meeting notes format
+#   docs/glossary.md          - Entity glossary
+#   docs/relationship-map.md  - Relationships + Mermaid diagram
+#   docs/status-report.md     - Project status report
+#   docs/entity-index.md      - Master entity index
+#   docs/csv.csv              - Spreadsheet-ready CSV
+#   docs/entities/             - Individual entity briefs
+```
+
+### Publish a GitHub wiki
+
+```bash
+# Generate wiki pages
+planopticon wiki generate knowledge_graph.db -o ./wiki --title "Project Knowledge Base"
+
+# Review locally, then push
+planopticon wiki push ./wiki ConflictHQ/my-project -m "Initial wiki from meeting analysis"
+```
+
+### Share data between projects
+
+```bash
+# Export from project A
+planopticon export exchange ./project-a/knowledge_graph.db \
+    -o project-a.json --name "Project A"
+
+# Export from project B
+planopticon export exchange ./project-b/knowledge_graph.db \
+    -o project-b.json --name "Project B"
+
+# Merge in Python
+python -c "
+from video_processor.exchange import PlanOpticonExchange
+a = PlanOpticonExchange.from_file('project-a.json')
+b = PlanOpticonExchange.from_file('project-b.json')
+a.merge(b)
+a.to_file('combined.json')
+print(f'Combined: {len(a.entities)} entities, {len(a.relationships)} relationships')
+"
+```
+
+### Export for spreadsheet analysis
+
+```bash
+# Generate just the CSV
+planopticon export markdown knowledge_graph.db --type csv -o ./export
+
+# The file export/csv.csv can be opened in Excel, Google Sheets, etc.
+```
+
+Alternatively, the Notion export includes an `entities_database.csv` that can be imported into any spreadsheet tool or Notion database.

--- a/docs/guide/knowledge-graphs.md
+++ b/docs/guide/knowledge-graphs.md
@@ -1,0 +1,650 @@
+# Knowledge Graphs
+
+PlanOpticon builds structured knowledge graphs from video analyses, document ingestion, and other content sources. A knowledge graph captures **entities** (people, technologies, concepts, organizations) and the **relationships** between them, providing a queryable representation of everything discussed or presented in your source material.
+
+---
+
+## Storage
+
+Knowledge graphs are stored as SQLite databases (`knowledge_graph.db`) using Python's built-in `sqlite3` module. This means:
+
+- **Zero external dependencies.** No database server to install or manage.
+- **Single-file portability.** Copy the `.db` file to share a knowledge graph.
+- **WAL mode.** SQLite Write-Ahead Logging is enabled for concurrent read performance.
+- **JSON fallback.** Knowledge graphs can also be saved as `knowledge_graph.json` for interoperability, though SQLite is preferred for performance and querying.
+
+### Database Schema
+
+The SQLite store uses the following tables:
+
+| Table | Purpose |
+|---|---|
+| `entities` | Core entity records with name, type, descriptions, source, and arbitrary properties |
+| `occurrences` | Where and when each entity was mentioned (source, timestamp, text snippet) |
+| `relationships` | Directed edges between entities with type, content source, timestamp, and properties |
+| `sources` | Registered content sources with provenance metadata (source type, title, path, URL, MIME type, ingestion timestamp) |
+| `source_locations` | Links between sources and specific entities/relationships, with location details (timestamp, page, section, line range, text snippet) |
+
+All entity lookups are case-insensitive (indexed on `name_lower`). Entities and relationships are indexed on their source and target fields for efficient traversal.
+
+### Storage Backends
+
+PlanOpticon supports two storage backends, selected automatically:
+
+| Backend | When Used | Persistence |
+|---|---|---|
+| `SQLiteStore` | When a `db_path` is provided | Persistent on disk |
+| `InMemoryStore` | When no path is given, or as fallback | In-memory only |
+
+Both backends implement the same `GraphStore` abstract interface, so all query and manipulation code works identically regardless of backend.
+
+```python
+from video_processor.integrators.graph_store import create_store
+
+# Persistent SQLite store
+store = create_store("/path/to/knowledge_graph.db")
+
+# In-memory store (for temporary operations)
+store = create_store()
+```
+
+---
+
+## Entity Types
+
+Entities extracted from content are assigned one of the following base types:
+
+| Type | Description | Specificity Rank |
+|---|---|---|
+| `person` | People mentioned or participating | 3 (highest) |
+| `technology` | Tools, languages, frameworks, platforms | 3 |
+| `organization` | Companies, teams, departments | 2 |
+| `time` | Dates, deadlines, time references | 1 |
+| `diagram` | Visual diagrams extracted from video frames | 1 |
+| `concept` | General concepts, topics, ideas (default) | 0 (lowest) |
+
+The specificity rank is used during merge operations: when two entities are matched as duplicates, the more specific type wins (e.g., `technology` overrides `concept`).
+
+### Planning Taxonomy
+
+Beyond the base entity types, PlanOpticon includes a planning taxonomy for classifying entities into project-planning categories. The `TaxonomyClassifier` maps extracted entities into these types:
+
+| Planning Type | Keywords Matched |
+|---|---|
+| `goal` | goal, objective, aim, target outcome |
+| `requirement` | must, should, requirement, need, required |
+| `constraint` | constraint, limitation, restrict, cannot, must not |
+| `decision` | decided, decision, chose, selected, agreed |
+| `risk` | risk, concern, worry, danger, threat |
+| `assumption` | assume, assumption, expecting, presume |
+| `dependency` | depends, dependency, relies on, prerequisite, blocked |
+| `milestone` | milestone, deadline, deliverable, release, launch |
+| `task` | task, todo, action item, work item, implement |
+| `feature` | feature, capability, functionality |
+
+Classification works in two stages:
+
+1. **Heuristic classification.** Entity descriptions are scanned for the keywords listed above. First match wins.
+2. **LLM refinement.** If an LLM provider is available, entities are sent to the LLM for more nuanced classification with priority assignment (`high`, `medium`, `low`). LLM results override heuristic results on conflicts.
+
+Classified entities are used by planning agent skills (project_plan, prd, roadmap, task_breakdown) to produce targeted, context-aware artifacts.
+
+---
+
+## Relationship Types
+
+Relationships are directed edges between entities. The `type` field is a free-text string determined by the LLM during extraction. Common relationship types include:
+
+- `related_to` (default)
+- `works_with`
+- `uses`
+- `depends_on`
+- `proposed`
+- `discussed_by`
+- `employed_by`
+- `collaborates_with`
+- `expert_in`
+
+### Typed Relationships
+
+The `add_typed_relationship()` method creates edges with custom labels and optional properties, enabling richer graph semantics:
+
+```python
+store.add_typed_relationship(
+    source="Authentication Service",
+    target="PostgreSQL",
+    edge_label="USES_SYSTEM",
+    properties={"purpose": "user credential storage", "version": "15"},
+)
+```
+
+### Relationship Checks
+
+You can check whether a relationship exists between two entities:
+
+```python
+# Check for any relationship
+store.has_relationship("Alice", "Kubernetes")
+
+# Check for a specific relationship type
+store.has_relationship("Alice", "Kubernetes", edge_label="expert_in")
+```
+
+---
+
+## Building a Knowledge Graph
+
+### From Video Analysis
+
+The primary path for building a knowledge graph is through video analysis. When you run `planopticon analyze`, the pipeline extracts entities and relationships from:
+
+- **Transcript segments** -- batched in groups of 10 for efficient API usage, with speaker identification
+- **Diagram content** -- text extracted from visual diagrams detected in video frames
+
+```bash
+planopticon analyze -i meeting.mp4 -o results/
+# Creates results/knowledge_graph.db
+```
+
+### From Document Ingestion
+
+Documents (Markdown, PDF, DOCX) can be ingested directly into a knowledge graph:
+
+```bash
+# Ingest a single file
+planopticon ingest -i requirements.pdf -o results/
+
+# Ingest a directory recursively
+planopticon ingest -i docs/ -o results/ --recursive
+
+# Ingest into an existing knowledge graph
+planopticon ingest -i notes.md --db results/knowledge_graph.db
+```
+
+### From Batch Processing
+
+Multiple videos can be processed in batch mode, with all results merged into a single knowledge graph:
+
+```bash
+planopticon batch -i videos/ -o results/
+```
+
+### Programmatic Construction
+
+```python
+from video_processor.integrators.knowledge_graph import KnowledgeGraph
+
+# Create a new knowledge graph with LLM extraction
+from video_processor.providers.manager import ProviderManager
+pm = ProviderManager()
+kg = KnowledgeGraph(provider_manager=pm, db_path="knowledge_graph.db")
+
+# Add content (entities and relationships are extracted by LLM)
+kg.add_content(
+    text="Alice proposed using Kubernetes for container orchestration.",
+    source="meeting_notes",
+    timestamp=120.5,
+)
+
+# Process a full transcript
+kg.process_transcript(transcript_data, batch_size=10)
+
+# Process diagram results
+kg.process_diagrams(diagram_results)
+
+# Save
+kg.save("knowledge_graph.db")
+```
+
+---
+
+## Merge and Deduplication
+
+When combining knowledge graphs from multiple sources, PlanOpticon performs intelligent merge with deduplication.
+
+### Fuzzy Name Matching
+
+Entity names are compared using Python's `SequenceMatcher` with a threshold of 0.85. This means "Kubernetes" and "kubernetes" are matched exactly (case-insensitive), while "React.js" and "ReactJS" may be matched as duplicates if their similarity ratio meets the threshold.
+
+### Type Conflict Resolution
+
+When two entities match but have different types, the more specific type wins based on the specificity ranking:
+
+| Scenario | Result |
+|---|---|
+| `concept` vs `technology` | `technology` wins (rank 3 > rank 0) |
+| `person` vs `concept` | `person` wins (rank 3 > rank 0) |
+| `organization` vs `concept` | `organization` wins (rank 2 > rank 0) |
+| `person` vs `technology` | Keeps whichever was first (equal rank) |
+
+### Provenance Tracking
+
+Merged entities receive a `merged_from:<original_name>` description entry, preserving the audit trail of which entities were unified.
+
+### Programmatic Merge
+
+```python
+from video_processor.integrators.knowledge_graph import KnowledgeGraph
+
+# Load two knowledge graphs
+kg1 = KnowledgeGraph(db_path="project_a.db")
+kg2 = KnowledgeGraph(db_path="project_b.db")
+
+# Merge kg2 into kg1
+kg1.merge(kg2)
+
+# Save the merged result
+kg1.save("merged.db")
+```
+
+The merge operation also copies all registered sources and occurrences, so provenance information is preserved across merges.
+
+---
+
+## Querying
+
+PlanOpticon provides two query modes: direct mode (no LLM required) and agentic mode (LLM-powered natural language).
+
+### Direct Mode
+
+Direct mode queries are fast, deterministic, and require no API key. They are the right choice for structured lookups.
+
+#### Stats
+
+Return entity count, relationship count, and entity type breakdown:
+
+```bash
+planopticon query
+```
+
+```python
+engine.stats()
+# QueryResult with data: {
+#   "entity_count": 42,
+#   "relationship_count": 87,
+#   "entity_types": {"technology": 15, "person": 12, ...}
+# }
+```
+
+#### Entities
+
+Filter entities by name substring and/or type:
+
+```bash
+planopticon query "entities --type technology"
+planopticon query "entities --name python"
+```
+
+```python
+engine.entities(entity_type="technology")
+engine.entities(name="python")
+engine.entities(name="auth", entity_type="concept", limit=10)
+```
+
+All filtering is case-insensitive. Results are capped at 50 by default (configurable via `limit`).
+
+#### Neighbors
+
+Get an entity and all directly connected nodes and relationships:
+
+```bash
+planopticon query "neighbors Alice"
+```
+
+```python
+engine.neighbors("Alice", depth=1)
+```
+
+The `depth` parameter controls how many hops to traverse (default 1). The result includes both entity objects and relationship objects.
+
+#### Relationships
+
+Filter relationships by source, target, and/or type:
+
+```bash
+planopticon query "relationships --source Alice"
+```
+
+```python
+engine.relationships(source="Alice")
+engine.relationships(target="Kubernetes", rel_type="uses")
+```
+
+#### Sources
+
+List all registered content sources:
+
+```python
+engine.sources()
+```
+
+#### Provenance
+
+Get all source locations for a specific entity, showing exactly where it was mentioned:
+
+```python
+engine.provenance("Kubernetes")
+# Returns source locations with timestamps, pages, sections, and text snippets
+```
+
+#### Raw SQL
+
+Execute arbitrary SQL against the SQLite backend (SQLite stores only):
+
+```python
+engine.sql("SELECT name, type FROM entities WHERE type = 'technology' ORDER BY name")
+```
+
+### Agentic Mode
+
+Agentic mode accepts natural-language questions and uses the LLM to plan and execute queries. It requires a configured LLM provider.
+
+```bash
+planopticon query "What technologies were discussed?"
+planopticon query "Who are the key people mentioned?"
+planopticon query "What depends on the authentication service?"
+```
+
+The agentic query pipeline:
+
+1. **Plan.** The LLM receives graph stats and available actions (entities, relationships, neighbors, stats). It selects exactly one action and its parameters.
+2. **Execute.** The chosen action is run through the direct-mode engine.
+3. **Synthesize.** The LLM receives the raw query results and the original question, then produces a concise natural-language answer.
+
+This design ensures the LLM never generates arbitrary code -- it only selects from a fixed set of known query actions.
+
+```bash
+# Requires an API key
+planopticon query "What technologies were discussed?" -p openai
+
+# Use the interactive REPL for multiple queries
+planopticon query -I
+```
+
+---
+
+## Graph Query Engine Python API
+
+The `GraphQueryEngine` class provides the programmatic interface for all query operations.
+
+### Initialization
+
+```python
+from video_processor.integrators.graph_query import GraphQueryEngine
+from video_processor.integrators.graph_discovery import find_nearest_graph
+
+# From a .db file
+path = find_nearest_graph()
+engine = GraphQueryEngine.from_db_path(path)
+
+# From a .json file
+engine = GraphQueryEngine.from_json_path("knowledge_graph.json")
+
+# With an LLM provider for agentic mode
+from video_processor.providers.manager import ProviderManager
+pm = ProviderManager()
+engine = GraphQueryEngine.from_db_path(path, provider_manager=pm)
+```
+
+### QueryResult
+
+All query methods return a `QueryResult` dataclass with multiple output formats:
+
+```python
+result = engine.stats()
+
+# Human-readable text
+print(result.to_text())
+
+# JSON string
+print(result.to_json())
+
+# Mermaid diagram (for graph results)
+result = engine.neighbors("Alice")
+print(result.to_mermaid())
+```
+
+The `QueryResult` contains:
+
+| Field | Type | Description |
+|---|---|---|
+| `data` | Any | The raw result data (dict, list, or scalar) |
+| `query_type` | str | `"filter"` for direct mode, `"agentic"` for LLM mode, `"sql"` for raw SQL |
+| `raw_query` | str | String representation of the executed query |
+| `explanation` | str | Human-readable explanation or LLM-synthesized answer |
+
+---
+
+## The Self-Contained HTML Viewer
+
+PlanOpticon includes a zero-dependency HTML knowledge graph viewer at `knowledge-base/viewer.html`. This file is fully self-contained -- it inlines D3.js and requires no build step, no server, and no internet connection.
+
+To use it, open `viewer.html` in a browser. It will load and visualize a `knowledge_graph.json` file (place it in the same directory, or use the file picker in the viewer).
+
+The viewer provides:
+
+- Interactive force-directed graph layout
+- Zoom and pan navigation
+- Entity nodes colored by type
+- Relationship edges with labels
+- Click-to-focus on individual entities
+- Entity detail panel showing descriptions and connections
+
+This covers approximately 80% of graph exploration needs with zero infrastructure.
+
+---
+
+## KG Management Commands
+
+The `planopticon kg` command group provides utilities for managing knowledge graph files.
+
+### kg convert
+
+Convert a knowledge graph between SQLite and JSON formats:
+
+```bash
+# SQLite to JSON
+planopticon kg convert results/knowledge_graph.db output.json
+
+# JSON to SQLite
+planopticon kg convert knowledge_graph.json knowledge_graph.db
+```
+
+The output format is inferred from the destination file extension. Source and destination must be different formats.
+
+### kg sync
+
+Synchronize a `.db` and `.json` knowledge graph, updating the stale one:
+
+```bash
+# Auto-detect which is newer and sync
+planopticon kg sync results/knowledge_graph.db
+
+# Explicit JSON path
+planopticon kg sync knowledge_graph.db knowledge_graph.json
+
+# Force a specific direction
+planopticon kg sync knowledge_graph.db knowledge_graph.json --direction db-to-json
+planopticon kg sync knowledge_graph.db knowledge_graph.json --direction json-to-db
+```
+
+If `JSON_PATH` is omitted, the `.json` path is derived from the `.db` path (same name, different extension). In `auto` mode (the default), the newer file is used as the source.
+
+### kg inspect
+
+Show summary statistics for a knowledge graph file:
+
+```bash
+planopticon kg inspect results/knowledge_graph.db
+```
+
+Output:
+
+```
+File: results/knowledge_graph.db
+Store: sqlite
+Entities: 42
+Relationships: 87
+Entity types:
+  technology: 15
+  person: 12
+  concept: 10
+  organization: 5
+```
+
+Works with both `.db` and `.json` files.
+
+### kg classify
+
+Classify knowledge graph entities into planning taxonomy types:
+
+```bash
+# Heuristic + LLM classification
+planopticon kg classify results/knowledge_graph.db
+
+# Heuristic only (no API key needed)
+planopticon kg classify results/knowledge_graph.db -p none
+
+# JSON output
+planopticon kg classify results/knowledge_graph.db --format json
+```
+
+Text output groups entities by planning type:
+
+```
+GOALS (3)
+  - Improve system reliability [high]
+    Must achieve 99.9% uptime
+  - Reduce deployment time [medium]
+    Automate the deployment pipeline
+
+RISKS (2)
+  - Data migration complexity [high]
+    Legacy schema incompatibilities
+  ...
+
+TASKS (5)
+  - Implement OAuth2 flow
+    Set up authentication service
+  ...
+```
+
+JSON output returns an array of `PlanningEntity` objects with `name`, `planning_type`, `priority`, `description`, and `source_entities` fields.
+
+### kg from-exchange
+
+Import a PlanOpticonExchange JSON file into a knowledge graph database:
+
+```bash
+# Import to default location (./knowledge_graph.db)
+planopticon kg from-exchange exchange.json
+
+# Import to a specific path
+planopticon kg from-exchange exchange.json -o project.db
+```
+
+The PlanOpticonExchange format is a standardized interchange format that includes entities, relationships, and source records.
+
+---
+
+## Output Formats
+
+Query results can be output in three formats:
+
+### Text (default)
+
+Human-readable format with entity types in brackets, relationship arrows, and indented details:
+
+```
+Found 15 entities
+  [technology] Python -- General-purpose programming language
+  [person] Alice -- Lead engineer on the project
+  [concept] Microservices -- Architectural pattern discussed
+```
+
+### JSON
+
+Full structured output including query metadata:
+
+```bash
+planopticon query --format json stats
+```
+
+```json
+{
+  "query_type": "filter",
+  "raw_query": "stats()",
+  "explanation": "Knowledge graph statistics",
+  "data": {
+    "entity_count": 42,
+    "relationship_count": 87,
+    "entity_types": {
+      "technology": 15,
+      "person": 12
+    }
+  }
+}
+```
+
+### Mermaid
+
+Graph results rendered as Mermaid diagram syntax, ready for embedding in markdown:
+
+```bash
+planopticon query --format mermaid "neighbors Alice"
+```
+
+```
+graph LR
+    Alice["Alice"]:::person
+    Python["Python"]:::technology
+    Kubernetes["Kubernetes"]:::technology
+    Alice -- "expert_in" --> Kubernetes
+    Alice -- "works_with" --> Python
+    classDef person fill:#f9d5e5,stroke:#333
+    classDef concept fill:#eeeeee,stroke:#333
+    classDef technology fill:#d5e5f9,stroke:#333
+    classDef organization fill:#f9e5d5,stroke:#333
+```
+
+The `KnowledgeGraph.generate_mermaid()` method also produces full-graph Mermaid diagrams, capped at the top 30 most-connected nodes by default.
+
+---
+
+## Auto-Discovery
+
+PlanOpticon automatically locates knowledge graph files using the `find_nearest_graph()` function. The search order is:
+
+1. **Current directory** -- check for `knowledge_graph.db` and `knowledge_graph.json`
+2. **Common subdirectories** -- `results/`, `output/`, `knowledge-base/`
+3. **Recursive downward walk** -- up to 4 levels deep, skipping hidden directories
+4. **Parent directory walk** -- upward through the directory tree, checking each level and its common subdirectories
+
+Within each search phase, `.db` files are preferred over `.json` files. Results are sorted by proximity (closest first).
+
+```python
+from video_processor.integrators.graph_discovery import (
+    find_nearest_graph,
+    find_knowledge_graphs,
+    describe_graph,
+)
+
+# Find the single closest knowledge graph
+path = find_nearest_graph()
+
+# Find all knowledge graphs, sorted by proximity
+paths = find_knowledge_graphs()
+
+# Find graphs starting from a specific directory
+paths = find_knowledge_graphs(start_dir="/path/to/project")
+
+# Disable upward walking
+paths = find_knowledge_graphs(walk_up=False)
+
+# Get summary stats without loading the full graph
+info = describe_graph(path)
+# {"entity_count": 42, "relationship_count": 87,
+#  "entity_types": {...}, "store_type": "sqlite"}
+```
+
+Auto-discovery is used by the Companion REPL, the `planopticon query` command, and the planning agent when no explicit `--kb` path is provided.

--- a/docs/guide/output-formats.md
+++ b/docs/guide/output-formats.md
@@ -1,47 +1,329 @@
 # Output Formats
 
-PlanOpticon produces multiple output formats from each analysis run.
+PlanOpticon produces a wide range of output formats from video analysis, document ingestion, batch processing, knowledge graph export, and agent skills. This page is the comprehensive reference for every format the tool can emit.
+
+---
 
 ## Transcripts
 
+Video analysis always produces transcripts in three formats, stored in the `transcript/` subdirectory of the output folder.
+
 | Format | File | Description |
 |--------|------|-------------|
-| JSON | `transcript/transcript.json` | Full transcript with segments, timestamps, speakers |
-| Text | `transcript/transcript.txt` | Plain text transcript |
-| SRT | `transcript/transcript.srt` | Subtitle format with timestamps |
+| JSON | `transcript/transcript.json` | Full transcript with segments, timestamps, speaker labels, and confidence scores. Each segment includes `start`, `end`, `text`, and optional `speaker` fields. |
+| Text | `transcript/transcript.txt` | Plain text transcript with no metadata. Suitable for feeding into other tools or reading directly. |
+| SRT | `transcript/transcript.srt` | SubRip subtitle format with sequential numbering and `HH:MM:SS,mmm` timestamps. Can be loaded into video players or subtitle editors. |
+
+### Transcript JSON structure
+
+```json
+{
+  "segments": [
+    {
+      "start": 0.0,
+      "end": 4.5,
+      "text": "Welcome to the sprint review.",
+      "speaker": "Alice"
+    }
+  ],
+  "text": "Welcome to the sprint review. ...",
+  "language": "en"
+}
+```
+
+When the `--speakers` flag is provided (e.g., `--speakers "Alice,Bob,Carol"`), speaker diarization hints are passed to the transcription provider and speaker labels appear in the JSON segments.
+
+---
 
 ## Reports
 
+Analysis reports are generated from the combined transcript, diagrams, key points, action items, and knowledge graph. They live in the `results/` subdirectory.
+
 | Format | File | Description |
 |--------|------|-------------|
-| Markdown | `results/analysis.md` | Structured report with diagrams |
-| HTML | `results/analysis.html` | Self-contained HTML with mermaid.js |
-| PDF | `results/analysis.pdf` | Print-ready PDF (requires `planopticon[pdf]`) |
+| Markdown | `results/analysis.md` | Structured report with embedded Mermaid diagram blocks, tables, and cross-references. Works in any Markdown renderer. |
+| HTML | `results/analysis.html` | Self-contained HTML page with inline CSS, embedded SVG diagrams, and a bundled mermaid.js script for rendering any unrendered Mermaid blocks. No external dependencies required to view. |
+| PDF | `results/analysis.pdf` | Print-ready PDF. Requires the `planopticon[pdf]` extra (`pip install planopticon[pdf]`). Generated from the HTML report. |
+
+---
 
 ## Diagrams
 
-Each detected diagram produces:
+Each visual element detected during frame analysis produces up to five output files in the `diagrams/` subdirectory. The index `N` is zero-based.
 
 | Format | File | Description |
 |--------|------|-------------|
-| JPEG | `diagrams/diagram_N.jpg` | Original frame |
-| Mermaid | `diagrams/diagram_N.mermaid` | Mermaid source code |
-| SVG | `diagrams/diagram_N.svg` | Vector rendering |
-| PNG | `diagrams/diagram_N.png` | Raster rendering |
-| JSON | `diagrams/diagram_N.json` | Structured analysis data |
+| JPEG | `diagrams/diagram_N.jpg` | Original video frame captured at the point of detection. |
+| Mermaid | `diagrams/diagram_N.mermaid` | Mermaid source code reconstructed from the diagram by the vision model. Supports flowcharts, sequence diagrams, architecture diagrams, and more. |
+| SVG | `diagrams/diagram_N.svg` | Vector rendering of the Mermaid source, produced by the Mermaid CLI or built-in renderer. |
+| PNG | `diagrams/diagram_N.png` | Raster rendering of the Mermaid source at high resolution. |
+| JSON | `diagrams/diagram_N.json` | Structured analysis data including diagram type, description, extracted text, chart data (if applicable), and confidence score. |
 
-## Structured data
+Frames that score as medium confidence are saved as captioned screenshots in the `captures/` subdirectory instead, with a `capture_N.jpg` and `capture_N.json` pair.
+
+---
+
+## Structured Data
+
+Core analysis artifacts are stored as JSON files in the `results/` subdirectory.
 
 | Format | File | Description |
 |--------|------|-------------|
-| JSON | `results/knowledge_graph.json` | Entities and relationships |
-| JSON | `results/key_points.json` | Extracted key points |
-| JSON | `results/action_items.json` | Action items with assignees |
-| JSON | `manifest.json` | Complete run manifest |
+| SQLite | `results/knowledge_graph.db` | Primary knowledge graph database. SQLite-based, queryable with `planopticon query`. Contains entities, relationships, source provenance, and metadata. This is the preferred format for querying and merging. |
+| JSON | `results/knowledge_graph.json` | JSON export of the knowledge graph. Contains `entities` and `relationships` arrays. Automatically kept in sync with the `.db` file. Used as a fallback when SQLite is not available. |
+| JSON | `results/key_points.json` | Array of extracted key points, each with `text`, `category`, and `confidence` fields. |
+| JSON | `results/action_items.json` | Array of action items, each with `text`, `assignee`, `due_date`, `priority`, and `status` fields. |
+| JSON | `manifest.json` | Complete run manifest. The single source of truth for the analysis run. Contains video metadata, processing stats, file paths to all outputs, and inline key points, action items, diagram metadata, and screen captures. |
+
+### Knowledge graph JSON structure
+
+```json
+{
+  "entities": [
+    {
+      "name": "Kubernetes",
+      "type": "technology",
+      "descriptions": ["Container orchestration platform discussed in architecture review"],
+      "occurrences": [
+        {"source": "video:recording.mp4", "timestamp": "00:05:23"}
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "source": "Kubernetes",
+      "target": "Docker",
+      "type": "DEPENDS_ON",
+      "descriptions": ["Kubernetes uses Docker as container runtime"]
+    }
+  ]
+}
+```
+
+---
 
 ## Charts
 
-When chart data is extracted from diagrams (bar, line, pie, scatter), PlanOpticon reproduces them:
+When chart data is extracted from diagrams (bar charts, line charts, pie charts, scatter plots), PlanOpticon reproduces them as standalone image files.
 
-- SVG + PNG via matplotlib
-- Embedded in HTML/PDF reports
+| Format | File | Description |
+|--------|------|-------------|
+| SVG | `diagrams/chart_N.svg` | Vector chart rendered via matplotlib. Suitable for embedding in documents or scaling to any size. |
+| PNG | `diagrams/chart_N.png` | Raster chart rendered via matplotlib at 150 DPI. |
+
+Reproduced charts are also embedded inline in the HTML and PDF reports.
+
+---
+
+## Knowledge Graph Exports
+
+Beyond the default `knowledge_graph.db` and `knowledge_graph.json` produced during analysis, PlanOpticon supports exporting knowledge graphs to several additional formats via the `planopticon export` and `planopticon kg convert` commands.
+
+| Format | Command / File | Description |
+|--------|---------------|-------------|
+| JSON | `knowledge_graph.json` | Default JSON export. Produced automatically alongside the `.db` file. |
+| SQLite | `knowledge_graph.db` | Primary database format. Can be converted to/from JSON with `planopticon kg convert`. |
+| GraphML | `output.graphml` | XML-based graph format via `planopticon kg convert kg.db output.graphml`. Compatible with Gephi, yEd, Cytoscape, and other graph visualization tools. |
+| CSV | `export/entities.csv`, `export/relationships.csv` | Tabular export via `planopticon export markdown kg.db --type csv`. Produces separate CSV files for entities and relationships. |
+| Mermaid | Inline in reports | Mermaid graph diagrams are embedded in Markdown and HTML reports. Also available programmatically via `GraphQueryEngine.to_mermaid()`. |
+
+### Converting between formats
+
+```bash
+# SQLite to JSON
+planopticon kg convert results/knowledge_graph.db output.json
+
+# JSON to SQLite
+planopticon kg convert knowledge_graph.json knowledge_graph.db
+
+# Sync both directions (updates the stale file)
+planopticon kg sync results/knowledge_graph.db
+planopticon kg sync knowledge_graph.db knowledge_graph.json --direction db-to-json
+```
+
+---
+
+## PlanOpticonExchange Format
+
+The PlanOpticonExchange format (`.json`) is a canonical interchange payload designed for sharing knowledge graphs between PlanOpticon instances, teams, or external systems.
+
+```bash
+planopticon export exchange knowledge_graph.db
+planopticon export exchange kg.db -o exchange.json --name "My Project"
+```
+
+The exchange payload includes:
+
+- **Schema version** for forward compatibility
+- **Project metadata** (name, description)
+- **Full entity and relationship data** with provenance
+- **Source tracking** for multi-source graphs
+- **Merge support** -- exchange files can be merged together, deduplicating entities by name
+
+### Exchange JSON structure
+
+```json
+{
+  "schema_version": "1.0",
+  "project": {
+    "name": "Sprint Reviews Q4",
+    "description": "Knowledge extracted from Q4 sprint review recordings"
+  },
+  "entities": [...],
+  "relationships": [...],
+  "sources": [...]
+}
+```
+
+---
+
+## Document Exports
+
+PlanOpticon can generate structured Markdown documents from any knowledge graph, with no API key required. These are pure template-based outputs derived from the graph data.
+
+### Markdown document types
+
+There are seven document types plus a CSV export, all generated via `planopticon export markdown`:
+
+| Type | File | Description |
+|------|------|-------------|
+| `summary` | `executive_summary.md` | High-level executive summary with entity counts, top relationships, and key themes. |
+| `meeting-notes` | `meeting_notes.md` | Structured meeting notes with attendees, topics discussed, decisions made, and action items. |
+| `glossary` | `glossary.md` | Alphabetical glossary of all entities with descriptions and types. |
+| `relationship-map` | `relationship_map.md` | Textual and Mermaid-based relationship map showing how entities connect. |
+| `status-report` | `status_report.md` | Status report format with progress indicators, risks, and next steps. |
+| `entity-index` | `entity_index.md` | Comprehensive index of all entities grouped by type, with links to individual briefs. |
+| `entity-brief` | `entities/<Name>.md` | One-pager brief for each entity, showing descriptions, relationships, and source references. |
+| `csv` | `entities.csv` | Tabular CSV export of entities and relationships. |
+
+```bash
+# Generate all document types
+planopticon export markdown knowledge_graph.db
+
+# Generate specific types
+planopticon export markdown kg.db -o ./docs --type summary --type glossary
+
+# Generate meeting notes and CSV
+planopticon export markdown kg.db --type meeting-notes --type csv
+```
+
+### Obsidian vault export
+
+Exports the knowledge graph as an Obsidian-compatible vault with YAML frontmatter, `[[wiki-links]]` between entities, and proper folder structure.
+
+```bash
+planopticon export obsidian knowledge_graph.db -o ./my-vault
+```
+
+The vault includes:
+
+- One note per entity with frontmatter (`type`, `aliases`, `tags`)
+- Wiki-links between related entities
+- A `_Index.md` file for navigation
+- Compatible with Obsidian graph view
+
+### Notion markdown export
+
+Exports as Notion-compatible Markdown with a CSV database file for import into Notion databases.
+
+```bash
+planopticon export notion knowledge_graph.db -o ./notion-export
+```
+
+### GitHub wiki export
+
+Generates a complete GitHub wiki with a sidebar, home page, and per-entity pages. Can be pushed directly to a GitHub wiki repository.
+
+```bash
+# Generate wiki pages
+planopticon wiki generate knowledge_graph.db -o ./wiki
+
+# Push to GitHub
+planopticon wiki push ./wiki ConflictHQ/PlanOpticon -m "Update wiki from KG"
+```
+
+---
+
+## Batch Outputs
+
+Batch processing produces additional files at the batch root directory, alongside per-video output folders.
+
+| Format | File | Description |
+|--------|------|-------------|
+| JSON | `batch_manifest.json` | Batch-level manifest with aggregate stats, per-video status (completed/failed), error details, and paths to all sub-outputs. |
+| Markdown | `batch_summary.md` | Aggregated summary report with combined key points, action items, entity counts, and a Mermaid diagram of the merged knowledge graph. |
+| SQLite | `knowledge_graph.db` | Merged knowledge graph combining entities and relationships across all successfully processed videos. Uses fuzzy matching and conflict resolution. |
+| JSON | `knowledge_graph.json` | JSON export of the merged knowledge graph. |
+
+---
+
+## Self-Contained HTML Viewer
+
+PlanOpticon ships with a self-contained interactive knowledge graph viewer at `knowledge-base/viewer.html` in the repository. This file:
+
+- Uses D3.js (bundled inline, no CDN dependency)
+- Renders an interactive force-directed graph visualization
+- Supports node filtering by entity type
+- Shows entity details and relationships on click
+- Can load any `knowledge_graph.json` file
+- Works offline with no server required -- just open in a browser
+- Covers approximately 80% of graph exploration needs with zero infrastructure
+
+---
+
+## Output Directory Structure
+
+A complete single-video analysis produces the following directory tree:
+
+```
+output/
+├── manifest.json                      # Run manifest (source of truth)
+├── transcript/
+│   ├── transcript.json                # Full transcript with segments
+│   ├── transcript.txt                 # Plain text
+│   └── transcript.srt                 # Subtitles
+├── frames/
+│   ├── frame_0000.jpg                 # Extracted video frames
+│   ├── frame_0001.jpg
+│   └── ...
+├── diagrams/
+│   ├── diagram_0.jpg                  # Original frame
+│   ├── diagram_0.mermaid             # Mermaid source
+│   ├── diagram_0.svg                 # Vector rendering
+│   ├── diagram_0.png                 # Raster rendering
+│   ├── diagram_0.json                # Analysis data
+│   ├── chart_0.svg                   # Reproduced chart (SVG)
+│   ├── chart_0.png                   # Reproduced chart (PNG)
+│   └── ...
+├── captures/
+│   ├── capture_0.jpg                 # Medium-confidence screenshots
+│   ├── capture_0.json                # Caption and metadata
+│   └── ...
+└── results/
+    ├── analysis.md                    # Markdown report
+    ├── analysis.html                  # HTML report
+    ├── analysis.pdf                   # PDF report (if planopticon[pdf] installed)
+    ├── knowledge_graph.db             # Knowledge graph (SQLite, primary)
+    ├── knowledge_graph.json           # Knowledge graph (JSON export)
+    ├── key_points.json                # Extracted key points
+    └── action_items.json              # Action items
+```
+
+---
+
+## Controlling Output Format
+
+Use the `--output-format` flag with `planopticon analyze` to control how results are presented:
+
+| Value | Behavior |
+|-------|----------|
+| `default` | Writes all output files to disk and prints a usage summary to stdout. |
+| `json` | Writes all output files to disk and also emits the complete `VideoManifest` as structured JSON to stdout. Useful for piping into other tools or CI/CD pipelines. |
+
+```bash
+# Standard output (files + console summary)
+planopticon analyze -i video.mp4 -o ./output
+
+# JSON manifest to stdout (for scripting)
+planopticon analyze -i video.mp4 -o ./output --output-format json
+```

--- a/docs/guide/planning-agent.md
+++ b/docs/guide/planning-agent.md
@@ -1,0 +1,425 @@
+# Planning Agent
+
+The Planning Agent is PlanOpticon's AI-powered system for synthesizing knowledge graph content into structured planning artifacts. It takes extracted entities and relationships from video analyses, document ingestions, and other sources, then uses LLM reasoning to produce project plans, PRDs, roadmaps, task breakdowns, GitHub issues, and more.
+
+---
+
+## How It Works
+
+The Planning Agent operates through a three-stage pipeline:
+
+### 1. Context Assembly
+
+The agent gathers context from all available sources:
+
+- **Knowledge graph** -- entity counts, types, relationships, and planning entities from the loaded KG
+- **Query engine** -- used to pull stats, entity lists, and relationship data for prompt construction
+- **Provider manager** -- the configured LLM provider used for generation
+- **Prior artifacts** -- any artifacts already generated in the session (skills can chain off each other)
+- **Conversation history** -- accumulated chat messages when running in interactive mode
+
+This context is bundled into an `AgentContext` dataclass that is shared across all skills.
+
+### 2. Skill Selection
+
+When the agent receives a user request, it determines which skills to run:
+
+**LLM-driven planning (with provider).** The agent constructs a prompt that includes the knowledge base summary, all available skill names and descriptions, and the user's request. The LLM returns a JSON array of skill names to execute in order, along with any parameters. For example, given "Create a project plan and break it into tasks," the LLM might select `["project_plan", "task_breakdown"]`.
+
+**Keyword fallback (without provider).** If no LLM provider is available, the agent falls back to simple keyword matching. It splits each skill name on underscores and checks whether any of those words appear in the user's request. For example, the request "generate a roadmap" would match the `roadmap` skill because "roadmap" appears in both the request and the skill name.
+
+### 3. Execution
+
+Selected skills are executed sequentially. Each skill:
+
+1. Checks `can_execute()` to verify the required context is available (by default, both a knowledge graph and an LLM provider must be present)
+2. Pulls relevant data from the knowledge graph via the query engine
+3. Constructs a detailed prompt for the LLM with extracted context
+4. Calls the LLM and parses the response
+5. Returns an `Artifact` object containing the generated content
+
+Each artifact is appended to `context.artifacts`, making it available to subsequent skills. This enables chaining -- for example, `task_breakdown` can feed into `github_issues`.
+
+---
+
+## AgentContext
+
+The `AgentContext` dataclass is the shared state object that connects all components of the planning agent system.
+
+```python
+@dataclass
+class AgentContext:
+    knowledge_graph: Any = None       # KnowledgeGraph instance
+    query_engine: Any = None          # GraphQueryEngine instance
+    provider_manager: Any = None      # ProviderManager instance
+    planning_entities: List[Any] = field(default_factory=list)
+    user_requirements: Dict[str, Any] = field(default_factory=dict)
+    conversation_history: List[Dict[str, str]] = field(default_factory=list)
+    artifacts: List[Artifact] = field(default_factory=list)
+    config: Dict[str, Any] = field(default_factory=dict)
+```
+
+| Field | Purpose |
+|---|---|
+| `knowledge_graph` | The loaded `KnowledgeGraph` instance; provides access to entities, relationships, and graph operations |
+| `query_engine` | A `GraphQueryEngine` for running structured queries (stats, entities, neighbors, relationships) |
+| `provider_manager` | The `ProviderManager` that handles LLM API calls across providers |
+| `planning_entities` | Entities classified into the planning taxonomy (goals, requirements, risks, etc.) |
+| `user_requirements` | Structured requirements gathered from the `requirements_chat` skill |
+| `conversation_history` | Accumulated chat messages for interactive sessions |
+| `artifacts` | All artifacts generated during the session, enabling skill chaining |
+| `config` | Arbitrary configuration overrides |
+
+---
+
+## Artifacts
+
+Every skill returns an `Artifact` dataclass:
+
+```python
+@dataclass
+class Artifact:
+    name: str              # Human-readable name (e.g., "Project Plan")
+    content: str           # The generated content (markdown, JSON, etc.)
+    artifact_type: str     # Type identifier: "project_plan", "prd", "roadmap", etc.
+    format: str = "markdown"  # Content format: "markdown", "json", "mermaid"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+```
+
+Artifacts are the currency of the agent system. They can be:
+
+- Displayed directly in the Companion REPL
+- Exported to disk via the `artifact_export` skill
+- Pushed to external tools via the `cli_adapter` skill
+- Chained into other skills (e.g., task breakdown feeds into GitHub issues)
+
+---
+
+## Skills Reference
+
+The agent ships with 11 built-in skills. Each skill is a class that extends `Skill` and self-registers at import time via `register_skill()`.
+
+### project_plan
+
+**Description:** Generate a structured project plan from knowledge graph.
+
+Pulls the full knowledge graph context (stats, entities, relationships, and planning entities grouped by type) and asks the LLM to produce a comprehensive project plan with:
+
+1. Executive Summary
+2. Goals and Objectives
+3. Scope
+4. Phases and Milestones
+5. Resource Requirements
+6. Risks and Mitigations
+7. Success Criteria
+
+**Artifact type:** `project_plan` | **Format:** markdown
+
+### prd
+
+**Description:** Generate a product requirements document (PRD) / feature spec.
+
+Filters planning entities to those of type `requirement`, `feature`, and `constraint`, then asks the LLM to generate a PRD with:
+
+1. Problem Statement
+2. User Stories
+3. Functional Requirements
+4. Non-Functional Requirements
+5. Acceptance Criteria
+6. Out of Scope
+
+If no pre-filtered entities match, the LLM derives requirements from the full knowledge graph context.
+
+**Artifact type:** `prd` | **Format:** markdown
+
+### roadmap
+
+**Description:** Generate a product/project roadmap.
+
+Focuses on planning entities of type `milestone`, `feature`, and `dependency`. Asks the LLM to produce a roadmap with:
+
+1. Vision and Strategy
+2. Phases (with timeline estimates)
+3. Key Dependencies
+4. A Mermaid Gantt chart summarizing the timeline
+
+**Artifact type:** `roadmap` | **Format:** markdown
+
+### task_breakdown
+
+**Description:** Break down goals into tasks with dependencies.
+
+Focuses on planning entities of type `goal`, `feature`, and `milestone`. Returns a JSON array of task objects, each containing:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Task identifier (e.g., "T1", "T2") |
+| `title` | string | Short task title |
+| `description` | string | Detailed description |
+| `depends_on` | list | IDs of prerequisite tasks |
+| `priority` | string | `high`, `medium`, or `low` |
+| `estimate` | string | Effort estimate (e.g., "2d", "1w") |
+| `assignee_role` | string | Role needed to perform the task |
+
+**Artifact type:** `task_list` | **Format:** json
+
+### github_issues
+
+**Description:** Generate GitHub issues from task breakdown.
+
+Converts tasks into GitHub-ready issue objects. If a `task_list` artifact exists in the context, it is used as input. Otherwise, minimal issues are generated from the planning entities directly.
+
+Each issue includes a formatted body with description, priority, estimate, and dependencies, plus labels derived from the task priority.
+
+The skill also provides a `push_to_github(issues_json, repo)` function that shells out to the `gh` CLI to create actual issues. This is used by the `cli_adapter` skill.
+
+**Artifact type:** `issues` | **Format:** json
+
+### requirements_chat
+
+**Description:** Interactive requirements gathering via guided questions.
+
+Generates a structured requirements questionnaire based on the knowledge graph context. The questionnaire contains 8-12 targeted questions, each with:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Question identifier (e.g., "Q1") |
+| `category` | string | `goals`, `constraints`, `priorities`, or `scope` |
+| `question` | string | The question text |
+| `context` | string | Why this question matters |
+
+The skill also provides a `gather_requirements(context, answers)` method that takes the completed Q&A and synthesizes structured requirements (goals, constraints, priorities, scope).
+
+**Artifact type:** `requirements` | **Format:** json
+
+### doc_generator
+
+**Description:** Generate technical documentation, ADRs, or meeting notes.
+
+Supports three document types, selected via the `doc_type` parameter:
+
+| `doc_type` | Output Structure |
+|---|---|
+| `technical_doc` (default) | Overview, Architecture, Components and Interfaces, Data Flow, Deployment and Configuration, API Reference |
+| `adr` | Title, Status (Proposed), Context, Decision, Consequences, Alternatives Considered |
+| `meeting_notes` | Meeting Summary, Key Discussion Points, Decisions Made, Action Items (with owners), Open Questions, Next Steps |
+
+**Artifact type:** `document` | **Format:** markdown
+
+### artifact_export
+
+**Description:** Export artifacts in agent-ready formats.
+
+Writes all artifacts accumulated in the context to a directory structure. Each artifact is written to a file based on its type:
+
+| Artifact Type | Filename |
+|---|---|
+| `project_plan` | `project_plan.md` |
+| `prd` | `prd.md` |
+| `roadmap` | `roadmap.md` |
+| `task_list` | `tasks.json` |
+| `issues` | `issues.json` |
+| `requirements` | `requirements.json` |
+| `document` | `docs/<name>.md` |
+
+A `manifest.json` is written alongside, listing all exported files with their names, types, and formats.
+
+**Artifact type:** `export_manifest` | **Format:** json
+
+Accepts an `output_dir` parameter (defaults to `plan/`).
+
+### cli_adapter
+
+**Description:** Push artifacts to external tools via their CLIs.
+
+Converts artifacts into CLI commands for external project management tools. Supported tools:
+
+| Tool | CLI | Example Command |
+|---|---|---|
+| `github` | `gh` | `gh issue create --title "..." --body "..." --label "..."` |
+| `jira` | `jira` | `jira issue create --summary "..." --description "..."` |
+| `linear` | `linear` | `linear issue create --title "..." --description "..."` |
+
+The skill checks whether the target CLI is available on the system and includes that status in the output. Commands are generated in dry-run mode by default.
+
+**Artifact type:** `cli_commands` | **Format:** json
+
+### notes_export
+
+**Description:** Export knowledge graph as structured notes (Obsidian, Notion).
+
+Exports the entire knowledge graph as a collection of markdown files optimized for a specific note-taking platform. Accepts a `format` parameter:
+
+**Obsidian format** creates:
+
+- One `.md` file per entity with YAML frontmatter, tags, and `[[wiki-links]]`
+- An `_Index.md` Map of Content grouping entities by type
+- Tag pages for each entity type
+- Artifact notes for any generated artifacts
+
+**Notion format** creates:
+
+- One `.md` file per entity with Notion-style callout blocks and relationship tables
+- An `entities_database.csv` for bulk import into a Notion database
+- An `Overview.md` page with stats and entity listings
+- Artifact pages
+
+**Artifact type:** `notes_export` | **Format:** markdown
+
+### wiki_generator
+
+**Description:** Generate a GitHub wiki from knowledge graph and artifacts.
+
+Generates a complete GitHub wiki structure as a dictionary of page names to markdown content. Creates:
+
+- **Home** page with entity type counts and links
+- **_Sidebar** navigation with entity types and artifacts
+- **Type index pages** with tables of entities per type
+- **Individual entity pages** with descriptions, outgoing/incoming relationships, and source occurrences
+- **Artifact pages** for any generated planning artifacts
+
+The skill also provides standalone functions `write_wiki(pages, output_dir)` to write pages to disk and `push_wiki(wiki_dir, repo)` to push directly to a GitHub wiki repository.
+
+**Artifact type:** `wiki` | **Format:** markdown
+
+---
+
+## CLI Usage
+
+### One-shot execution
+
+Run the agent with a request string. The agent selects and executes appropriate skills automatically.
+
+```bash
+# Generate a project plan
+planopticon agent "Create a project plan" --kb ./results
+
+# Generate a PRD
+planopticon agent "Write a PRD for the authentication system" --kb ./results
+
+# Break down into tasks
+planopticon agent "Break this into tasks and estimate effort" --kb ./results
+```
+
+### Export artifacts to disk
+
+Use `--export` to write generated artifacts to a directory:
+
+```bash
+planopticon agent "Create a full project plan with tasks" --kb ./results --export ./output
+```
+
+### Interactive mode
+
+Use `-I` for a multi-turn session where you can issue multiple requests:
+
+```bash
+planopticon agent -I --kb ./results
+```
+
+In interactive mode, the agent supports:
+
+- Free-text requests (executed via LLM skill selection)
+- `/plan` -- shortcut to generate a project plan
+- `/skills` -- list available skills
+- `quit`, `exit`, `q` -- end the session
+
+### Provider and model options
+
+```bash
+# Use a specific provider
+planopticon agent "Create a roadmap" --kb ./results -p anthropic
+
+# Use a specific model
+planopticon agent "Generate a PRD" --kb ./results --chat-model gpt-4o
+```
+
+### Auto-discovery
+
+If `--kb` is not specified, the agent uses `KBContext.auto_discover()` to find knowledge graphs in the workspace.
+
+---
+
+## Using Skills from the Companion REPL
+
+The Companion REPL provides direct access to agent skills through slash commands. See the [Companion guide](companion.md) for full details.
+
+| Companion Command | Skill Executed |
+|---|---|
+| `/plan` | `project_plan` |
+| `/prd` | `prd` |
+| `/tasks` | `task_breakdown` |
+| `/run SKILL_NAME` | Any registered skill by name |
+
+When executed from the Companion, skills use the same `AgentContext` that powers the chat mode. This means:
+
+- The knowledge graph loaded at startup is automatically available
+- The active LLM provider (set via `/provider` or `/model`) is used for generation
+- Generated artifacts accumulate across the session, enabling chaining
+
+---
+
+## Example Workflows
+
+### From video to project plan
+
+```bash
+# 1. Analyze a video
+planopticon analyze -i sprint-review.mp4 -o results/
+
+# 2. Launch the agent with the results
+planopticon agent "Create a comprehensive project plan with tasks and a roadmap" \
+    --kb results/ --export plan/
+
+# 3. Review the generated artifacts
+ls plan/
+# project_plan.md  roadmap.md  tasks.json  manifest.json
+```
+
+### Interactive planning session
+
+```bash
+$ planopticon companion --kb ./results
+
+planopticon> /status
+Workspace status:
+  KG: knowledge_graph.db (58 entities, 124 relationships)
+  ...
+
+planopticon> What are the main goals discussed?
+Based on the knowledge graph, the main goals are...
+
+planopticon> /plan
+--- Project Plan (project_plan) ---
+...
+
+planopticon> /tasks
+--- Task Breakdown (task_list) ---
+...
+
+planopticon> /run github_issues
+--- GitHub Issues (issues) ---
+[
+  {"title": "Set up authentication service", ...},
+  ...
+]
+
+planopticon> /run artifact_export
+--- Export Manifest (export_manifest) ---
+{
+  "artifact_count": 3,
+  "output_dir": "plan",
+  "files": [...]
+}
+```
+
+### Skill chaining
+
+Skills that produce artifacts make them available to subsequent skills automatically:
+
+1. `/tasks` generates a `task_list` artifact
+2. `/run github_issues` detects the existing `task_list` artifact and converts its tasks into GitHub issues
+3. `/run cli_adapter` takes the most recent artifact and generates `gh issue create` commands
+4. `/run artifact_export` writes all accumulated artifacts to disk with a manifest
+
+This chaining works both in the Companion REPL and in one-shot agent execution, since the `AgentContext.artifacts` list persists for the duration of the session.

--- a/docs/guide/single-video.md
+++ b/docs/guide/single-video.md
@@ -10,18 +10,24 @@ planopticon analyze -i recording.mp4 -o ./output
 
 The pipeline runs these steps in order:
 
-1. **Frame extraction** — Samples frames using change detection for transitions plus periodic capture (every 30s) for slow-evolving content like document scrolling
-2. **People frame filtering** — OpenCV face detection automatically removes webcam/video conference frames, keeping only shared content (slides, documents, screen shares)
-3. **Audio extraction** — Extracts audio track to WAV
-4. **Transcription** — Sends audio to speech-to-text (Whisper or Gemini)
-5. **Diagram detection** — Vision model classifies each frame as diagram/chart/whiteboard/screenshot/none
-6. **Diagram analysis** — High-confidence diagrams get full extraction (description, text, mermaid, chart data)
-7. **Screengrab fallback** — Medium-confidence frames are saved as captioned screenshots
-8. **Knowledge graph** — Extracts entities and relationships from transcript + diagrams
-9. **Key points** — LLM extracts main points and topics
-10. **Action items** — LLM finds tasks, commitments, and follow-ups
-11. **Reports** — Generates markdown, HTML, and PDF
-12. **Export** — Renders mermaid diagrams to SVG/PNG, reproduces charts
+1. **Frame extraction** -- Samples frames using change detection for transitions plus periodic capture (every 30s) for slow-evolving content like document scrolling
+2. **People frame filtering** -- OpenCV face detection automatically removes webcam/video conference frames, keeping only shared content (slides, documents, screen shares)
+3. **Audio extraction** -- Extracts audio track to WAV
+4. **Transcription** -- Sends audio to speech-to-text (Whisper or Gemini). If `--speakers` is provided, speaker diarization hints are passed to the provider.
+5. **Diagram detection** -- Vision model classifies each frame as diagram/chart/whiteboard/screenshot/none
+6. **Diagram analysis** -- High-confidence diagrams get full extraction (description, text, mermaid, chart data)
+7. **Screengrab fallback** -- Medium-confidence frames are saved as captioned screenshots
+8. **Knowledge graph** -- Extracts entities and relationships from transcript + diagrams, stored in both `knowledge_graph.db` (SQLite, primary) and `knowledge_graph.json` (export)
+9. **Key points** -- LLM extracts main points and topics
+10. **Action items** -- LLM finds tasks, commitments, and follow-ups
+11. **Reports** -- Generates markdown, HTML, and PDF
+12. **Export** -- Renders mermaid diagrams to SVG/PNG, reproduces charts
+
+After analysis, you can optionally run planning taxonomy classification on the knowledge graph to categorize entities for use with the planning agent:
+
+```bash
+planopticon kg classify results/knowledge_graph.db
+```
 
 ## Processing depth
 
@@ -32,7 +38,7 @@ The pipeline runs these steps in order:
 
 ### `standard` (default)
 - Everything in basic
-- Diagram extraction (up to 10 frames)
+- Diagram extraction (up to 10 frames, evenly sampled)
 - Knowledge graph
 - Full report generation
 
@@ -40,6 +46,99 @@ The pipeline runs these steps in order:
 - Everything in standard
 - More frames analyzed (up to 20)
 - Deeper analysis
+
+## Command-line options
+
+### Provider and model selection
+
+```bash
+# Use a specific provider
+planopticon analyze -i video.mp4 -o ./output --provider anthropic
+
+# Override vision and chat models separately
+planopticon analyze -i video.mp4 -o ./output --vision-model gpt-4o --chat-model claude-sonnet-4-20250514
+```
+
+### Speaker diarization hints
+
+Use `--speakers` to provide speaker names as comma-separated hints. These are passed to the transcription provider to improve speaker identification in the transcript segments.
+
+```bash
+planopticon analyze -i video.mp4 -o ./output --speakers "Alice,Bob,Carol"
+```
+
+### Custom prompt templates
+
+Use `--templates-dir` to point to a directory of custom `.txt` prompt template files. These override the built-in prompts used for diagram analysis, key point extraction, action item extraction, and other LLM-driven steps.
+
+```bash
+planopticon analyze -i video.mp4 -o ./output --templates-dir ./my-prompts
+```
+
+Template files should be named to match the built-in template names (e.g., `key_points.txt`, `action_items.txt`). See the `video_processor/utils/prompt_templates.py` module for the full list of template names.
+
+### Output format
+
+Use `--output-format json` to emit the complete `VideoManifest` as structured JSON to stdout, in addition to writing all output files to disk. This is useful for scripting, CI/CD integration, or piping results into other tools.
+
+```bash
+# Standard output (files + console summary)
+planopticon analyze -i video.mp4 -o ./output
+
+# JSON manifest to stdout
+planopticon analyze -i video.mp4 -o ./output --output-format json
+```
+
+### Frame extraction tuning
+
+```bash
+# Adjust sampling rate (frames per second to consider)
+planopticon analyze -i video.mp4 -o ./output --sampling-rate 1.0
+
+# Adjust change detection threshold (lower = more sensitive)
+planopticon analyze -i video.mp4 -o ./output --change-threshold 0.10
+
+# Adjust periodic capture interval
+planopticon analyze -i video.mp4 -o ./output --periodic-capture 60
+
+# Enable GPU acceleration for frame extraction
+planopticon analyze -i video.mp4 -o ./output --use-gpu
+```
+
+## Output structure
+
+Every run produces a standardized directory structure:
+
+```
+output/
+├── manifest.json                      # Run manifest (source of truth)
+├── transcript/
+│   ├── transcript.json                # Full transcript with segments + speakers
+│   ├── transcript.txt                 # Plain text
+│   └── transcript.srt                 # Subtitles
+├── frames/
+│   ├── frame_0000.jpg
+│   └── ...
+├── diagrams/
+│   ├── diagram_0.jpg                  # Original frame
+│   ├── diagram_0.mermaid             # Mermaid source
+│   ├── diagram_0.svg                 # Vector rendering
+│   ├── diagram_0.png                 # Raster rendering
+│   ├── diagram_0.json                # Analysis data
+│   └── ...
+├── captures/
+│   ├── capture_0.jpg                 # Medium-confidence screenshots
+│   ├── capture_0.json
+│   └── ...
+└── results/
+    ├── analysis.md                    # Markdown report
+    ├── analysis.html                  # HTML report
+    ├── analysis.pdf                   # PDF (if planopticon[pdf] installed)
+    ├── knowledge_graph.db             # Knowledge graph (SQLite, primary)
+    ├── knowledge_graph.json           # Knowledge graph (JSON export)
+    ├── key_points.json                # Extracted key points
+    └── action_items.json              # Action items
+```
 
 ## Output manifest
 
@@ -58,11 +157,88 @@ Every run produces a `manifest.json` that is the single source of truth:
     "frames_extracted": 42,
     "people_frames_filtered": 11,
     "diagrams_detected": 3,
-    "screen_captures": 5
+    "screen_captures": 5,
+    "models_used": {
+      "vision": "gpt-4o",
+      "chat": "gpt-4o"
+    }
   },
+  "transcript_json": "transcript/transcript.json",
+  "transcript_txt": "transcript/transcript.txt",
+  "transcript_srt": "transcript/transcript.srt",
+  "analysis_md": "results/analysis.md",
+  "knowledge_graph_json": "results/knowledge_graph.json",
+  "knowledge_graph_db": "results/knowledge_graph.db",
+  "key_points_json": "results/key_points.json",
+  "action_items_json": "results/action_items.json",
   "key_points": [...],
   "action_items": [...],
   "diagrams": [...],
   "screen_captures": [...]
 }
+```
+
+## Checkpoint and resume
+
+The pipeline supports checkpoint/resume. If a step's output files already exist on disk, that step is skipped on re-run. This means you can safely re-run an interrupted analysis and it will pick up where it left off:
+
+```bash
+# First run (interrupted at step 6)
+planopticon analyze -i video.mp4 -o ./output
+
+# Second run (resumes from step 6)
+planopticon analyze -i video.mp4 -o ./output
+```
+
+## Using results after analysis
+
+### Query the knowledge graph
+
+After analysis completes, you can query the knowledge graph directly:
+
+```bash
+# Show graph stats
+planopticon query --db results/knowledge_graph.db
+
+# List entities by type
+planopticon query --db results/knowledge_graph.db "entities --type technology"
+
+# Find neighbors of an entity
+planopticon query --db results/knowledge_graph.db "neighbors Kubernetes"
+
+# Ask natural language questions (requires API key)
+planopticon query --db results/knowledge_graph.db "What technologies were discussed?"
+```
+
+### Classify entities for planning
+
+Run taxonomy classification to categorize entities into planning types (goal, milestone, risk, dependency, etc.):
+
+```bash
+planopticon kg classify results/knowledge_graph.db
+planopticon kg classify results/knowledge_graph.db --format json
+```
+
+### Export to other formats
+
+```bash
+# Generate markdown documents
+planopticon export markdown results/knowledge_graph.db -o ./docs
+
+# Export as Obsidian vault
+planopticon export obsidian results/knowledge_graph.db -o ./vault
+
+# Export as PlanOpticonExchange
+planopticon export exchange results/knowledge_graph.db -o exchange.json
+
+# Generate GitHub wiki
+planopticon wiki generate results/knowledge_graph.db -o ./wiki
+```
+
+### Use with the planning agent
+
+The planning agent can consume the knowledge graph to generate project plans, PRDs, roadmaps, and other planning artifacts:
+
+```bash
+planopticon agent --db results/knowledge_graph.db
 ```

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,342 @@
+# Use Cases
+
+PlanOpticon is built for anyone who needs to turn unstructured content — recordings, documents, notes, web pages — into structured, searchable, actionable knowledge. Here are the most common ways people use it.
+
+---
+
+## Meeting notes and follow-ups
+
+**Problem:** You have hours of meeting recordings but no time to rewatch them. Action items get lost, decisions are forgotten, and new team members have no way to catch up.
+
+**Solution:** Point PlanOpticon at your recordings and get structured transcripts, action items with assignees and deadlines, key decisions, and a knowledge graph linking people to topics.
+
+```bash
+# Analyze a single meeting recording
+planopticon analyze -i standup-2026-03-07.mp4 -o ./meetings/march-7
+
+# Process a month of recordings at once
+planopticon batch -i ./recordings/march -o ./meetings --title "March 2026 Meetings"
+
+# Query what was decided
+planopticon query "What decisions were made about the API redesign?"
+
+# Find all action items assigned to Alice
+planopticon query "relationships --source Alice"
+```
+
+**What you get:**
+
+- Full transcript with timestamps and speaker segments
+- Action items extracted with assignees, deadlines, and context
+- Key points and decisions highlighted
+- Knowledge graph connecting people, topics, technologies, and decisions
+- Markdown report you can share with the team
+
+**Next steps:** Export to your team's wiki or note system:
+
+```bash
+# Push to GitHub wiki
+planopticon wiki generate --input ./meetings --output ./wiki
+planopticon wiki push --input ./wiki --target "github://your-org/your-repo"
+
+# Export to Obsidian for personal knowledge management
+planopticon export obsidian --input ./meetings --output ~/Obsidian/Meetings
+```
+
+---
+
+## Research processing
+
+**Problem:** You're researching a topic across YouTube talks, arXiv papers, blog posts, and podcasts. Information is scattered and hard to cross-reference.
+
+**Solution:** Ingest everything into a single knowledge graph, then query across all sources.
+
+```bash
+# Ingest a YouTube conference talk
+planopticon ingest "https://youtube.com/watch?v=..." --output ./research
+
+# Ingest arXiv papers
+planopticon ingest "https://arxiv.org/abs/2401.12345" --output ./research
+
+# Ingest blog posts and documentation
+planopticon ingest "https://example.com/blog/post" --output ./research
+
+# Ingest local PDF papers
+planopticon ingest ./papers/ --output ./research --recursive
+
+# Now query across everything
+planopticon query "What approaches to vector search were discussed?"
+planopticon query "entities --type technology"
+planopticon query "neighbors TransformerArchitecture"
+```
+
+**What you get:**
+
+- A unified knowledge graph merging entities across all sources
+- Cross-references showing where the same concept appears in different sources
+- Searchable entity index by type (people, technologies, concepts, papers)
+- Relationship maps showing how ideas connect
+
+**Go deeper with the companion:**
+
+```bash
+planopticon companion --kb ./research
+```
+
+```
+planopticon> What are the main approaches to retrieval-augmented generation?
+planopticon> /entities --type technology
+planopticon> /neighbors RAG
+planopticon> /export obsidian
+```
+
+---
+
+## Knowledge gathering across platforms
+
+**Problem:** Your team's knowledge is spread across Google Docs, Notion, Obsidian, GitHub wikis, and Apple Notes. There's no single place to search everything.
+
+**Solution:** Pull from all sources into one knowledge graph.
+
+```bash
+# Authenticate with your platforms
+planopticon auth google
+planopticon auth notion
+planopticon auth github
+
+# Ingest from Google Workspace
+planopticon gws ingest --folder-id abc123 --output ./kb --recursive
+
+# Ingest from Notion
+planopticon ingest --source notion --output ./kb
+
+# Ingest from an Obsidian vault
+planopticon ingest ~/Obsidian/WorkVault --output ./kb --recursive
+
+# Ingest from GitHub wikis and READMEs
+planopticon ingest "github://your-org/project-a" --output ./kb
+planopticon ingest "github://your-org/project-b" --output ./kb
+
+# Query the unified knowledge base
+planopticon query stats
+planopticon query "entities --type person"
+planopticon query "What do we know about the authentication system?"
+```
+
+**What you get:**
+
+- Merged knowledge graph with provenance tracking (you can see which source each entity came from)
+- Deduplicated entities across platforms (same concept mentioned in Notion and Google Docs gets merged)
+- Full-text search across all ingested content
+- Relationship maps showing how concepts connect across your organization's documents
+
+---
+
+## Team onboarding
+
+**Problem:** New team members spend weeks reading docs, watching recorded meetings, and asking questions to get up to speed.
+
+**Solution:** Build a knowledge base from existing content and let new people explore it conversationally.
+
+```bash
+# Build the knowledge base from everything
+planopticon batch -i ./recordings/onboarding -o ./kb --title "Team Onboarding"
+planopticon ingest ./docs/ --output ./kb --recursive
+planopticon ingest ./architecture-decisions/ --output ./kb --recursive
+
+# New team member launches the companion
+planopticon companion --kb ./kb
+```
+
+```
+planopticon> What is the overall architecture of the system?
+planopticon> Who are the key people on the team?
+planopticon> /entities --type technology
+planopticon> What was the rationale for choosing PostgreSQL over MongoDB?
+planopticon> /neighbors AuthenticationService
+planopticon> What are the main open issues or risks?
+```
+
+**What you get:**
+
+- Interactive Q&A over the entire team knowledge base
+- Entity exploration — browse people, technologies, services, decisions
+- Relationship navigation — "show me everything connected to the payment system"
+- No need to rewatch hours of recordings
+
+---
+
+## Data collection and synthesis
+
+**Problem:** You need to collect and synthesize information from many sources — customer interviews, competitor analysis, market research — into a coherent picture.
+
+**Solution:** Batch process recordings and documents, then use the planning agent to generate synthesis artifacts.
+
+```bash
+# Process customer interview recordings
+planopticon batch -i ./interviews -o ./research --title "Customer Interviews Q1"
+
+# Ingest competitor documentation
+planopticon ingest ./competitor-analysis/ --output ./research --recursive
+
+# Ingest market research PDFs
+planopticon ingest ./market-reports/ --output ./research --recursive
+
+# Use the planning agent to synthesize
+planopticon agent --kb ./research --interactive
+```
+
+```
+planopticon> Generate a summary of common customer pain points
+planopticon> /plan
+planopticon> /tasks
+planopticon> /export markdown
+```
+
+**What you get:**
+
+- Merged knowledge graph across all interviews and documents
+- Cross-referenced entities showing which customers mentioned which features
+- Agent-generated project plans, PRDs, and task breakdowns based on the data
+- Exportable artifacts for sharing with stakeholders
+
+---
+
+## Content creation from video
+
+**Problem:** You have video content (lectures, tutorials, webinars) that you want to turn into written documentation, blog posts, or course materials.
+
+**Solution:** Extract structured knowledge and export it in your preferred format.
+
+```bash
+# Analyze the video
+planopticon analyze -i webinar-recording.mp4 -o ./content
+
+# Generate multiple document types (no LLM needed for these)
+planopticon export markdown --input ./content --output ./docs
+
+# Export to Obsidian for further editing
+planopticon export obsidian --input ./content --output ~/Obsidian/Content
+```
+
+**What you get for each video:**
+
+- Full transcript (JSON, plain text, SRT subtitles)
+- Extracted diagrams reproduced as Mermaid/SVG/PNG
+- Charts reproduced with data tables
+- Knowledge graph of concepts and relationships
+- 7 types of markdown documents: summary, meeting notes, glossary, relationship map, status report, entity index, CSV data
+
+---
+
+## Decision tracking over time
+
+**Problem:** Important decisions are made in meetings but never formally recorded. Months later, nobody remembers why a choice was made.
+
+**Solution:** Process meeting recordings continuously and query the growing knowledge graph for decisions and their context.
+
+```bash
+# Process each week's recordings
+planopticon batch -i ./recordings/week-12 -o ./decisions --title "Week 12"
+
+# The knowledge graph grows over time — entities merge across weeks
+planopticon query "entities --type goal"
+planopticon query "entities --type risk"
+planopticon query "entities --type milestone"
+
+# Find decisions about a specific topic
+planopticon query "What was decided about the database migration?"
+
+# Track risks over time
+planopticon query "relationships --type risk"
+```
+
+The planning taxonomy automatically classifies entities as goals, requirements, risks, tasks, and milestones — giving you a structured view of project evolution over time.
+
+---
+
+## Zoom / Teams / Meet integration
+
+**Problem:** Meeting recordings are sitting in Zoom/Teams/Meet cloud storage. You want to process them without manually downloading each one.
+
+**Solution:** Authenticate once, list recordings, and process them directly.
+
+```bash
+# Authenticate with your meeting platform
+planopticon auth zoom
+# or: planopticon auth microsoft
+# or: planopticon auth google
+
+# List recent recordings
+planopticon recordings zoom-list
+planopticon recordings teams-list --from 2026-01-01
+planopticon recordings meet-list --limit 20
+
+# Process recordings (download + analyze)
+planopticon analyze -i "zoom://recording-id" -o ./output
+```
+
+**Setup requirements:**
+
+| Platform | What you need |
+|----------|--------------|
+| Zoom | `ZOOM_CLIENT_ID` + `ZOOM_CLIENT_SECRET` (create an OAuth app at marketplace.zoom.us) |
+| Teams | `MICROSOFT_CLIENT_ID` + `MICROSOFT_CLIENT_SECRET` (register an Azure AD app) |
+| Meet | `GOOGLE_CLIENT_ID` + `GOOGLE_CLIENT_SECRET` (create OAuth credentials in Google Cloud Console) |
+
+See the [Authentication guide](guide/authentication.md) for detailed setup instructions.
+
+---
+
+## Fully offline processing
+
+**Problem:** You're working with sensitive content that can't leave your network, or you simply don't want to pay for API calls.
+
+**Solution:** Use Ollama for local AI processing with no external API calls.
+
+```bash
+# Install Ollama and pull models
+ollama pull llama3.2       # Chat/analysis
+ollama pull llava          # Vision (diagram detection)
+
+# Install local Whisper for transcription
+pip install planopticon[gpu]
+
+# Process entirely offline
+planopticon analyze -i sensitive-meeting.mp4 -o ./output --provider ollama
+```
+
+PlanOpticon auto-detects Ollama when it's running. If no cloud API keys are configured, it uses Ollama automatically. Pair with local Whisper transcription for a fully air-gapped pipeline.
+
+---
+
+## Competitive research
+
+**Problem:** You want to systematically analyze competitor content — conference talks, documentation, blog posts — and identify patterns.
+
+**Solution:** Ingest competitor content from multiple sources and query for patterns.
+
+```bash
+# Ingest competitor conference talks from YouTube
+planopticon ingest "https://youtube.com/watch?v=competitor-talk-1" --output ./competitive
+planopticon ingest "https://youtube.com/watch?v=competitor-talk-2" --output ./competitive
+
+# Ingest their documentation
+planopticon ingest "https://competitor.com/docs" --output ./competitive
+
+# Ingest their GitHub repos
+planopticon auth github
+planopticon ingest "github://competitor/main-product" --output ./competitive
+
+# Analyze patterns
+planopticon query "entities --type technology"
+planopticon query "What technologies are competitors investing in?"
+planopticon companion --kb ./competitive
+```
+
+```
+planopticon> What are the common architectural patterns across competitors?
+planopticon> /entities --type technology
+planopticon> Which technologies appear most frequently?
+planopticon> /export markdown
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,8 +81,15 @@ nav:
   - User Guide:
       - Single Video Analysis: guide/single-video.md
       - Batch Processing: guide/batch.md
+      - Document Ingestion: guide/document-ingestion.md
       - Cloud Sources: guide/cloud-sources.md
+      - Knowledge Graphs: guide/knowledge-graphs.md
+      - Interactive Companion: guide/companion.md
+      - Planning Agent: guide/planning-agent.md
+      - Authentication: guide/authentication.md
+      - Export & Documents: guide/export.md
       - Output Formats: guide/output-formats.md
+  - Use Cases: use-cases.md
   - CLI Reference: cli-reference.md
   - Architecture:
       - Overview: architecture/overview.md
@@ -92,6 +99,10 @@ nav:
       - Models: api/models.md
       - Providers: api/providers.md
       - Analyzers: api/analyzers.md
+      - Agent & Skills: api/agent.md
+      - Sources: api/sources.md
+      - Authentication: api/auth.md
+  - FAQ & Troubleshooting: faq.md
   - Contributing: contributing.md
 
 extra:


### PR DESCRIPTION
## Summary

Complete documentation overhaul for planopticon.dev — expanding from 16 to 27 pages with ~8,000 lines of new content.

### New pages (11)

**User Guide:**
- **Interactive Companion** — full REPL guide with all 18 slash commands, provider switching, chat mode, example session
- **Planning Agent** — 11 skills documented, AgentContext, interactive vs non-interactive, skill chaining workflows
- **Knowledge Graphs** — SQLite storage, planning taxonomy (6 entity types), merge/dedup, querying, HTML viewer, KG management
- **Authentication** — OAuth setup for all 6 services, auth chain explanation, token storage, troubleshooting
- **Document Ingestion** — PDF/Markdown/plaintext pipelines, merging, chunking strategies
- **Export & Documents** — 7 markdown doc types, Obsidian/Notion/Wiki/Exchange exports

**API Reference:**
- **Agent & Skills** — PlanningAgent, AgentContext, Skill ABC, Artifact, KBContext
- **Sources** — BaseSource, 21 source connectors by category, auth integration
- **Authentication** — AuthConfig, OAuthManager, KNOWN_CONFIGS

**Top-level:**
- **Use Cases** — 10 real-world workflows: meeting notes, research processing, knowledge gathering, team onboarding, data synthesis, content creation, decision tracking, Zoom/Teams/Meet integration, offline processing, competitive research
- **FAQ & Troubleshooting** — common questions (cost, offline, formats), auth errors, provider errors, processing errors, KG issues, companion issues, export issues

### Updated pages (10)
- output-formats.md — all formats including SQLite KG, Exchange, 7 doc types
- single-video.md — taxonomy, --speakers, --output-format, post-analysis workflows
- batch.md — fuzzy merge, incremental processing, querying results
- pipeline.md — 5 mermaid diagrams covering all pipelines
- contributing.md — ruff, ProviderRegistry, skills, processors, exporters
- configuration.md — full .env example file with OAuth setup links for every service
- api/models.md, providers.md, analyzers.md — expanded from stubs to full reference

### Also
- mkdocs.yml nav updated with all new pages
- Fixed check-yaml pre-commit hook for mkdocs.yml Python tags

## Test plan
- [x] Pre-commit hooks pass (yaml, trailing whitespace, end-of-file)
- [x] All 821+ tests still pass (no code changes)
- [ ] MkDocs build verified by docs CI workflow on merge