### PR TITLE
Sync batch output docs with shipped manifest layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to PlanOpticon are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-13
+
+### Fixed
+
+- Aligned public output-format docs with the emitted JSON schemas for `knowledge_graph.json`, `key_points.json`, and `action_items.json`.
+- Updated PlanOpticonExchange docs to use the emitted `version` field instead of `schema_version`.
+- Corrected batch output docs and CLI messaging to point at the batch root `manifest.json`.
+
 ## [0.4.0] - 2026-03-07
 
 ### Added
@@ -65,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Markdown and HTML report output.
 - Mermaid diagram generation.
 
+[0.6.0]: https://github.com/ConflictHQ/PlanOpticon/compare/v0.5.0...v0.6.0
 [0.4.0]: https://github.com/ConflictHQ/PlanOpticon/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/ConflictHQ/PlanOpticon/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/ConflictHQ/PlanOpticon/compare/v0.1.0...v0.2.0

--- a/docs/architecture/pipeline.md
+++ b/docs/architecture/pipeline.md
@@ -102,7 +102,7 @@ flowchart TD
     I --> J[Fuzzy matching + conflict resolution]
     J --> K[Generate batch summary]
     K --> L[Write batch manifest]
-    L --> M[batch_manifest.json + batch_summary.md + merged KG]
+    L --> M[manifest.json + batch_summary.md + merged KG]
 ```
 
 ### Knowledge graph merge strategy

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -221,7 +221,7 @@ planopticon analyze -i long-video.mp4 -o ./output --sampling-rate 0.25
 
 #### Batch processing — one video fails
 
-Individual video failures don't stop the batch. Failed videos are logged in the batch manifest with error details. Check `batch_manifest.json` for the specific error.
+Individual video failures don't stop the batch. Failed videos are logged in the batch manifest with error details. Check the batch root `manifest.json` for the specific error.
 
 ### Knowledge graph issues
 

--- a/docs/guide/batch.md
+++ b/docs/guide/batch.md
@@ -14,7 +14,7 @@ Batch mode:
 2. Processes each video through the full single-video pipeline
 3. Merges knowledge graphs across all videos with fuzzy matching and conflict resolution
 4. Generates a batch summary with aggregated stats and action items
-5. Writes a batch manifest linking to per-video results
+5. Writes a batch manifest (`manifest.json` at the batch root) linking to per-video results
 
 ## File patterns
 
@@ -30,7 +30,7 @@ planopticon batch -i ./recordings -o ./output --pattern "*.mp4,*.mov"
 
 ```
 output/
-├── batch_manifest.json       # Batch-level manifest
+├── manifest.json             # Batch-level manifest
 ├── batch_summary.md          # Aggregated summary
 ├── knowledge_graph.db        # Merged KG across all videos (SQLite, primary)
 ├── knowledge_graph.json      # Merged KG across all videos (JSON export)

--- a/docs/guide/output-formats.md
+++ b/docs/guide/output-formats.md
@@ -70,16 +70,16 @@ Core analysis artifacts are stored as JSON files in the `results/` subdirectory.
 | Format | File | Description |
 |--------|------|-------------|
 | SQLite | `results/knowledge_graph.db` | Primary knowledge graph database. SQLite-based, queryable with `planopticon query`. Contains entities, relationships, source provenance, and metadata. This is the preferred format for querying and merging. |
