### PR TITLE
feat(export): PDF and PPTX export formats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
 
 [project.optional-dependencies]
 pdf = ["pymupdf>=1.24.0"]
+exports = ["reportlab>=4.0", "python-pptx>=1.0"]
 gpu = ["torch>=2.0.0", "torchvision>=0.15.0"]
 gdrive = ["google-auth>=2.0.0", "google-auth-oauthlib>=1.0.0", "google-api-python-client>=2.0.0"]
 dropbox = ["dropbox>=12.0.0"]

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -1,0 +1,157 @@
+"""Tests for PDF and PPTX exporters."""
+
+import pytest
+
+from video_processor.exporters.pdf_export import generate_pdf
+from video_processor.exporters.pptx_export import generate_pptx
+
+
+def _sample_kg():
+    """Return a sample knowledge graph dict for testing."""
+    return {
+        "nodes": [
+            {"name": "Python", "type": "technology", "descriptions": ["A programming language"]},
+            {"name": "Django", "type": "technology", "descriptions": ["A web framework"]},
+            {"name": "Alice", "type": "person", "descriptions": ["Software engineer"]},
+            {"name": "Bob", "type": "person", "descriptions": ["Product manager"]},
+            {"name": "Acme Corp", "type": "organization", "descriptions": ["A tech company"]},
+        ],
+        "relationships": [
+            {"source": "Alice", "target": "Python", "type": "uses"},
+            {"source": "Alice", "target": "Bob", "type": "works_with"},
+            {"source": "Django", "target": "Python", "type": "built_on"},
+            {"source": "Alice", "target": "Acme Corp", "type": "employed_by"},
+        ],
+    }
+
+
+def _empty_kg():
+    return {"nodes": [], "relationships": []}
+
+
+class TestPDFExport:
+    @pytest.fixture(autouse=True)
+    def _check_reportlab(self):
+        pytest.importorskip("reportlab")
+
+    def test_generate_pdf(self, tmp_path):
+        out = tmp_path / "report.pdf"
+        result = generate_pdf(_sample_kg(), out, title="Test Report")
+        assert result == out
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    def test_generate_pdf_empty_kg(self, tmp_path):
+        out = tmp_path / "empty.pdf"
+        result = generate_pdf(_empty_kg(), out)
+        assert result == out
+        assert out.exists()
+
+    def test_generate_pdf_creates_parent_dirs(self, tmp_path):
+        out = tmp_path / "sub" / "dir" / "report.pdf"
+        result = generate_pdf(_sample_kg(), out)
+        assert result == out
+        assert out.exists()
+
+    def test_generate_pdf_default_title(self, tmp_path):
+        out = tmp_path / "default.pdf"
+        generate_pdf(_sample_kg(), out)
+        assert out.exists()
+
+    def test_generate_pdf_with_diagrams_dir(self, tmp_path):
+        diag_dir = tmp_path / "diagrams"
+        diag_dir.mkdir()
+        out = tmp_path / "report.pdf"
+        # No PNGs in dir — should still work
+        result = generate_pdf(_sample_kg(), out, diagrams_dir=diag_dir)
+        assert result == out
+
+    def test_generate_pdf_no_reportlab(self, tmp_path, monkeypatch):
+        """Verify ImportError propagates when reportlab is missing."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name.startswith("reportlab"):
+                raise ImportError("No module named 'reportlab'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        with pytest.raises(ImportError):
+            generate_pdf(_sample_kg(), tmp_path / "fail.pdf")
+
+
+class TestPPTXExport:
+    @pytest.fixture(autouse=True)
+    def _check_pptx(self):
+        pytest.importorskip("pptx")
+
+    def test_generate_pptx(self, tmp_path):
+        out = tmp_path / "slides.pptx"
+        result = generate_pptx(_sample_kg(), out, title="Test Deck")
+        assert result == out
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    def test_generate_pptx_empty_kg(self, tmp_path):
+        out = tmp_path / "empty.pptx"
+        result = generate_pptx(_empty_kg(), out)
+        assert result == out
+        assert out.exists()
+
+    def test_generate_pptx_creates_parent_dirs(self, tmp_path):
+        out = tmp_path / "sub" / "dir" / "slides.pptx"
+        result = generate_pptx(_sample_kg(), out)
+        assert result == out
+        assert out.exists()
+
+    def test_generate_pptx_with_diagrams_dir(self, tmp_path):
+        diag_dir = tmp_path / "diagrams"
+        diag_dir.mkdir()
+        out = tmp_path / "slides.pptx"
+        result = generate_pptx(_sample_kg(), out, diagrams_dir=diag_dir)
+        assert result == out
+
+    def test_pptx_slide_count(self, tmp_path):
+        """Verify expected number of slides are created."""
+        from pptx import Presentation
+
+        out = tmp_path / "count.pptx"
+        generate_pptx(_sample_kg(), out)
+        prs = Presentation(str(out))
+        # Title + Overview + Key Entities + Rel Types + 1 entity batch = 5
+        assert len(prs.slides) == 5
+
+    def test_pptx_many_entities_batched(self, tmp_path):
+        """Entities are batched into multiple slides when >12."""
+        from pptx import Presentation
+
+        kg = {
+            "nodes": [
+                {"name": f"Entity{i}", "type": "concept", "descriptions": [f"desc {i}"]}
+                for i in range(25)
+            ],
+            "relationships": [],
+        }
+        out = tmp_path / "many.pptx"
+        generate_pptx(kg, out)
+        prs = Presentation(str(out))
+        # Title + Overview + 3 entity batches (12 + 12 + 1) = 5
+        # No Key Entities or Rel Types slides (no relationships)
+        assert len(prs.slides) == 5
+
+    def test_generate_pptx_no_pptx(self, tmp_path, monkeypatch):
+        """Verify ImportError propagates when python-pptx is missing."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name.startswith("pptx"):
+                raise ImportError("No module named 'pptx'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        with pytest.raises(ImportError):
+            generate_pptx(_sample_kg(), tmp_path / "fail.pptx")

--- a/video_processor/cli/commands.py
+++ b/video_processor/cli/commands.py
@@ -1579,6 +1579,80 @@ def export_notion(db_path, output):
     click.echo(f"Exported Notion markdown: {len(created)} files in {out_dir}/")
 
 
+@export.command("pdf")
+@click.argument("db_path", type=click.Path(exists=True))
+@click.option("-o", "--output", type=click.Path(), default=None, help="Output PDF file path")
+@click.option("--title", type=str, default=None, help="Report title")
+@click.option(
+    "--diagrams",
+    type=click.Path(exists=True),
+    default=None,
+    help="Directory with diagram PNGs to embed",
+)
+def export_pdf(db_path, output, title, diagrams):
+    """Generate a PDF report from a knowledge graph.
+
+    Requires: pip install reportlab
+
+    Examples:
+
+        planopticon export pdf knowledge_graph.db
+
+        planopticon export pdf kg.db -o report.pdf --title "Q1 Review"
+
+        planopticon export pdf kg.db --diagrams ./diagrams/
+    """
+    from video_processor.exporters.pdf_export import generate_pdf
+    from video_processor.integrators.knowledge_graph import KnowledgeGraph
+
+    db_path = Path(db_path)
+    out_path = Path(output) if output else Path.cwd() / "export" / "report.pdf"
+    diagrams_path = Path(diagrams) if diagrams else None
+
+    kg = KnowledgeGraph(db_path=db_path)
+    kg_data = kg.to_dict()
+
+    result = generate_pdf(kg_data, out_path, title=title, diagrams_dir=diagrams_path)
+    click.echo(f"Generated PDF: {result}")
+
+
+@export.command("pptx")
+@click.argument("db_path", type=click.Path(exists=True))
+@click.option("-o", "--output", type=click.Path(), default=None, help="Output PPTX file path")
+@click.option("--title", type=str, default=None, help="Presentation title")
+@click.option(
+    "--diagrams",
+    type=click.Path(exists=True),
+    default=None,
+    help="Directory with diagram PNGs to embed",
+)
+def export_pptx(db_path, output, title, diagrams):
+    """Generate a PPTX slide deck from a knowledge graph.
+
+    Requires: pip install python-pptx
+
+    Examples:
+
+        planopticon export pptx knowledge_graph.db
+
+        planopticon export pptx kg.db -o slides.pptx --title "Architecture Overview"
+
+        planopticon export pptx kg.db --diagrams ./diagrams/
+    """
+    from video_processor.exporters.pptx_export import generate_pptx
+    from video_processor.integrators.knowledge_graph import KnowledgeGraph
+
+    db_path = Path(db_path)
+    out_path = Path(output) if output else Path.cwd() / "export" / "presentation.pptx"
+    diagrams_path = Path(diagrams) if diagrams else None
+
+    kg = KnowledgeGraph(db_path=db_path)
+    kg_data = kg.to_dict()
+
+    result = generate_pptx(kg_data, out_path, title=title, diagrams_dir=diagrams_path)
+    click.echo(f"Generated PPTX: {result}")
+
+
 @export.command("exchange")
 @click.argument("db_path", type=click.Path(exists=True))
 @click.option(

--- a/video_processor/exporters/__init__.py
+++ b/video_processor/exporters/__init__.py
@@ -1,1 +1,1 @@
-"""Document exporters for generating markdown, CSV, and structured notes."""
+"""Document exporters for generating markdown, CSV, PDF, PPTX, and structured notes."""

--- a/video_processor/exporters/pdf_export.py
+++ b/video_processor/exporters/pdf_export.py
@@ -1,0 +1,277 @@
+"""Generate PDF reports from knowledge graph data.
+
+Uses reportlab for PDF generation. Falls back gracefully if not installed.
+No LLM required — pure template-based generation from KG data.
+"""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _get_styles():
+    """Import and configure reportlab styles."""
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+    from reportlab.lib.units import inch
+
+    styles = getSampleStyleSheet()
+
+    styles.add(
+        ParagraphStyle(
+            "KGTitle",
+            parent=styles["Title"],
+            fontSize=24,
+            spaceAfter=20,
+            textColor=colors.HexColor("#1a1a2e"),
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            "KGHeading2",
+            parent=styles["Heading2"],
+            fontSize=16,
+            spaceBefore=16,
+            spaceAfter=8,
+            textColor=colors.HexColor("#16213e"),
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            "KGBody",
+            parent=styles["Normal"],
+            fontSize=10,
+            leading=14,
+            spaceBefore=4,
+            spaceAfter=4,
+        )
+    )
+    styles.add(
+        ParagraphStyle(
+            "KGBullet",
+            parent=styles["Normal"],
+            fontSize=10,
+            leading=14,
+            leftIndent=20,
+            bulletIndent=10,
+            spaceBefore=2,
+            spaceAfter=2,
+        )
+    )
+
+    return styles, letter, inch, colors
+
+
+def _build_entity_table(nodes: List[dict], colors) -> Any:
+    """Build a table of entities grouped by type."""
+    from reportlab.lib.units import inch
+    from reportlab.platypus import Table, TableStyle
+
+    by_type: Dict[str, list] = {}
+    for n in nodes:
+        t = n.get("type", "concept")
+        by_type.setdefault(t, []).append(n)
+
+    data = [["Type", "Count", "Examples"]]
+    for etype, elist in sorted(by_type.items(), key=lambda x: -len(x[1])):
+        examples = ", ".join(e.get("name", "") for e in elist[:3])
+        if len(elist) > 3:
+            examples += f" (+{len(elist) - 3} more)"
+        data.append([etype.title(), str(len(elist)), examples])
+
+    table = Table(data, colWidths=[1.2 * inch, 0.8 * inch, 4.0 * inch])
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#e8eaf6")),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 9),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("TOPPADDING", (0, 0), (-1, -1), 4),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+            ]
+        )
+    )
+    return table
+
+
+def _build_relationship_table(rels: List[dict], colors, max_rows: int = 30) -> Any:
+    """Build a table of relationships."""
+    from reportlab.lib.units import inch
+    from reportlab.platypus import Table, TableStyle
+
+    data = [["Source", "Relationship", "Target"]]
+    for r in rels[:max_rows]:
+        data.append([r.get("source", ""), r.get("type", ""), r.get("target", "")])
+    if len(rels) > max_rows:
+        data.append(["...", f"({len(rels) - max_rows} more)", "..."])
+
+    table = Table(data, colWidths=[2.0 * inch, 2.0 * inch, 2.0 * inch])
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#e8eaf6")),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 9),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("TOPPADDING", (0, 0), (-1, -1), 4),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+            ]
+        )
+    )
+    return table
+
+
+def _build_key_entities_table(rels: List[dict], colors) -> Any:
+    """Build a table of top entities by connection count."""
+    from reportlab.lib.units import inch
+    from reportlab.platypus import Table, TableStyle
+
+    degree: Dict[str, int] = {}
+    for r in rels:
+        degree[r.get("source", "")] = degree.get(r.get("source", ""), 0) + 1
+        degree[r.get("target", "")] = degree.get(r.get("target", ""), 0) + 1
+
+    top = sorted(degree.items(), key=lambda x: -x[1])[:10]
+    if not top:
+        return None
+
+    data = [["Entity", "Connections"]]
+    for name, deg in top:
+        data.append([name, str(deg)])
+
+    table = Table(data, colWidths=[4.0 * inch, 1.5 * inch])
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#e8eaf6")),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 9),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                ("TOPPADDING", (0, 0), (-1, -1), 4),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+            ]
+        )
+    )
+    return table
+
+
+def generate_pdf(
+    kg_data: dict,
+    output_path: Path,
+    title: Optional[str] = None,
+    diagrams_dir: Optional[Path] = None,
+) -> Path:
+    """Generate a PDF report from knowledge graph data.
+
+    Args:
+        kg_data: Knowledge graph dict with 'nodes' and 'relationships'.
+        output_path: Path to write the PDF file.
+        title: Optional report title.
+        diagrams_dir: Optional directory containing diagram images to embed.
+
+    Returns:
+        Path to the generated PDF.
+
+    Raises:
+        ImportError: If reportlab is not installed.
+    """
+    from reportlab.platypus import (
+        Paragraph,
+        SimpleDocTemplate,
+        Spacer,
+    )
+
+    styles, letter, inch, colors = _get_styles()
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    doc = SimpleDocTemplate(
+        str(output_path),
+        pagesize=letter,
+        topMargin=0.75 * inch,
+        bottomMargin=0.75 * inch,
+        leftMargin=0.75 * inch,
+        rightMargin=0.75 * inch,
+    )
+
+    story = []
+    nodes = kg_data.get("nodes", [])
+    rels = kg_data.get("relationships", [])
+
+    # Title
+    report_title = title or "Knowledge Graph Report"
+    story.append(Paragraph(report_title, styles["KGTitle"]))
+    story.append(
+        Paragraph(
+            f"Generated {datetime.now().strftime('%Y-%m-%d %H:%M')} &bull; "
+            f"{len(nodes)} entities &bull; {len(rels)} relationships",
+            styles["KGBody"],
+        )
+    )
+    story.append(Spacer(1, 20))
+
+    # Entity breakdown
+    if nodes:
+        story.append(Paragraph("Entity Breakdown", styles["KGHeading2"]))
+        story.append(_build_entity_table(nodes, colors))
+        story.append(Spacer(1, 12))
+
+    # Key entities
+    if rels:
+        key_table = _build_key_entities_table(rels, colors)
+        if key_table:
+            story.append(Paragraph("Key Entities (by connections)", styles["KGHeading2"]))
+            story.append(key_table)
+            story.append(Spacer(1, 12))
+
+    # Embed diagram images
+    if diagrams_dir and diagrams_dir.exists():
+        _embed_diagrams(story, styles, diagrams_dir, inch)
+
+    # Relationship table
+    if rels:
+        story.append(Paragraph("Relationships", styles["KGHeading2"]))
+        story.append(_build_relationship_table(rels, colors))
+        story.append(Spacer(1, 12))
+
+    # Entity details
+    if nodes:
+        story.append(Paragraph("Entity Details", styles["KGHeading2"]))
+        for node in sorted(nodes, key=lambda n: n.get("name", "")):
+            name = node.get("name", "")
+            etype = node.get("type", "concept")
+            descs = node.get("descriptions", [])
+            desc = descs[0] if descs else "No description."
+            story.append(Paragraph(f"<b>{name}</b> <i>({etype})</i>: {desc}", styles["KGBullet"]))
+
+    doc.build(story)
+    logger.info(f"Generated PDF report: {output_path}")
+    return output_path
+
+
+def _embed_diagrams(story, styles, diagrams_dir: Path, inch):
+    """Embed diagram PNG images from a directory."""
+    from reportlab.platypus import Image, Paragraph, Spacer
+
+    pngs = sorted(diagrams_dir.glob("*.png"))
+    if not pngs:
+        return
+
+    story.append(Paragraph("Diagrams", styles["KGHeading2"]))
+
+    for png in pngs:
+        try:
+            img = Image(str(png), width=5 * inch, height=3.5 * inch)
+            img.hAlign = "CENTER"
+            story.append(img)
+            story.append(Spacer(1, 8))
+        except Exception as e:
+            logger.warning(f"Could not embed diagram {png.name}: {e}")

