### PR TITLE
feat(transcription): Deepgram + ElevenLabs diarizing backends (--diarize)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,7 @@
 OPENAI_API_KEY=your_openai_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 GOOGLE_APPLICATION_CREDENTIALS=path_to_your_google_credentials.json
+
+# Transcription backends with speaker diarization (used by --diarize / --transcriber)
+DEEPGRAM_API_KEY=your_deepgram_api_key_here
+ELEVENLABS_API_KEY=your_elevenlabs_api_key_here

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -1,0 +1,153 @@
+"""Tests for the diarizing transcribers (Deepgram, ElevenLabs) and the
+ProviderManager diarization routing."""
+
+from unittest.mock import MagicMock, patch
+
+from video_processor.providers.base import BaseProvider
+from video_processor.providers.deepgram_provider import DeepgramProvider
+from video_processor.providers.elevenlabs_provider import ElevenLabsProvider
+from video_processor.providers.manager import ProviderManager
+
+
+def _mock_response(payload):
+    resp = MagicMock()
+    resp.json.return_value = payload
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def _dummy_wav(tmp_path):
+    p = tmp_path / "a.wav"
+    p.write_bytes(b"\x00\x01")
+    return str(p)
+
+
+class TestDeepgramProvider:
+    def test_parses_speaker_labeled_utterances(self, tmp_path):
+        payload = {
+            "metadata": {"duration": 4.0},
+            "results": {
+                "channels": [
+                    {
+                        "alternatives": [{"transcript": "Hello there. Hi back."}],
+                        "detected_language": "en",
+                    }
+                ],
+                "utterances": [
+                    {"start": 0.0, "end": 2.0, "transcript": "Hello there.", "speaker": 0},
+                    {"start": 2.5, "end": 4.0, "transcript": "Hi back.", "speaker": 1},
+                ],
+            },
+        }
+        with patch(
+            "video_processor.providers.deepgram_provider.requests.post",
+            return_value=_mock_response(payload),
+        ):
+            result = DeepgramProvider(api_key="x").transcribe_audio(
+                _dummy_wav(tmp_path), diarize=True
+            )
+
+        assert result["provider"] == "deepgram"
+        assert result["duration"] == 4.0
+        speakers = [s["speaker"] for s in result["segments"]]
+        assert speakers == ["Speaker 0", "Speaker 1"]
+        assert result["segments"][0]["text"] == "Hello there."
+
+    def test_no_speaker_field_when_diarize_off(self, tmp_path):
+        payload = {
+            "metadata": {"duration": 2.0},
+            "results": {
+                "channels": [{"alternatives": [{"transcript": "Just text."}]}],
+                "utterances": [
+                    {"start": 0.0, "end": 2.0, "transcript": "Just text.", "speaker": 0}
+                ],
+            },
+        }
+        with patch(
+            "video_processor.providers.deepgram_provider.requests.post",
+            return_value=_mock_response(payload),
+        ):
+            result = DeepgramProvider(api_key="x").transcribe_audio(
+                _dummy_wav(tmp_path), diarize=False
+            )
+        assert "speaker" not in result["segments"][0]
+
+
+class TestElevenLabsProvider:
+    def test_groups_words_into_speaker_turns(self, tmp_path):
+        payload = {
+            "text": "Hello there. Hi back.",
+            "language_code": "en",
+            "words": [
+                {
+                    "type": "word",
+                    "text": "Hello",
+                    "start": 0.0,
+                    "end": 0.5,
+                    "speaker_id": "speaker_0",
+                },
+                {"type": "spacing", "text": " "},
+                {
+                    "type": "word",
+                    "text": "there.",
+                    "start": 0.5,
+                    "end": 1.0,
+                    "speaker_id": "speaker_0",
+                },
+                {"type": "word", "text": "Hi", "start": 2.5, "end": 2.8, "speaker_id": "speaker_1"},
+                {"type": "spacing", "text": " "},
+                {
+                    "type": "word",
+                    "text": "back.",
+                    "start": 2.8,
+                    "end": 3.2,
+                    "speaker_id": "speaker_1",
+                },
+            ],
+        }
+        with patch(
+            "video_processor.providers.elevenlabs_provider.requests.post",
+            return_value=_mock_response(payload),
+        ):
+            result = ElevenLabsProvider(api_key="x").transcribe_audio(
+                _dummy_wav(tmp_path), diarize=True
+            )
+
+        assert result["provider"] == "elevenlabs"
+        assert [s["speaker"] for s in result["segments"]] == ["Speaker 0", "Speaker 1"]
+        assert result["segments"][0]["text"] == "Hello there."
+        assert result["segments"][1]["text"] == "Hi back."
+
+
+class TestDiarizeRouting:
+    def _mock_provider(self, name):
+        prov = MagicMock(spec=BaseProvider)
+        prov.transcribe_audio.return_value = {
+            "text": "x",
+            "segments": [],
+            "duration": 1.0,
+            "provider": name,
+            "model": "m",
+        }
+        return prov
+
+    def test_diarize_routes_to_capable_provider(self):
+        mgr = ProviderManager(transcription_model="nova-3")
+        prov = self._mock_provider("deepgram")
+        mgr._providers["deepgram"] = prov
+
+        mgr.transcribe_audio("/tmp/a.wav", diarize=True)
+
+        prov.transcribe_audio.assert_called_once()
+        assert prov.transcribe_audio.call_args.kwargs.get("diarize") is True
+
+    def test_non_capable_transcriber_falls_back_without_diarize(self):
+        # openai can't diarize → manager should not call it with diarize and
+        # should fall through to the normal (non-diarized) path.
+        mgr = ProviderManager(transcription_model="whisper-1")
+        prov = self._mock_provider("openai")
+        mgr._providers["openai"] = prov
+
+        mgr.transcribe_audio("/tmp/a.wav", diarize=True)
+
+        assert prov.transcribe_audio.call_args.kwargs.get("diarize") is None

