### PR TITLE
feat: screenshot knowledge extraction

### DIFF
--- a/tests/test_diagram_analyzer.py
+++ b/tests/test_diagram_analyzer.py
@@ -149,18 +149,29 @@ class TestDiagramAnalyzer:
             }
         )
 
+        # Screenshot extraction response for medium-confidence frame
+        screenshot_response = json.dumps(
+            {
+                "content_type": "slide",
+                "caption": "A slide about something",
+                "text_content": "Key Points\n- Item 1\n- Item 2",
+                "entities": ["Item 1", "Item 2"],
+                "topics": ["presentation"],
+            }
+        )
+
         # Calls are interleaved per-frame:
         # call 0: classify frame 0 (high conf)
         # call 1: analyze frame 0 (full analysis)
         # call 2: classify frame 1 (low conf - skip)
         # call 3: classify frame 2 (medium conf)
-        # call 4: caption frame 2 (screengrab)
+        # call 4: screenshot extraction frame 2
         call_sequence = [
             classify_responses[0],  # classify frame 0
             analysis_response,  # analyze frame 0
             classify_responses[1],  # classify frame 1
             classify_responses[2],  # classify frame 2
-            "A slide about something",  # caption frame 2
+            screenshot_response,  # screenshot extraction frame 2
         ]
         call_count = [0]
 
@@ -180,6 +191,10 @@ class TestDiagramAnalyzer:
 
         assert len(captures) == 1
         assert captures[0].frame_index == 2
+        assert captures[0].content_type == "slide"
+        assert captures[0].text_content == "Key Points\n- Item 1\n- Item 2"
+        assert "Item 1" in captures[0].entities
+        assert "presentation" in captures[0].topics
 
         # Check files were saved
         assert (diagrams_dir / "diagram_0.jpg").exists()
@@ -210,7 +225,16 @@ class TestDiagramAnalyzer:
                 )
             if idx == 1:
                 return "This is not valid JSON"  # Analysis fails
-            return "A chart showing data"  # Caption
+            # Screenshot extraction for the fallback screengrab
+            return json.dumps(
+                {
+                    "content_type": "chart",
+                    "caption": "A chart showing data",
+                    "text_content": "Sales Q1 Q2 Q3",
+                    "entities": ["Sales"],
+                    "topics": ["metrics"],
+                }
+            )
 
         mock_pm.analyze_image.side_effect = side_effect
 
@@ -218,3 +242,25 @@ class TestDiagramAnalyzer:
         assert len(diagrams) == 0
         assert len(captures) == 1
         assert captures[0].frame_index == 0
+        assert captures[0].content_type == "chart"
+        assert captures[0].text_content == "Sales Q1 Q2 Q3"
+
+    def test_extract_screenshot_knowledge(self, analyzer, mock_pm, fake_frame):
+        mock_pm.analyze_image.return_value = json.dumps(
+            {
+                "content_type": "code",
+                "caption": "Python source code",
+                "text_content": "def main():\n    print('hello')",
+                "entities": ["Python", "main function"],
+                "topics": ["programming", "source code"],
+            }
+        )
+        result = analyzer.extract_screenshot_knowledge(fake_frame)
+        assert result["content_type"] == "code"
+        assert "Python" in result["entities"]
+        assert "def main" in result["text_content"]
+
+    def test_extract_screenshot_knowledge_failure(self, analyzer, mock_pm, fake_frame):
+        mock_pm.analyze_image.return_value = "not json"
+        result = analyzer.extract_screenshot_knowledge(fake_frame)
+        assert result == {}

--- a/tests/test_knowledge_graph.py
+++ b/tests/test_knowledge_graph.py
@@ -136,6 +136,80 @@ class TestProcessDiagrams:
         assert kg_with_provider._store.has_entity("diagram_1")
 
 