--- a/video_processor/exporters/pptx_export.py
+++ b/video_processor/exporters/pptx_export.py
@@ -1,0 +1,202 @@
+"""Generate PPTX slide decks from knowledge graph data.
+
+Uses python-pptx for slide generation. Falls back gracefully if not installed.
+No LLM required — pure template-based generation from KG data.
+"""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _add_title_slide(prs, title: str, subtitle: str):
+    """Add a title slide."""
+    from pptx.util import Pt
+
+    slide = prs.slides.add_slide(prs.slide_layouts[0])
+    slide.shapes.title.text = title
+    body = slide.placeholders[1]
+    body.text = subtitle
+    for paragraph in body.text_frame.paragraphs:
+        for run in paragraph.runs:
+            run.font.size = Pt(14)
+
+
+def _add_content_slide(prs, title: str, bullets: List[str]):
+    """Add a slide with bullet points."""
+    from pptx.util import Pt
+
+    slide = prs.slides.add_slide(prs.slide_layouts[1])
+    slide.shapes.title.text = title
+    body = slide.placeholders[1]
+    tf = body.text_frame
+    tf.clear()
+
+    for i, bullet in enumerate(bullets):
+        if i == 0:
+            tf.paragraphs[0].text = bullet
+            for run in tf.paragraphs[0].runs:
+                run.font.size = Pt(14)
+        else:
+            p = tf.add_paragraph()
+            p.text = bullet
+            for run in p.runs:
+                run.font.size = Pt(14)
+
+
+def _add_table_slide(prs, title: str, headers: List[str], rows: List[List[str]]):
+    """Add a slide with a table."""
+    from pptx.util import Emu, Inches, Pt
+
+    slide = prs.slides.add_slide(prs.slide_layouts[5])  # Blank layout
+    slide.shapes.title.text = title
+
+    num_rows = len(rows) + 1
+    num_cols = len(headers)
+
+    left = Inches(0.5)
+    top = Inches(1.5)
+    width = Inches(9.0)
+    row_height = Emu(int(Inches(0.35)))
+    height = row_height * num_rows
+
+    table_shape = slide.shapes.add_table(num_rows, num_cols, left, top, width, height)
+    table = table_shape.table
+
+    for i, header in enumerate(headers):
+        cell = table.cell(0, i)
+        cell.text = header
+        for paragraph in cell.text_frame.paragraphs:
+            paragraph.font.size = Pt(11)
+            paragraph.font.bold = True
+
+    for r_idx, row in enumerate(rows):
+        for c_idx, val in enumerate(row):
+            cell = table.cell(r_idx + 1, c_idx)
+            cell.text = str(val)
+            for paragraph in cell.text_frame.paragraphs:
+                paragraph.font.size = Pt(10)
+
+
+def _add_image_slide(prs, title: str, image_path: Path):
+    """Add a slide with an embedded image."""
+    from pptx.util import Inches
+
+    slide = prs.slides.add_slide(prs.slide_layouts[5])  # Blank
+    slide.shapes.title.text = title
+
+    left = Inches(1.0)
+    top = Inches(1.5)
+    width = Inches(8.0)
+    slide.shapes.add_picture(str(image_path), left, top, width=width)
+
+
+def generate_pptx(
+    kg_data: dict,
+    output_path: Path,
+    title: Optional[str] = None,
+    diagrams_dir: Optional[Path] = None,
+) -> Path:
+    """Generate a PPTX slide deck from knowledge graph data.
+
+    Args:
+        kg_data: Knowledge graph dict with 'nodes' and 'relationships'.
+        output_path: Path to write the PPTX file.
+        title: Optional presentation title.
+        diagrams_dir: Optional directory containing diagram images to embed.
+
+    Returns:
+        Path to the generated PPTX.
+
+    Raises:
+        ImportError: If python-pptx is not installed.
+    """
+    from pptx import Presentation
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    prs = Presentation()
+    nodes = kg_data.get("nodes", [])
+    rels = kg_data.get("relationships", [])
+
+    report_title = title or "Knowledge Graph"
+    now = datetime.now().strftime("%Y-%m-%d %H:%M")
+
+    # Title slide
+    _add_title_slide(
+        prs,
+        report_title,
+        f"Generated {now}\n{len(nodes)} entities \u2022 {len(rels)} relationships",
+    )
+
+    # Overview slide
+    by_type: Dict[str, list] = {}
+    for n in nodes:
+        t = n.get("type", "concept")
+        by_type.setdefault(t, []).append(n)
+
+    overview_bullets = [f"{len(nodes)} entities across {len(by_type)} types"]
+    for etype, elist in sorted(by_type.items(), key=lambda x: -len(x[1])):
+        examples = ", ".join(e.get("name", "") for e in elist[:3])
+        overview_bullets.append(f"{etype.title()} ({len(elist)}): {examples}")
+    _add_content_slide(prs, "Overview", overview_bullets)
+
+    # Key entities slide
+    degree: Dict[str, int] = {}
+    for r in rels:
+        degree[r.get("source", "")] = degree.get(r.get("source", ""), 0) + 1
+        degree[r.get("target", "")] = degree.get(r.get("target", ""), 0) + 1
+
+    top = sorted(degree.items(), key=lambda x: -x[1])[:10]
+    if top:
+        _add_table_slide(
+            prs,
+            "Key Entities",
+            ["Entity", "Connections"],
+            [[name, str(deg)] for name, deg in top],
+        )
+
+    # Diagram slides
+    if diagrams_dir and diagrams_dir.exists():
+        pngs = sorted(diagrams_dir.glob("*.png"))
+        for i, png in enumerate(pngs):
+            _add_image_slide(prs, f"Diagram {i + 1}", png)
+
+    # Relationship types slide
+    rel_types: Dict[str, int] = {}
+    for r in rels:
+        rt = r.get("type", "related_to")
+        rel_types[rt] = rel_types.get(rt, 0) + 1
+
+    if rel_types:
+        _add_table_slide(
+            prs,
+            "Relationship Types",
+            ["Type", "Count"],
+            [[rt, str(c)] for rt, c in sorted(rel_types.items(), key=lambda x: -x[1])],
+        )
+
+    # Entity detail slides (batched, max 12 per slide)
+    batch_size = 12
+    for batch_start in range(0, len(nodes), batch_size):
+        batch = nodes[batch_start : batch_start + batch_size]
+        bullets = []
+        for node in batch:
+            name = node.get("name", "")
+            etype = node.get("type", "concept")
+            descs = node.get("descriptions", [])
+            desc = descs[0][:80] if descs else ""
+            bullets.append(f"{name} ({etype}): {desc}")
+
+        slide_num = batch_start // batch_size + 1
+        total_pages = (len(nodes) + batch_size - 1) // batch_size
+        page_label = f" ({slide_num}/{total_pages})" if total_pages > 1 else ""
+        _add_content_slide(prs, f"Entities{page_label}", bullets)
+
+    prs.save(str(output_path))
+    logger.info(f"Generated PPTX: {output_path}")
+    return output_path

--- a/video_processor/models.py
+++ b/video_processor/models.py
@@ -37,6 +37,7 @@ class OutputFormat(str, Enum):
     json = "json"
     html = "html"
     pdf = "pdf"
+    pptx = "pptx"
     svg = "svg"
     png = "png"
 


### PR DESCRIPTION
## Summary
- Add `planopticon export pdf <db>` — generates formatted PDF reports from knowledge graphs using reportlab (entity tables, key entities, relationships, optional embedded diagrams)
- Add `planopticon export pptx <db>` — generates PPTX slide decks using python-pptx (title, overview, key entities, diagrams, relationship types, batched entity details)
- New `exports` optional dependency group: `pip install planopticon[exports]`
- Add `pptx` to `OutputFormat` enum
- 13 tests covering both exporters (generation, empty graphs, parent dir creation, diagram embedding, slide counts, entity batching, missing dependency handling)

Closes #113

## Test plan
- [x] All 13 exporter tests pass
- [x] Tests gracefully skip when reportlab/python-pptx not installed (`pytest.importorskip`)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)