--- a/video_processor/cli/commands.py
+++ b/video_processor/cli/commands.py
@@ -10,6 +10,18 @@ import click
 import colorlog
 from tqdm import tqdm
 
+# Maps the --transcriber choice to a ProviderManager transcription_model.
+# "auto" (None) lets the manager pick: diarization prefs when --diarize is set,
+# else local Whisper / the default transcription preferences.
+_TRANSCRIBER_MODELS = {
+    "auto": None,
+    "deepgram": "nova-3",
+    "elevenlabs": "scribe_v1",
+    "openai": "whisper-1",
+    "gemini": "gemini-2.5-flash",
+    "whisper-local": "whisper-local",
+}
+
 
 def setup_logging(verbose: bool = False) -> None:
     """Set up logging with color formatting."""
@@ -150,6 +162,17 @@ def doctor(ctx):
     default=None,
     help='Comma-separated speaker names for diarization hints (e.g., "Alice,Bob,Carol")',
 )
+@click.option(
+    "--transcriber",
+    type=click.Choice(["auto", "deepgram", "elevenlabs", "openai", "gemini", "whisper-local"]),
+    default="auto",
+    help="Transcription backend (deepgram/elevenlabs support speaker diarization)",
+)
+@click.option(
+    "--diarize/--no-diarize",
+    default=False,
+    help="Label speakers in the transcript (uses Deepgram/ElevenLabs)",
+)
 @click.pass_context
 def analyze(
     ctx,
@@ -168,6 +191,8 @@ def analyze(
     output_format,
     templates_dir,
     speakers,
+    transcriber,
+    diarize,
 ):
     """Analyze a single video and extract structured knowledge."""
     from video_processor.pipeline import process_single_video
@@ -180,6 +205,7 @@ def analyze(
     pm = ProviderManager(
         vision_model=vision_model,
         chat_model=chat_model,
+        transcription_model=_TRANSCRIBER_MODELS.get(transcriber),
         provider=prov,
     )
 
@@ -201,6 +227,7 @@ def analyze(
             use_gpu=use_gpu,
             title=title,
             speaker_hints=speaker_hints,
+            diarize=diarize,
         )
         if output_format == "json":
             click.echo(json.dumps(manifest.model_dump(), indent=2, default=str))
@@ -271,6 +298,17 @@ def analyze(
 @click.option(
     "--recursive/--no-recursive", default=True, help="Recurse into subfolders (default: recursive)"
 )
+@click.option(
+    "--transcriber",
+    type=click.Choice(["auto", "deepgram", "elevenlabs", "openai", "gemini", "whisper-local"]),
+    default="auto",
+    help="Transcription backend (deepgram/elevenlabs support speaker diarization)",
+)
+@click.option(
+    "--diarize/--no-diarize",
+    default=False,
+    help="Label speakers in transcripts (uses Deepgram/ElevenLabs)",
+)
 @click.pass_context
 def batch(
     ctx,
@@ -286,6 +324,8 @@ def batch(
     folder_id,
     folder_path,
     recursive,
+    transcriber,
+    diarize,
 ):
     """Process a folder of videos in batch."""
     from video_processor.integrators.knowledge_graph import KnowledgeGraph
@@ -299,7 +339,12 @@ def batch(
     from video_processor.providers.manager import ProviderManager
 
     prov = None if provider == "auto" else provider
-    pm = ProviderManager(vision_model=vision_model, chat_model=chat_model, provider=prov)
+    pm = ProviderManager(
+        vision_model=vision_model,
+        chat_model=chat_model,
+        transcription_model=_TRANSCRIBER_MODELS.get(transcriber),
+        provider=prov,
+    )
     patterns = [p.strip() for p in pattern.split(",")]
 
     # Handle cloud sources
@@ -374,6 +419,7 @@ def batch(
                 provider_manager=pm,
                 depth=depth,
                 title=f"Analysis of {video_name}",
+                diarize=diarize,
             )
             entry.status = "completed"
             entry.diagrams_count = len(manifest.diagrams)

--- a/video_processor/pipeline.py
+++ b/video_processor/pipeline.py
@@ -59,6 +59,7 @@ def process_single_video(
     title: Optional[str] = None,
     progress_callback: Optional[ProgressCallback] = None,
     speaker_hints: Optional[list[str]] = None,
+    diarize: bool = False,
 ) -> VideoManifest:
     """
     Full pipeline: frames -> audio -> transcription -> diagrams -> KG -> report -> export.
@@ -149,7 +150,9 @@ def process_single_video(
         segments = transcript_data.get("segments", [])
     else:
         logger.info("Transcribing audio...")
-        transcription = pm.transcribe_audio(audio_path, speaker_hints=speaker_hints)
+        transcription = pm.transcribe_audio(
+            audio_path, speaker_hints=speaker_hints, diarize=diarize
+        )
         transcript_text = transcription.get("text", "")
         segments = transcription.get("segments", [])
 
@@ -206,18 +209,36 @@ def process_single_video(
         }
         transcript_json.write_text(json.dumps(transcript_data, indent=2))
 
+        # transcript.txt — when segments carry speakers, render as grouped
+        # "Speaker N: ..." turns; otherwise the plain transcript text.
         transcript_txt = dirs["transcript"] / "transcript.txt"
-        transcript_txt.write_text(transcript_text)
+        has_speakers = any(seg.get("speaker") for seg in segments)
+        if has_speakers:
+            turns, last_spk, buf = [], None, []
+            for seg in segments:
+                spk = seg.get("speaker") or "Speaker ?"
+                if spk != last_spk and buf:
+                    turns.append(f"{last_spk}: " + " ".join(buf))
+                    buf = []
+                last_spk = spk
+                buf.append(seg.get("text", "").strip())
+            if buf:
+                turns.append(f"{last_spk}: " + " ".join(buf))
+            transcript_txt.write_text("\n\n".join(turns))
+        else:
+            transcript_txt.write_text(transcript_text)
 
-        # SRT
+        # SRT — prefix each cue with its speaker label when present.
         transcript_srt = dirs["transcript"] / "transcript.srt"
         srt_lines = []
         for i, seg in enumerate(segments):
             start = seg.get("start", 0)
             end = seg.get("end", 0)
+            text = seg.get("text", "").strip()
+            spk = seg.get("speaker")
             srt_lines.append(str(i + 1))
             srt_lines.append(f"{_format_srt_time(start)} --> {_format_srt_time(end)}")
-            srt_lines.append(seg.get("text", "").strip())
+            srt_lines.append(f"[{spk}] {text}" if spk else text)
             srt_lines.append("")
         transcript_srt.write_text("\n".join(srt_lines))
     pipeline_bar.update(1)

--- a/video_processor/providers/deepgram_provider.py
+++ b/video_processor/providers/deepgram_provider.py
@@ -1,0 +1,123 @@
+"""Deepgram provider — fast pre-recorded transcription with speaker diarization.
+
+Transcription-only provider (no chat/vision). Uses Deepgram's pre-recorded
+`/v1/listen` endpoint with `diarize=true` + `utterances=true`, which returns
+speaker-labeled utterances we map straight onto TranscriptSegment.speaker.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+import requests
+from dotenv import load_dotenv
+
+from video_processor.providers.base import BaseProvider, ModelInfo, ProviderRegistry
+
+load_dotenv()
+logger = logging.getLogger(__name__)
+
+_LISTEN_URL = "https://api.deepgram.com/v1/listen"
+_MIME = {
+    ".wav": "audio/wav",
+    ".mp3": "audio/mpeg",
+    ".m4a": "audio/mp4",
+    ".mp4": "audio/mp4",
+    ".flac": "audio/flac",
+    ".ogg": "audio/ogg",
+    ".webm": "audio/webm",
+}
+
+
+class DeepgramProvider(BaseProvider):
+    """Deepgram speech-to-text provider (transcription + diarization only)."""
+
+    provider_name = "deepgram"
+
+    def __init__(self, api_key: Optional[str] = None):
+        self.api_key = api_key or os.getenv("DEEPGRAM_API_KEY")
+        if not self.api_key:
+            raise ValueError("DEEPGRAM_API_KEY not set")
+
+    def transcribe_audio(
+        self,
+        audio_path: str | Path,
+        language: Optional[str] = None,
+        model: Optional[str] = None,
+        diarize: bool = False,
+        speaker_hints: Optional[list[str]] = None,
+    ) -> dict:
+        model = model or "nova-3"
+        audio_path = Path(audio_path)
+        params = {
+            "model": model,
+            "smart_format": "true",
+            "punctuate": "true",
+            "diarize": "true" if diarize else "false",
+            "utterances": "true",
+        }
+        if language:
+            params["language"] = language
+        headers = {
+            "Authorization": f"Token {self.api_key}",
+            "Content-Type": _MIME.get(audio_path.suffix.lower(), "application/octet-stream"),
+        }
+        logger.info(f"Deepgram transcribing {audio_path.name} (model={model}, diarize={diarize})")
+        resp = requests.post(
+            _LISTEN_URL,
+            params=params,
+            headers=headers,
+            data=audio_path.read_bytes(),
+            timeout=900,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+
+        results = payload.get("results", {})
+        channels = results.get("channels") or [{}]
+        alt = (channels[0].get("alternatives") or [{}])[0]
+        full_text = alt.get("transcript", "")
+
+        segments = []
+        for utt in results.get("utterances") or []:
+            text = (utt.get("transcript") or "").strip()
+            if not text:
+                continue
+            seg = {"start": utt.get("start", 0.0), "end": utt.get("end", 0.0), "text": text}
+            if diarize and "speaker" in utt:
+                seg["speaker"] = f"Speaker {utt['speaker']}"
+            segments.append(seg)
+
+        if not full_text and segments:
+            full_text = " ".join(s["text"] for s in segments)
+
+        return {
+            "text": full_text,
+            "segments": segments,
+            "language": (channels[0].get("detected_language") or language),
+            "duration": payload.get("metadata", {}).get("duration"),
+            "provider": "deepgram",
+            "model": model,
+        }
+
+    def chat(self, messages, max_tokens=4096, temperature=0.7, model=None) -> str:
+        raise NotImplementedError("Deepgram is a transcription-only provider")
+
+    def analyze_image(self, image_bytes, prompt, max_tokens=4096, model=None) -> str:
+        raise NotImplementedError("Deepgram is a transcription-only provider")
+
+    def list_models(self) -> list[ModelInfo]:
+        return [
+            ModelInfo(id=mid, provider="deepgram", display_name=mid, capabilities=["audio"])
+            for mid in ("nova-3", "nova-2")
+        ]
+
+
+ProviderRegistry.register(
+    name="deepgram",
+    provider_class=DeepgramProvider,
+    env_var="DEEPGRAM_API_KEY",
+    model_prefixes=["nova-", "deepgram"],
+    default_models={"audio": "nova-3"},
+)

--- a/video_processor/providers/elevenlabs_provider.py
+++ b/video_processor/providers/elevenlabs_provider.py
@@ -1,0 +1,148 @@
+"""ElevenLabs provider — high-accuracy transcription (Scribe) with diarization.
+
+Transcription-only provider (no chat/vision). Uses the ElevenLabs
+`/v1/speech-to-text` endpoint (model `scribe_v1`) with word-level timestamps and
+`diarize=true`. Words carry a `speaker_id`; we group consecutive same-speaker
+words into TranscriptSegments.
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+import requests
+from dotenv import load_dotenv
+
+from video_processor.providers.base import BaseProvider, ModelInfo, ProviderRegistry
+
+load_dotenv()
+logger = logging.getLogger(__name__)
+
+_STT_URL = "https://api.elevenlabs.io/v1/speech-to-text"
+_MIME = {
+    ".wav": "audio/wav",
+    ".mp3": "audio/mpeg",
+    ".m4a": "audio/mp4",
+    ".mp4": "audio/mp4",
+    ".flac": "audio/flac",
+    ".ogg": "audio/ogg",
+    ".webm": "audio/webm",
+}
+
+
+def _fmt_speaker(speaker_id: Optional[str]) -> Optional[str]:
+    """Normalize 'speaker_0' -> 'Speaker 0'; pass anything else through."""
+    if not speaker_id:
+        return None
+    tail = str(speaker_id).rsplit("_", 1)[-1]
+    return f"Speaker {tail}" if tail.isdigit() else str(speaker_id)
+
+
+class ElevenLabsProvider(BaseProvider):
+    """ElevenLabs Scribe speech-to-text provider (transcription + diarization only)."""
+
+    provider_name = "elevenlabs"
+
+    def __init__(self, api_key: Optional[str] = None):
+        self.api_key = api_key or os.getenv("ELEVENLABS_API_KEY")
+        if not self.api_key:
+            raise ValueError("ELEVENLABS_API_KEY not set")
+
+    def transcribe_audio(
+        self,
+        audio_path: str | Path,
+        language: Optional[str] = None,
+        model: Optional[str] = None,
+        diarize: bool = False,
+        speaker_hints: Optional[list[str]] = None,
+    ) -> dict:
+        model = model or "scribe_v1"
+        audio_path = Path(audio_path)
+        mime = _MIME.get(audio_path.suffix.lower(), "application/octet-stream")
+        data = {
+            "model_id": model,
+            "diarize": "true" if diarize else "false",
+            "timestamps_granularity": "word",
+        }
+        if language:
+            data["language_code"] = language
+        logger.info(f"ElevenLabs transcribing {audio_path.name} (model={model}, diarize={diarize})")
+        resp = requests.post(
+            _STT_URL,
+            headers={"xi-api-key": self.api_key},
+            files={"file": (audio_path.name, audio_path.read_bytes(), mime)},
+            data=data,
+            timeout=900,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+
+        full_text = (payload.get("text") or "").strip()
+
+        # Group consecutive words into turns; start a new turn when the speaker
+        # changes (diarized) — spacing tokens attach to the current turn's text.
+        groups: list[dict] = []
+        cur = None
+        for w in payload.get("words") or []:
+            if w.get("type") == "spacing":
+                if cur is not None:
+                    cur["text"] += w.get("text", "")
+                continue
+            spk = w.get("speaker_id")
+            if cur is None or (diarize and spk != cur["_spk"]):
+                cur = {
+                    "_spk": spk,
+                    "start": w.get("start", 0.0),
+                    "end": w.get("end", 0.0),
+                    "text": w.get("text", ""),
+                }
+                groups.append(cur)
+            else:
+                cur["text"] += w.get("text", "")
+                cur["end"] = w.get("end", cur["end"])
+
+        segments = []
+        for g in groups:
+            seg = {"start": g["start"], "end": g["end"], "text": g["text"].strip()}
+            spk = _fmt_speaker(g["_spk"])
+            if diarize and spk:
+                seg["speaker"] = spk
+            segments.append(seg)
+
+        if not full_text and segments:
+            full_text = " ".join(s["text"] for s in segments)
+
+        return {
+            "text": full_text,
+            "segments": segments,
+            "language": payload.get("language_code", language),
+            "duration": (segments[-1]["end"] if segments else None),
+            "provider": "elevenlabs",
+            "model": model,
+        }
+
+    def chat(self, messages, max_tokens=4096, temperature=0.7, model=None) -> str:
+        raise NotImplementedError("ElevenLabs is a transcription-only provider")
+
+    def analyze_image(self, image_bytes, prompt, max_tokens=4096, model=None) -> str:
+        raise NotImplementedError("ElevenLabs is a transcription-only provider")
+
+    def list_models(self) -> list[ModelInfo]:
+        return [
+            ModelInfo(
+                id="scribe_v1",
+                provider="elevenlabs",
+                display_name="scribe_v1",
+                capabilities=["audio"],
+            )
+        ]
+
+
+ProviderRegistry.register(
+    name="elevenlabs",
+    provider_class=ElevenLabsProvider,
+    env_var="ELEVENLABS_API_KEY",
+    model_prefixes=["scribe"],
+    default_models={"audio": "scribe_v1"},
+)

--- a/video_processor/providers/manager.py
+++ b/video_processor/providers/manager.py
@@ -14,14 +14,26 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 
+_BUILTINS_REGISTERED = False
+
+
 def _ensure_providers_registered() -> None:
-    """Import all built-in provider modules so they register themselves."""
-    if ProviderRegistry.all_registered():
+    """Import all built-in provider modules so they register themselves.
+
+    Guarded by a module flag rather than the registry contents: a single
+    provider module imported elsewhere first would otherwise make this
+    short-circuit and skip the rest. Imports are cached, so this is cheap.
+    """
+    global _BUILTINS_REGISTERED
+    if _BUILTINS_REGISTERED:
         return
+    _BUILTINS_REGISTERED = True
     # Each module registers itself on import via ProviderRegistry.register()
     import video_processor.providers.anthropic_provider  # noqa: F401
     import video_processor.providers.azure_provider  # noqa: F401
     import video_processor.providers.cerebras_provider  # noqa: F401
+    import video_processor.providers.deepgram_provider  # noqa: F401
+    import video_processor.providers.elevenlabs_provider  # noqa: F401
     import video_processor.providers.fireworks_provider  # noqa: F401
     import video_processor.providers.gemini_provider  # noqa: F401
     import video_processor.providers.ollama_provider  # noqa: F401
@@ -47,6 +59,14 @@ _TRANSCRIPTION_PREFERENCES = [
     ("openai", "whisper-1"),
     ("gemini", "gemini-2.5-flash"),
 ]
+
+# Diarization-capable transcribers, tried in order when --diarize is requested
+# without an explicit transcriber. Deepgram first (fastest/cheapest).
+_DIARIZATION_PREFERENCES = [
+    ("deepgram", "nova-3"),
+    ("elevenlabs", "scribe_v1"),
+]
+_DIARIZE_CAPABLE = {"deepgram", "elevenlabs"}
 
 
 class ProviderManager:
@@ -223,8 +243,34 @@ class ProviderManager:
         audio_path: str | Path,
         language: Optional[str] = None,
         speaker_hints: Optional[list[str]] = None,
+        diarize: bool = False,
     ) -> dict:
-        """Transcribe audio using local Whisper if available, otherwise API."""
+        """Transcribe audio. With diarize=True, route to a speaker-labeling
+        provider (Deepgram/ElevenLabs); otherwise prefer local Whisper, then API."""
+        # Diarization path: only Deepgram/ElevenLabs populate segment speakers.
+        if diarize:
+            prov_name, model = self._resolve_model(
+                self.transcription_model, "audio", _DIARIZATION_PREFERENCES
+            )
+            if prov_name in _DIARIZE_CAPABLE:
+                logger.info(f"Transcription (diarized): using {prov_name}/{model}")
+                provider = self._get_provider(prov_name)
+                kwargs: dict = {"language": language, "model": model, "diarize": True}
+                if speaker_hints:
+                    kwargs["speaker_hints"] = speaker_hints
+                result = provider.transcribe_audio(audio_path, **kwargs)
+                duration = result.get("duration") or 0
+                self.usage.record(
+                    provider=prov_name,
+                    model=model,
+                    audio_minutes=duration / 60 if duration else 0,
+                )
+                return result
+            logger.warning(
+                f"Transcriber '{prov_name}' does not support diarization; "
+                "transcribing without speaker labels."
+            )
+
         # Prefer local Whisper — no file size limits, no API costs
         if not self.transcription_model or self.transcription_model.startswith("whisper-local"):
             try:


### PR DESCRIPTION
## What

Adds **speaker diarization** to PlanOpticon via two new transcription backends, populating the existing (previously unused) `TranscriptSegment.speaker` field.

- **`deepgram_provider.py`** — Nova-3 (`/v1/listen`, `utterances` + `diarize`). Fast, cheap (~$0.01/min).
- **`elevenlabs_provider.py`** — Scribe v1 (`/v1/speech-to-text`, word-level + `diarize`), grouping consecutive same-speaker words into turns.

## How to use

```bash
planopticon analyze -i meeting.mp4 -o out/ --diarize                 # auto-picks Deepgram
planopticon analyze -i meeting.mp4 -o out/ --diarize --transcriber elevenlabs
planopticon batch   -i folder/   -o out/ --diarize
```

- `ProviderManager.transcribe_audio(diarize=True)` routes to the first available diarization-capable provider (`_DIARIZATION_PREFERENCES`: deepgram → elevenlabs); warns + falls back to a normal transcription if the chosen transcriber can't diarize.
- `--transcriber {auto,deepgram,elevenlabs,openai,gemini,whisper-local}` to force a backend.
- `transcript.txt` now renders `Speaker N: …` turns and `transcript.srt` prefixes cues with the speaker when segments carry speakers. Downstream (`plan_generator`, `knowledge_graph`) already consumed `speaker`.

## Also

- Hardened `_ensure_providers_registered()` to guard on a module flag instead of registry contents — importing a single provider module first no longer short-circuits registration of the rest.
- `.env.example`: `DEEPGRAM_API_KEY`, `ELEVENLABS_API_KEY`.

## Testing

- New `tests/test_diarization.py` (provider response parsing → speaker mapping, manager routing + non-capable fallback).
- Full suite green: **905 passed**. Ruff clean.
- Live-validated the Deepgram path end-to-end on a real recording clip.