+class TestProcessScreenshots:
+    @pytest.fixture
+    def mock_pm(self):
+        pm = MagicMock()
+        pm.chat.return_value = json.dumps(
+            [
+                {"name": "Python", "type": "technology", "description": "Language"},
+                {"name": "Flask", "type": "technology", "description": "Framework"},
+            ]
+        )
+        return pm
+
+    @pytest.fixture
+    def kg_with_provider(self, mock_pm):
+        return KnowledgeGraph(provider_manager=mock_pm)
+
+    def test_process_screenshots_with_text(self, kg_with_provider, mock_pm):
+        screenshots = [
+            {
+                "text_content": "import flask\napp = Flask(__name__)",
+                "content_type": "code",
+                "entities": ["Flask", "Python"],
+                "frame_index": 3,
+            },
+        ]
+        kg_with_provider.process_screenshots(screenshots)
+        # LLM extraction from text_content
+        mock_pm.chat.assert_called()
+        # Explicitly listed entities should be added
+        assert kg_with_provider._store.has_entity("Flask")
+        assert kg_with_provider._store.has_entity("Python")
+
+    def test_process_screenshots_without_text(self, kg_with_provider, mock_pm):
+        screenshots = [
+            {
+                "text_content": "",
+                "content_type": "other",
+                "entities": ["Docker"],
+                "frame_index": 5,
+            },
+        ]
+        kg_with_provider.process_screenshots(screenshots)
+        # No chat call for empty text
+        mock_pm.chat.assert_not_called()
+        # But explicit entities still added
+        assert kg_with_provider._store.has_entity("Docker")
+
+    def test_process_screenshots_empty_entities(self, kg_with_provider):
+        screenshots = [
+            {
+                "text_content": "",
+                "content_type": "slide",
+                "entities": [],
+                "frame_index": 0,
+            },
+        ]
+        kg_with_provider.process_screenshots(screenshots)
+        # No crash, no entities added
+
+    def test_process_screenshots_filters_short_names(self, kg_with_provider):
+        screenshots = [
+            {
+                "text_content": "",
+                "entities": ["A", "Go", "Python"],
+                "frame_index": 0,
+            },
+        ]
+        kg_with_provider.process_screenshots(screenshots)
+        # "A" is too short (< 2 chars), filtered out
+        assert not kg_with_provider._store.has_entity("A")
+        assert kg_with_provider._store.has_entity("Go")
+        assert kg_with_provider._store.has_entity("Python")
+
+
 class TestToDictFromDict:
     def test_round_trip_empty(self):
         kg = KnowledgeGraph()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -117,6 +117,24 @@ class TestScreenCapture:
     def test_basic(self):
         sc = ScreenCapture(frame_index=10, caption="Architecture overview slide", confidence=0.5)
         assert sc.image_path is None
+        assert sc.content_type is None
+        assert sc.text_content is None
+        assert sc.entities == []
+        assert sc.topics == []
+
+    def test_with_extraction(self):
+        sc = ScreenCapture(
+            frame_index=5,
+            caption="Code editor showing Python",
+            confidence=0.5,
+            content_type="code",
+            text_content="def main():\n    print('hello')",
+            entities=["Python", "main function"],
+            topics=["programming"],
+        )
+        assert sc.content_type == "code"
+        assert "Python" in sc.entities
+        assert sc.text_content is not None
 
     def test_round_trip(self):
         sc = ScreenCapture(
@@ -125,6 +143,10 @@ class TestScreenCapture:
             caption="Timeline",
             image_path="captures/capture_0.jpg",
             confidence=0.45,
+            content_type="slide",
+            text_content="Q4 Roadmap",
+            entities=["Roadmap"],
+            topics=["planning"],
         )
         restored = ScreenCapture.model_validate_json(sc.model_dump_json())
         assert restored == sc

--- a/video_processor/analyzers/diagram_analyzer.py
+++ b/video_processor/analyzers/diagram_analyzer.py
@@ -57,6 +57,27 @@ If any field cannot be determined, use null or empty list.
 # Caption prompt for screengrab fallback
 _CAPTION_PROMPT = "Briefly describe what this image shows in 1-2 sentences."
 
