### PR TITLE
feat(graph): shortest path, clusters, and enhanced queries

### DIFF
--- a/tests/test_graph_query.py
+++ b/tests/test_graph_query.py
@@ -273,3 +273,65 @@ class TestAgenticMode:
         result = engine.ask("Gibberish?")
         assert result.data is None
         assert "parse" in result.explanation.lower() or "could not" in result.explanation.lower()
+
+
+class TestGraphAlgorithms:
+    def test_shortest_path(self):
+        store = InMemoryStore()
+        store.merge_entity("A", "concept", [])
+        store.merge_entity("B", "concept", [])
+        store.merge_entity("C", "concept", [])
+        store.add_relationship("A", "B", "connects")
+        store.add_relationship("B", "C", "connects")
+        engine = GraphQueryEngine(store)
+
+        result = engine.shortest_path("A", "C")
+        assert "Path found" in result.explanation
+        assert len(result.data) > 0
+
+    def test_shortest_path_same_entity(self):
+        store = InMemoryStore()
+        store.merge_entity("X", "concept", [])
+        engine = GraphQueryEngine(store)
+
+        result = engine.shortest_path("X", "X")
+        assert "same entity" in result.explanation.lower()
+
+    def test_shortest_path_not_found(self):
+        store = InMemoryStore()
+        store.merge_entity("A", "concept", [])
+        store.merge_entity("Z", "concept", [])
+        engine = GraphQueryEngine(store)
+
+        result = engine.shortest_path("A", "Z")
+        assert "No path found" in result.explanation
+
+    def test_shortest_path_entity_missing(self):
+        store = InMemoryStore()
+        engine = GraphQueryEngine(store)
+
+        result = engine.shortest_path("Missing", "Also Missing")
+        assert "not found" in result.explanation
+
+    def test_clusters(self):
+        store = InMemoryStore()
+        store.merge_entity("A", "concept", [])
+        store.merge_entity("B", "concept", [])
+        store.add_relationship("A", "B", "connected")
+
+        store.merge_entity("X", "concept", [])
+        store.merge_entity("Y", "concept", [])
+        store.add_relationship("X", "Y", "connected")
+
+        store.merge_entity("Lone", "concept", [])
+
+        engine = GraphQueryEngine(store)
+        result = engine.clusters()
+        assert "3 clusters" in result.explanation
+        assert result.data[0]["size"] == 2
+
+    def test_clusters_empty(self):
+        store = InMemoryStore()
+        engine = GraphQueryEngine(store)
+        result = engine.clusters()
+        assert result.data == []