-| JSON | `results/knowledge_graph.json` | JSON export of the knowledge graph. Contains `entities` and `relationships` arrays. Automatically kept in sync with the `.db` file. Used as a fallback when SQLite is not available. |
-| JSON | `results/key_points.json` | Array of extracted key points, each with `text`, `category`, and `confidence` fields. |
-| JSON | `results/action_items.json` | Array of action items, each with `text`, `assignee`, `due_date`, `priority`, and `status` fields. |
+| JSON | `results/knowledge_graph.json` | JSON export of the knowledge graph. Contains `nodes`, `relationships`, and optional `sources` arrays. Automatically kept in sync with the `.db` file. Used as a fallback when SQLite is not available. |
+| JSON | `results/key_points.json` | Array of extracted key points with fields such as `point`, `topic`, `details`, `timestamp`, `source`, and `related_diagrams`. |
+| JSON | `results/action_items.json` | Array of action items with fields such as `action`, `assignee`, `deadline`, `priority`, `context`, and `source`. |
 | JSON | `manifest.json` | Complete run manifest. The single source of truth for the analysis run. Contains video metadata, processing stats, file paths to all outputs, and inline key points, action items, diagram metadata, and screen captures. |
 
 ### Knowledge graph JSON structure
 
 ```json
 {
-  "entities": [
+  "nodes": [
     {
       "name": "Kubernetes",
       "type": "technology",
@@ -93,8 +93,16 @@ Core analysis artifacts are stored as JSON files in the `results/` subdirectory.
     {
       "source": "Kubernetes",
       "target": "Docker",
-      "type": "DEPENDS_ON",
-      "descriptions": ["Kubernetes uses Docker as container runtime"]
+      "type": "depends_on",
+      "content_source": "transcript:recording.mp4",
+      "timestamp": 323.0
+    }
+  ],
+  "sources": [
+    {
+      "source_id": "src1",
+      "source_type": "video",
+      "title": "Architecture Review"
     }
   ]
 }
@@ -164,7 +172,7 @@ The exchange payload includes:
 
 ```json
 {
-  "schema_version": "1.0",
+  "version": "1.0",
   "project": {
     "name": "Sprint Reviews Q4",
     "description": "Knowledge extracted from Q4 sprint review recordings"
@@ -250,7 +258,7 @@ Batch processing produces additional files at the batch root directory, alongsid
 
 | Format | File | Description |
 |--------|------|-------------|
-| JSON | `batch_manifest.json` | Batch-level manifest with aggregate stats, per-video status (completed/failed), error details, and paths to all sub-outputs. |
+| JSON | `manifest.json` | Batch-level manifest at the batch root with aggregate stats, per-video status (completed/failed), error details, and paths to all sub-outputs. |
 | Markdown | `batch_summary.md` | Aggregated summary report with combined key points, action items, entity counts, and a Mermaid diagram of the merged knowledge graph. |
 | SQLite | `knowledge_graph.db` | Merged knowledge graph combining entities and relationships across all successfully processed videos. Uses fuzzy matching and conflict resolution. |
 | JSON | `knowledge_graph.json` | JSON export of the merged knowledge graph. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "planopticon"
-version = "0.5.0"
+version = "0.6.0"
 description = "AI-powered video analysis and knowledge extraction tool"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ class TestCLIRoot:
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
         assert "PlanOpticon" in result.output
-        assert "0.5.0" in result.output  # matches @click.version_option
+        assert "0.6.0" in result.output  # matches @click.version_option
 
     def test_help(self):
         runner = CliRunner()

--- a/video_processor/cli/commands.py
+++ b/video_processor/cli/commands.py
@@ -49,7 +49,7 @@ def setup_logging(verbose: bool = False) -> None:
     is_flag=True,
     help="Launch interactive companion REPL",
 )
-@click.version_option("0.5.0", prog_name="PlanOpticon")
+@click.version_option("0.6.0", prog_name="PlanOpticon")
 @click.pass_context
 def cli(ctx, verbose, chat, interactive_flag):
     """PlanOpticon - Comprehensive Video Analysis & Knowledge Extraction Tool."""
@@ -437,7 +437,7 @@ def batch(
         f"\n  Batch complete: {batch_manifest.completed_videos}"
         f"/{batch_manifest.total_videos} succeeded"
     )
-    click.echo(f"  Results: {output}/batch_manifest.json")
+    click.echo(f"  Results: {output}/manifest.json")
 
 
 @cli.command()


### PR DESCRIPTION
## Summary
- align batch CLI messaging and docs with the current root manifest.json layout
- sync output format docs to the current emitted schema
- bump to 0.6.0

## Testing
- python3 -m pytest tests/test_cli.py tests/test_batch.py tests/test_output_structure.py tests/test_exchange.py
- python3 -m build

Closes #128