+# Rich screenshot extraction prompt — extracts knowledge from shared screens
+_SCREENSHOT_EXTRACT_PROMPT = """\
+Analyze this screenshot from a video recording. Extract all visible knowledge.
+This is shared screen content (slides, code, documents, browser, terminal, etc.).
+
+Return ONLY a JSON object (no markdown fences):
+{
+  "content_type": "slide"|"code"|"document"|"terminal"|"browser"|"chat"|"other",
+  "caption": "one-sentence description of what is shown",
+  "text_content": "all visible text, preserving structure and line breaks",
+  "entities": ["named things visible: people, technologies, tools, services, \
+projects, libraries, APIs, error codes, URLs, file paths"],
+  "topics": ["concepts or subjects this content is about"]
+}
+
+For text_content: extract ALL readable text — code, titles, bullet points, URLs,
+error messages, terminal output, chat messages, file names. Be thorough.
+For entities: extract specific named things, not generic words.
+For topics: extract 2-5 high-level topics this content relates to.
+"""
+
 
 def _read_image_bytes(image_path: Union[str, Path]) -> bytes:
     """Read image file as bytes."""
@@ -131,6 +152,13 @@ class DiagramAnalyzer:
         """Get a brief caption for a screengrab fallback."""
         image_bytes = _read_image_bytes(image_path)
         return self.pm.analyze_image(image_bytes, _CAPTION_PROMPT, max_tokens=256)
+
+    def extract_screenshot_knowledge(self, image_path: Union[str, Path]) -> dict:
+        """Extract knowledge from a screenshot — text, entities, topics."""
+        image_bytes = _read_image_bytes(image_path)
+        raw = self.pm.analyze_image(image_bytes, _SCREENSHOT_EXTRACT_PROMPT, max_tokens=2048)
+        result = _parse_json_response(raw)
+        return result or {}
 
     def process_frames(
         self,
@@ -314,17 +342,47 @@ class DiagramAnalyzer:
         captures_dir: Optional[Path],
         confidence: float,
     ) -> ScreenCapture:
-        """Save a frame as a captioned screengrab."""
+        """Extract knowledge from a screenshot and save it."""
+        # Try rich extraction first, fall back to caption-only
         caption = ""
+        content_type = None
+        text_content = None
+        entities: List[str] = []
+        topics: List[str] = []
+
         try:
-            caption = self.caption_frame(frame_path)
+            extraction = self.extract_screenshot_knowledge(frame_path)
+            if extraction:
+                caption = extraction.get("caption", "")
+                content_type = extraction.get("content_type")
+                text_content = extraction.get("text_content")
+                raw_entities = extraction.get("entities", [])
+                entities = [str(e) for e in raw_entities] if isinstance(raw_entities, list) else []
+                raw_topics = extraction.get("topics", [])
+                topics = [str(t) for t in raw_topics] if isinstance(raw_topics, list) else []
+                logger.info(
+                    f"Frame {frame_index}: extracted "
+                    f"{len(entities)} entities, "
+                    f"{len(topics)} topics from {content_type}"
+                )
         except Exception as e:
-            logger.warning(f"Caption failed for frame {frame_index}: {e}")
+            logger.warning(
+                f"Screenshot extraction failed for frame "
+                f"{frame_index}: {e}, falling back to caption"
+            )
+            try:
+                caption = self.caption_frame(frame_path)
+            except Exception as e2:
+                logger.warning(f"Caption also failed for frame {frame_index}: {e2}")
 
         sc = ScreenCapture(
             frame_index=frame_index,
             caption=caption,
             confidence=confidence,
+            content_type=content_type,
+            text_content=text_content,
+            entities=entities,
+            topics=topics,
         )
 
         if captures_dir:

--- a/video_processor/integrators/knowledge_graph.py
+++ b/video_processor/integrators/knowledge_graph.py
@@ -199,6 +199,38 @@ class KnowledgeGraph:
                     text=f"frame_index={diagram.get('frame_index')}",
                 )
 