--- a/video_processor/cli/commands.py
+++ b/video_processor/cli/commands.py
@@ -853,7 +853,8 @@ def query(ctx, question, db_path, mode, output_format, interactive, provider, ch
     """Query a knowledge graph. Runs stats if no question given.
 
     Direct commands recognized in QUESTION: stats, entities, relationships,
-    neighbors, sources, provenance, sql. Natural language questions use agentic mode.
+    neighbors, path, clusters, sources, provenance, sql.
+    Natural language questions use agentic mode.
 
     Examples:
 
@@ -951,6 +952,14 @@ def _execute_query(engine, question, mode):
     if cmd == "provenance":
         entity_name = " ".join(parts[1:]) if len(parts) > 1 else ""
         return engine.provenance(entity_name)
+
+    if cmd == "path":
+        if len(parts) < 3:
+            return engine.stats()
+        return engine.shortest_path(start=parts[1], end=parts[2])
+
+    if cmd == "clusters":
+        return engine.clusters()
 
     if cmd == "sql":
         sql_query = " ".join(parts[1:])

--- a/video_processor/integrators/graph_query.py
+++ b/video_processor/integrators/graph_query.py
@@ -313,6 +313,134 @@ class GraphQueryEngine:
             explanation=f"Found {len(locations)} provenance records for '{entity_name}'",
         )
 
+    def shortest_path(self, start: str, end: str, max_depth: int = 6) -> QueryResult:
+        """Find the shortest path between two entities via BFS."""
+        start_entity = self.store.get_entity(start)
+        end_entity = self.store.get_entity(end)
+        if not start_entity:
+            return QueryResult(
+                data=[],
+                query_type="filter",
+                raw_query=f"shortest_path({start!r}, {end!r})",
+                explanation=f"Entity '{start}' not found",
+            )
+        if not end_entity:
+            return QueryResult(
+                data=[],
+                query_type="filter",
+                raw_query=f"shortest_path({start!r}, {end!r})",
+                explanation=f"Entity '{end}' not found",
+            )
+
+        all_rels = self.store.get_all_relationships()
+        # Build adjacency list
+        adj: dict[str, list[tuple[str, dict]]] = {}
+        for rel in all_rels:
+            src_l = rel["source"].lower()
+            tgt_l = rel["target"].lower()
+            adj.setdefault(src_l, []).append((tgt_l, rel))
+            adj.setdefault(tgt_l, []).append((src_l, rel))
+
+        # BFS
+        start_l = start.lower()
+        end_l = end.lower()
+        if start_l == end_l:
+            return QueryResult(
+                data=[start_entity],
+                query_type="filter",
+                raw_query=f"shortest_path({start!r}, {end!r})",
+                explanation="Start and end are the same entity",
+            )
+
+        from collections import deque
+
+        queue: deque[tuple[str, list[dict]]] = deque([(start_l, [])])
+        visited = {start_l}
+
+        while queue:
+            current, path = queue.popleft()
+            if len(path) >= max_depth:
+                continue
+            for neighbor, rel in adj.get(current, []):
+                if neighbor in visited:
+                    continue
+                new_path = path + [rel]
+                if neighbor == end_l:
+                    # Build result: entities + relationships along path
+                    path_entities = [start_entity]
+                    for r in new_path:
+                        path_entities.append(r)
+                        tgt_name = r["target"] if r["source"].lower() == current else r["source"]
+                        e = self.store.get_entity(tgt_name)
+                        if e:
+                            path_entities.append(e)
+                    path_entities.append(end_entity)
+                    # Deduplicate
+                    seen = set()
+                    deduped = []
+                    for item in path_entities:
+                        key = str(item)
+                        if key not in seen:
+                            seen.add(key)
+                            deduped.append(item)
+                    return QueryResult(
+                        data=deduped,
+                        query_type="filter",
+                        raw_query=f"shortest_path({start!r}, {end!r})",
+                        explanation=f"Path found: {len(new_path)} hops",
+                    )
+                visited.add(neighbor)
+                queue.append((neighbor, new_path))
+
+        return QueryResult(
+            data=[],
+            query_type="filter",
+            raw_query=f"shortest_path({start!r}, {end!r})",
+            explanation=f"No path found between '{start}' and '{end}' within {max_depth} hops",
+        )
+
+    def clusters(self) -> QueryResult:
+        """Find connected components (clusters) in the graph."""
+        all_entities = self.store.get_all_entities()
+        all_rels = self.store.get_all_relationships()
+
+        # Build adjacency
+        adj: dict[str, set[str]] = {}
+        for e in all_entities:
+            adj.setdefault(e["name"].lower(), set())
+        for r in all_rels:
+            adj.setdefault(r["source"].lower(), set()).add(r["target"].lower())
+            adj.setdefault(r["target"].lower(), set()).add(r["source"].lower())
+
+        visited: set[str] = set()
+        components: list[list[str]] = []
+
+        for node in adj:
+            if node in visited:
+                continue
+            component: list[str] = []
+            stack = [node]
+            while stack:
+                n = stack.pop()
+                if n in visited:
+                    continue
+                visited.add(n)
+                component.append(n)
+                stack.extend(adj.get(n, set()) - visited)
+            components.append(sorted(component))
+
+        # Sort by size descending
+        components.sort(key=len, reverse=True)
+
+        result = [{"cluster_id": i, "size": len(c), "members": c} for i, c in enumerate(components)]
+
+        return QueryResult(
+            data=result,
+            query_type="filter",
+            raw_query="clusters()",
+            explanation=f"Found {len(components)} clusters",
+        )
+
     def sql(self, query: str) -> QueryResult:
         """Execute a raw SQL query (SQLite only)."""
         result = self.store.raw_query(query)
@@ -352,6 +480,8 @@ class GraphQueryEngine:
             '- {{"action": "entities", "name": "...", "entity_type": "..."}}\n'
             '- {{"action": "relationships", "source": "...", "target": "...", "rel_type": "..."}}\n'
             '- {{"action": "neighbors", "entity_name": "...", "depth": 1}}\n'
+            '- {{"action": "shortest_path", "start": "...", "end": "..."}}\n'
+            '- {{"action": "clusters"}}\n'
             '- {{"action": "stats"}}\n\n'
             f"User question: {question}\n\n"
             "Return ONLY a JSON object with the action. Omit optional fields you don't need."
@@ -400,6 +530,13 @@ class GraphQueryEngine:
                     entity_name=plan.get("entity_name", ""),
                     depth=plan.get("depth", 1),
                 )
+            elif action == "shortest_path":
+                result = self.shortest_path(
+                    start=plan.get("start", ""),
+                    end=plan.get("end", ""),
+                )
+            elif action == "clusters":
+                result = self.clusters()
             elif action == "stats":
                 result = self.stats()
             else:


### PR DESCRIPTION
## Summary
- Add `shortest_path(start, end)` — BFS-based path finding between entities with max depth control
- Add `clusters()` — connected component detection returning sorted cluster info
- Wire `path` and `clusters` commands into CLI (`planopticon query "path A C"`, `planopticon query clusters`)
- Extend agentic query mode to support shortest_path and clusters actions
- 6 new tests covering path finding (found, same entity, not found, missing entity) and clustering (multiple components, empty graph)

Closes #112

## Test plan
- [x] All 34 graph query tests pass
- [x] Existing tests unaffected
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)