### PR TITLE
feat(cli): init wizard, doctor, and tab completion

### DIFF
--- a/tests/test_cli_ux.py
+++ b/tests/test_cli_ux.py
@@ -1,0 +1,161 @@
+"""Tests for CLI UX improvements — doctor, init wizard, and tab completion."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from video_processor.cli.commands import cli
+from video_processor.cli.companion import CompanionREPL
+from video_processor.cli.doctor import (
+    check_api_keys,
+    check_dotenv,
+    check_ffmpeg,
+    check_optional_deps,
+    check_python_version,
+    format_results,
+    run_all_checks,
+)
+
+
+class TestDoctor:
+    def test_check_python_version(self):
+        name, status, detail = check_python_version()
+        assert name == "Python"
+        assert status == "ok"
+
+    def test_check_ffmpeg_found(self):
+        with patch("video_processor.cli.doctor.shutil") as mock_shutil:
+            mock_shutil.which.return_value = "/usr/bin/ffmpeg"
+            name, status, detail = check_ffmpeg()
+            assert status == "ok"
+
+    def test_check_ffmpeg_missing(self):
+        with patch("video_processor.cli.doctor.shutil") as mock_shutil:
+            mock_shutil.which.return_value = None
+            name, status, detail = check_ffmpeg()
+            assert status == "missing"
+
+    def test_check_api_keys_with_key(self):
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test1234567890"}):
+            results = check_api_keys()
+            openai = [r for r in results if r[0].strip() == "OpenAI"]
+            assert len(openai) == 1
+            assert openai[0][1] == "ok"
+            assert "sk-t" in openai[0][2]
+
+    def test_check_api_keys_without_key(self):
+        with patch.dict(os.environ, {}, clear=True):
+            results = check_api_keys()
+            openai = [r for r in results if "OpenAI" in r[0]]
+            assert openai[0][1] == "not set"
+
+    def test_check_dotenv_exists(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("KEY=val\n")
+        name, status, detail = check_dotenv()
+        assert status == "ok"
+
+    def test_check_dotenv_missing(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        name, status, detail = check_dotenv()
+        assert status == "not found"
+
+    def test_check_optional_deps(self):
+        results = check_optional_deps()
+        assert len(results) > 0
+        # All results should have 3 elements
+        for name, status, detail in results:
+            assert status in ("ok", "not installed")
+
+    def test_format_results(self):
+        results = [
+            ("Python", "ok", "3.12.0"),
+            ("FFmpeg", "missing", "Install it"),
+        ]
+        output = format_results(results)
+        assert "PlanOpticon Doctor" in output
+        assert "[ok]" in output
+        assert "[XX]" in output
+
+    def test_run_all_checks(self):
+        with patch(
+            "video_processor.integrators.graph_discovery.find_nearest_graph",
+            return_value=None,
+        ):
+            results = run_all_checks()
+            assert len(results) > 5
+            # Should have section headers
+            sections = [r for r in results if r[1] == "section"]
+            assert len(sections) >= 2
+
+    def test_doctor_cli_command(self):
+        runner = CliRunner()
+        with patch(
+            "video_processor.integrators.graph_discovery.find_nearest_graph",
+            return_value=None,
+        ):
+            result = runner.invoke(cli, ["doctor"])
+            assert result.exit_code == 0
+            assert "PlanOpticon Doctor" in result.output
+
+
+class TestInitWizard:
+    def test_init_cli_command_exists(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["init", "--help"])
+        assert result.exit_code == 0
+        assert "setup wizard" in result.output.lower() or "wizard" in result.output.lower()
+
+    def test_wizard_provider_selection(self):
+        """Test the wizard runs with simulated input."""
+        runner = CliRunner()
+        # Select provider 1 (OpenAI), enter a key, decline additional providers
+        result = runner.invoke(
+            cli,
+            ["init"],
+            input="1\nsk-test-key-1234567890\nn\n",
+        )
+        assert result.exit_code == 0
+        assert "Setup complete" in result.output
+
+    def test_wizard_ollama_provider(self):
+        """Test selecting Ollama (no API key needed)."""
+        runner = CliRunner()
+        with patch(
+            "video_processor.cli.init_wizard.shutil.which",
+            return_value="/usr/local/bin/ollama",
+        ):
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="NAME\nllama3\n")
+                result = runner.invoke(
+                    cli,
+                    ["init"],
+                    input="4\nn\n",
+                )
+                assert result.exit_code == 0
+                assert "Setup complete" in result.output
+
+
+class TestCompanionTabCompletion:
+    def test_commands_list_exists(self):
+        assert len(CompanionREPL.COMMANDS) > 10
+        assert "/help" in CompanionREPL.COMMANDS
+        assert "/quit" in CompanionREPL.COMMANDS
+
+    def test_setup_readline_no_crash(self):
+        """Readline setup should not crash even if readline is unavailable."""
+        repl = CompanionREPL()
+        # Just ensure it doesn't raise
+        repl._setup_readline()
+
+    def test_all_commands_in_dispatch(self):
+        """Every command in COMMANDS should be handled by handle_input."""
+        repl = CompanionREPL()
+        for cmd in CompanionREPL.COMMANDS:
+            if cmd in ("/quit", "/exit"):
+                result = repl.handle_input(cmd)
+                assert result == "__QUIT__"
+            else:
+                result = repl.handle_input(cmd)
+                assert "Unknown command" not in result, f"{cmd} not handled"

--- a/video_processor/cli/commands.py
+++ b/video_processor/cli/commands.py
@@ -67,6 +67,25 @@ def cli(ctx, verbose, chat, interactive_flag):
         _interactive_menu(ctx)
 
 
+@cli.command("init")
+@click.pass_context
+def init_cmd(ctx):
+    """Interactive setup wizard — configure providers, API keys, and .env."""
+    from video_processor.cli.init_wizard import run_wizard
+
+    run_wizard()
+
+
+@cli.command()
+@click.pass_context
+def doctor(ctx):
+    """Check setup health — Python, FFmpeg, API keys, dependencies."""
+    from video_processor.cli.doctor import format_results, run_all_checks
+
+    results = run_all_checks()
+    click.echo(format_results(results))
+
+
 @cli.command()
 @click.option(
     "--input", "-i", required=True, type=click.Path(exists=True), help="Input video file path"

--- a/video_processor/cli/companion.py
+++ b/video_processor/cli/companion.py
@@ -445,11 +445,79 @@ class CompanionREPL:
 
         return f"Unknown command: {cmd}. Type /help for help."
 
+    COMMANDS = [
+        "/help",
+        "/status",
+        "/skills",
+        "/entities",
+        "/search",
+        "/neighbors",
+        "/export",
+        "/analyze",
+        "/ingest",
+        "/auth",
+        "/provider",
+        "/model",
+        "/run",
+        "/plan",
+        "/prd",
+        "/tasks",
+        "/quit",
+        "/exit",
+    ]
+
+    def _setup_readline(self) -> None:
+        """Set up readline for tab completion and history."""
+        try:
+            import readline
+        except ImportError:
+            return
+
+        commands = self.COMMANDS
+
+        def completer(text, state):
+            if text.startswith("/"):
+                matches = [c for c in commands if c.startswith(text)]
+            else:
+                matches = [c for c in commands if c.startswith("/" + text)]
+                matches = [m[1:] for m in matches]  # strip leading /
+            if state < len(matches):
+                return matches[state]
+            return None
+
+        readline.set_completer(completer)
+        readline.set_completer_delims(" \t\n")
+        # macOS uses libedit which needs a different syntax
+        if "libedit" in readline.__doc__:
+            readline.parse_and_bind("bind ^I rl_complete")
+        else:
+            readline.parse_and_bind("tab: complete")
+
+        # Load history
+        history_path = Path.home() / ".planopticon_history"
+        try:
+            if history_path.exists():
+                readline.read_history_file(str(history_path))
+        except Exception:
+            pass
+
+        self._history_path = history_path
+
+    def _save_history(self) -> None:
+        """Save readline history."""
+        try:
+            import readline
+
+            readline.write_history_file(str(self._history_path))
+        except Exception:
+            pass
+
     def run(self) -> None:
         """Main REPL loop."""
         self._discover()
         self._init_provider()
         self._init_agent()
+        self._setup_readline()
 
         print(self._welcome_banner())
 
@@ -466,3 +534,5 @@ class CompanionREPL:
                 break
             if output:
                 print(output)
+
+        self._save_history()

--- a/video_processor/cli/doctor.py
+++ b/video_processor/cli/doctor.py
@@ -1,0 +1,194 @@
+"""Diagnostic checks for PlanOpticon setup."""
+
+import logging
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+logger = logging.getLogger(__name__)
+
+# (check_name, status, detail)
+CheckResult = Tuple[str, str, str]
+
+
+def check_python_version() -> CheckResult:
+    """Check Python version meets minimum."""
+    v = sys.version_info
+    version = f"{v.major}.{v.minor}.{v.micro}"
+    if v >= (3, 10):
+        return ("Python", "ok", version)
+    return ("Python", "warn", f"{version} (3.10+ recommended)")
+
+
+def check_ffmpeg() -> CheckResult:
+    """Check if ffmpeg is installed and accessible."""
+    path = shutil.which("ffmpeg")
+    if path:
+        return ("FFmpeg", "ok", path)
+    return ("FFmpeg", "missing", "Install via: brew install ffmpeg / apt install ffmpeg")
+
+
+def check_api_keys() -> List[CheckResult]:
+    """Check for configured API keys."""
+    keys = {
+        "OpenAI": "OPENAI_API_KEY",
+        "Anthropic": "ANTHROPIC_API_KEY",
+        "Google Gemini": "GEMINI_API_KEY",
+        "Azure OpenAI": "AZURE_OPENAI_API_KEY",
+        "Together": "TOGETHER_API_KEY",
+        "Fireworks": "FIREWORKS_API_KEY",
+        "Cerebras": "CEREBRAS_API_KEY",
+        "xAI": "XAI_API_KEY",
+        "Mistral": "MISTRAL_API_KEY",
+        "Cohere": "COHERE_API_KEY",
+        "HuggingFace": "HUGGINGFACE_API_KEY",
+    }
+    results = []
+    for name, env in keys.items():
+        val = os.environ.get(env, "")
+        if val:
+            masked = val[:4] + "..." + val[-4:] if len(val) > 8 else "***"
+            results.append((f"  {name}", "ok", f"{env}={masked}"))
+        else:
+            results.append((f"  {name}", "not set", env))
+    return results
+
+
+def check_ollama() -> CheckResult:
+    """Check if Ollama is running locally."""
+    path = shutil.which("ollama")
+    if not path:
+        return ("Ollama", "not installed", "Optional: https://ollama.ai")
+    try:
+        import subprocess
+
+        result = subprocess.run(
+            ["ollama", "list"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            models = [
+                line.split()[0] for line in result.stdout.strip().split("\n")[1:] if line.strip()
+            ]
+            if models:
+                return ("Ollama", "ok", f"{len(models)} models: {', '.join(models[:3])}")
+            return ("Ollama", "ok", "Running but no models pulled")
+        return ("Ollama", "warn", "Installed but not running")
+    except Exception:
+        return ("Ollama", "warn", "Installed but not reachable")
+
+
+def check_optional_deps() -> List[CheckResult]:
+    """Check optional Python dependencies."""
+    deps = [
+        ("reportlab", "PDF export"),
+        ("pptx", "PPTX export"),
+        ("markdown", "HTML reports"),
+        ("torch", "GPU acceleration"),
+        ("yt_dlp", "YouTube download"),
+        ("feedparser", "RSS sources"),
+        ("bs4", "Web scraping"),
+    ]
+    results = []
+    for module, purpose in deps:
+        try:
+            __import__(module)
+            results.append((f"  {module}", "ok", purpose))
+        except ImportError:
+            results.append((f"  {module}", "not installed", purpose))
+    return results
+
+
+def check_dotenv() -> CheckResult:
+    """Check if .env file exists in current directory."""
+    env_path = Path.cwd() / ".env"
+    if env_path.exists():
+        return (".env file", "ok", str(env_path))
+    return (".env file", "not found", "Run `planopticon init` to create one")
+
+
+def check_knowledge_graph() -> CheckResult:
+    """Check for knowledge graph files in common locations."""
+    from video_processor.integrators.graph_discovery import find_nearest_graph
+
+    path = find_nearest_graph()
+    if path:
+        return ("Knowledge graph", "ok", str(path))
+    return ("Knowledge graph", "not found", "Run `planopticon analyze` to create one")
+
+
+def run_all_checks() -> List[CheckResult]:
+    """Run all diagnostic checks and return results."""
+    results = []
+
+    results.append(check_python_version())
+    results.append(check_ffmpeg())
+    results.append(check_dotenv())
+
+    results.append(("API Keys", "section", ""))
+    results.extend(check_api_keys())
+
+    results.append(check_ollama())
+
+    results.append(("Optional Dependencies", "section", ""))
+    results.extend(check_optional_deps())
+
+    results.append(check_knowledge_graph())
+
+    return results
+
+
+def format_results(results: List[CheckResult]) -> str:
+    """Format check results for terminal display."""
+    lines = ["", "PlanOpticon Doctor", ""]
+    status_icons = {
+        "ok": "[ok]",
+        "warn": "[!!]",
+        "missing": "[XX]",
+        "not set": "[--]",
+        "not found": "[--]",
+        "not installed": "[--]",
+        "section": "---",
+    }
+
+    any_issues = False
+    for name, status, detail in results:
+        icon = status_icons.get(status, "[??]")
+        if status == "section":
+            lines.append(f"\n{name}:")
+            continue
+        if status in ("missing", "warn"):
+            any_issues = True
+        detail_str = f"  {detail}" if detail else ""
+        lines.append(f"  {icon} {name}{detail_str}")
+
+    lines.append("")
+    if any_issues:
+        lines.append("Some issues found. Run `planopticon init` for guided setup.")
+    else:
+        has_key = any(
+            s == "ok"
+            for n, s, _ in results
+            if n.strip()
+            in (
+                "OpenAI",
+                "Anthropic",
+                "Google Gemini",
+                "Azure OpenAI",
+                "Together",
+                "Fireworks",
+                "Cerebras",
+                "xAI",
+            )
+        )
+        if has_key:
+            lines.append("Setup looks good!")
+        else:
+            lines.append("No API keys configured. Run `planopticon init` to set up a provider.")
+    lines.append("")
+
+    return "\n".join(lines)

--- a/video_processor/cli/init_wizard.py
+++ b/video_processor/cli/init_wizard.py
@@ -1,0 +1,200 @@
+"""Interactive setup wizard for PlanOpticon."""
+
+import os
+import shutil
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+import click
+
+PROVIDERS = [
+    ("openai", "OpenAI", "OPENAI_API_KEY"),
+    ("anthropic", "Anthropic", "ANTHROPIC_API_KEY"),
+    ("gemini", "Google Gemini", "GEMINI_API_KEY"),
+    ("ollama", "Ollama (local)", None),
+    ("azure", "Azure OpenAI", "AZURE_OPENAI_API_KEY"),
+    ("together", "Together AI", "TOGETHER_API_KEY"),
+    ("fireworks", "Fireworks AI", "FIREWORKS_API_KEY"),
+    ("cerebras", "Cerebras", "CEREBRAS_API_KEY"),
+    ("xai", "xAI", "XAI_API_KEY"),
+]
+
+
+def _check_ffmpeg() -> bool:
+    return shutil.which("ffmpeg") is not None
+
+
+def _test_provider(provider_id: str, api_key: Optional[str] = None) -> Tuple[bool, str]:
+    """Test that a provider connection works."""
+    if provider_id == "ollama":
+        try:
+            import subprocess
+
+            result = subprocess.run(
+                ["ollama", "list"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                return True, "Ollama is running"
+            return False, "Ollama is installed but not running. Start with: ollama serve"
+        except FileNotFoundError:
+            return False, "Ollama not found. Install from: https://ollama.ai"
+        except Exception as e:
+            return False, f"Could not reach Ollama: {e}"
+
+    if not api_key:
+        return False, "No API key provided"
+
+    # For API-based providers, just check the key looks valid
+    if len(api_key) < 8:
+        return False, "API key looks too short"
+    return True, "API key configured"
+
+
+def run_wizard() -> None:
+    """Run the interactive setup wizard."""
+    click.echo()
+    click.echo("  PlanOpticon Setup Wizard")
+    click.echo("  " + "-" * 30)
+    click.echo()
+
+    # Step 1: Check prerequisites
+    click.echo("Checking prerequisites...")
+    click.echo()
+
+    if _check_ffmpeg():
+        click.echo("  [ok] FFmpeg found")
+    else:
+        click.echo("  [!!] FFmpeg not found")
+        click.echo("       Install: brew install ffmpeg (macOS)")
+        click.echo("                apt install ffmpeg (Ubuntu)")
+        click.echo("                winget install ffmpeg (Windows)")
+        click.echo()
+
+    # Step 2: Choose provider
+    click.echo()
+    click.echo("Choose your AI provider:")
+    click.echo()
+    for i, (pid, name, _) in enumerate(PROVIDERS, 1):
+        # Check if already configured
+        env_key = PROVIDERS[i - 1][2]
+        status = ""
+        if pid == "ollama":
+            if shutil.which("ollama"):
+                status = " (installed)"
+        elif env_key and os.environ.get(env_key):
+            status = " (configured)"
+        click.echo(f"  {i}. {name}{status}")
+    click.echo()
+
+    choice = click.prompt(
+        "Select provider",
+        type=click.IntRange(1, len(PROVIDERS)),
+        default=1,
+    )
+    provider_id, provider_name, env_var = PROVIDERS[choice - 1]
+
+    # Step 3: Configure API key
+    env_vars: Dict[str, str] = {}
+
+    if provider_id == "ollama":
+        click.echo()
+        ok, msg = _test_provider("ollama")
+        if ok:
+            click.echo(f"  [ok] {msg}")
+        else:
+            click.echo(f"  [!!] {msg}")
+    elif env_var:
+        existing = os.environ.get(env_var, "")
+        if existing:
+            click.echo(f"\n  {env_var} is already set.")
+            if not click.confirm("  Update it?", default=False):
+                env_vars[env_var] = existing
+            else:
+                key = click.prompt(f"  Enter {env_var}", hide_input=True)
+                env_vars[env_var] = key
+        else:
+            click.echo(f"\n  {provider_name} requires {env_var}.")
+            key = click.prompt(f"  Enter {env_var}", hide_input=True)
+            env_vars[env_var] = key
+
+        if env_var in env_vars:
+            ok, msg = _test_provider(provider_id, env_vars[env_var])
+            if ok:
+                click.echo(f"  [ok] {msg}")
+            else:
+                click.echo(f"  [!!] {msg}")
+
+    # Step 4: Additional providers?
+    click.echo()
+    if click.confirm("Configure additional providers?", default=False):
+        for pid, pname, evar in PROVIDERS:
+            if pid == provider_id or not evar:
+                continue
+            if os.environ.get(evar):
+                continue
+            if click.confirm(f"  Set up {pname}?", default=False):
+                key = click.prompt(f"    Enter {evar}", hide_input=True)
+                env_vars[evar] = key
+
+    # Step 5: Write .env file
+    env_path = Path.cwd() / ".env"
+    if env_vars:
+        click.echo()
+
+        if env_path.exists():
+            click.echo(f"  .env already exists at {env_path}")
+            if not click.confirm("  Append new keys?", default=True):
+                click.echo("  Skipping .env update.")
+                _print_summary(provider_name, env_vars)
+                return
+
+        # Read existing content
+        existing_content = env_path.read_text() if env_path.exists() else ""
+        existing_keys = set()
+        for line in existing_content.split("\n"):
+            if "=" in line and not line.strip().startswith("#"):
+                existing_keys.add(line.split("=", 1)[0].strip())
+
+        new_lines = []
+        for key, val in env_vars.items():
+            if key not in existing_keys:
+                new_lines.append(f"{key}={val}")
+
+        if new_lines:
+            with open(env_path, "a") as f:
+                if existing_content and not existing_content.endswith("\n"):
+                    f.write("\n")
+                f.write("\n".join(new_lines) + "\n")
+            click.echo(f"  Updated {env_path} with {len(new_lines)} key(s)")
+        else:
+            click.echo("  All keys already in .env")
+
+        # Remind about .gitignore
+        gitignore = Path.cwd() / ".gitignore"
+        if gitignore.exists():
+            content = gitignore.read_text()
+            if ".env" not in content:
+                click.echo("  [!!] .env is not in .gitignore — consider adding it")
+        else:
+            click.echo("  [!!] No .gitignore found — make sure .env is not committed")
+
+    _print_summary(provider_name, env_vars)
+
+
+def _print_summary(provider_name: str, env_vars: Dict[str, str]) -> None:
+    """Print setup summary."""
+    click.echo()
+    click.echo("  Setup complete!")
+    click.echo()
+    click.echo(f"  Provider: {provider_name}")
+    if env_vars:
+        click.echo(f"  Keys configured: {len(env_vars)}")
+    click.echo()
+    click.echo("  Next steps:")
+    click.echo("    planopticon doctor        Check setup health")
+    click.echo("    planopticon analyze -i VIDEO -o OUTPUT")
+    click.echo("    planopticon -I            Interactive mode")
+    click.echo()


### PR DESCRIPTION
## Summary
- Add `planopticon init` — interactive setup wizard that walks through provider selection, API key configuration, .env file creation, and connection testing
- Add `planopticon doctor` — diagnostic tool that checks Python version, FFmpeg, API keys, Ollama, optional dependencies, .env, and knowledge graph availability
- Add tab completion and persistent history to the companion REPL (readline-based, supports both GNU readline and macOS libedit)
- 17 tests covering doctor checks, init wizard flows, and companion tab completion

Closes #114

## Test plan
- [x] All 17 CLI UX tests pass
- [x] `planopticon init --help` and `planopticon doctor --help` work
- [x] Tab completion handles all REPL commands
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)