+    def process_screenshots(self, screenshots: List[Dict]) -> None:
+        """Process screenshot captures into knowledge graph.
+
+        Extracts entities from text_content and adds screenshot-specific
+        entities from the entities list.
+        """
+        for i, capture in enumerate(screenshots):
+            text_content = capture.get("text_content", "")
+            source = f"screenshot_{i}"
+            content_type = capture.get("content_type", "screenshot")
+
+            # Extract entities from visible text via LLM
+            if text_content:
+                self.add_content(text_content, source)
+
+            # Add explicitly identified entities from vision extraction
+            for entity_name in capture.get("entities", []):
+                if not entity_name or len(entity_name) < 2:
+                    continue
+                if not self._store.has_entity(entity_name):
+                    self._store.merge_entity(
+                        entity_name,
+                        "concept",
+                        [f"Identified in {content_type} screenshot"],
+                        source=source,
+                    )
+                self._store.add_occurrence(
+                    entity_name,
+                    source,
+                    text=f"Visible in {content_type} (frame {capture.get('frame_index', '?')})",
+                )
+
     def to_data(self) -> KnowledgeGraphData:
         """Convert to pydantic KnowledgeGraphData model."""
         nodes = []

--- a/video_processor/models.py
+++ b/video_processor/models.py
@@ -99,7 +99,7 @@ class DiagramResult(BaseModel):
 
 
 class ScreenCapture(BaseModel):
-    """A screengrab fallback when diagram extraction fails or is uncertain."""
+    """A screen capture with knowledge extraction from shared content."""
 
     frame_index: int = Field(description="Index of the source frame")
     timestamp: Optional[float] = Field(default=None, description="Timestamp in video (seconds)")
@@ -107,6 +107,19 @@ class ScreenCapture(BaseModel):
     image_path: Optional[str] = Field(default=None, description="Relative path to screenshot")
     confidence: float = Field(
         default=0.0, description="Detection confidence that triggered fallback"
+    )
+    content_type: Optional[str] = Field(
+        default=None,
+        description="Content type: slide, code, document, terminal, browser, chat, other",
+    )
+    text_content: Optional[str] = Field(
+        default=None, description="All visible text extracted from the screenshot"
+    )
+    entities: List[str] = Field(
+        default_factory=list, description="Entities identified in the screenshot"
+    )
+    topics: List[str] = Field(
+        default_factory=list, description="Topics or concepts visible in the screenshot"
     )
 
 

--- a/video_processor/pipeline.py
+++ b/video_processor/pipeline.py
@@ -245,6 +245,9 @@ def process_single_video(
         if diagrams:
             diagram_dicts = [d.model_dump() for d in diagrams]
             kg.process_diagrams(diagram_dicts)
+        if screen_captures:
+            capture_dicts = [sc.model_dump() for sc in screen_captures]
+            kg.process_screenshots(capture_dicts)
     # Export JSON copy alongside the SQLite db
     kg.save(kg_json_path)
     pipeline_bar.update(1)


### PR DESCRIPTION
## Summary
- Screenshots (medium-confidence frames) now get full knowledge extraction instead of just a 1-sentence caption
- New vision LLM prompt extracts `content_type`, `text_content`, `entities`, and `topics` from each screenshot
- Extracted entities are fed into the knowledge graph via new `process_screenshots()` method
- Extended `ScreenCapture` model with new fields, updated pipeline wiring

## Changes
- `video_processor/analyzers/diagram_analyzer.py` — Added `_SCREENSHOT_EXTRACT_PROMPT`, `extract_screenshot_knowledge()`, upgraded `_save_screengrab()` 
- `video_processor/models.py` — Extended `ScreenCapture` with `content_type`, `text_content`, `entities`, `topics`
- `video_processor/integrators/knowledge_graph.py` — Added `process_screenshots()`
- `video_processor/pipeline.py` — Wired screenshot processing into KG build step
- Tests updated across `test_diagram_analyzer.py`, `test_models.py`, `test_knowledge_graph.py`

## Test plan
- [x] All 77 unit tests pass (test_diagram_analyzer, test_models, test_knowledge_graph)
- [ ] CI passes

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)