### PR TITLE
Fix --speakers crash for providers without speaker_hints support

### DIFF
--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -226,6 +226,66 @@ class TestProviderManager:
         assert result["text"] == "hello world"
         mock_prov.transcribe_audio.assert_called_once()
 
+    @patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"})
+    def test_transcribe_drops_speaker_hints_for_unsupporting_provider(self, caplog):
+        """Regression for #127: --speakers with a provider whose transcribe_audio
+        doesn't accept speaker_hints must warn and drop the kwarg, not crash."""
+
+        class _NoHintsTranscriber:
+            def __init__(self):
+                self.calls = []
+
+            def transcribe_audio(self, audio_path, language=None, model=None):
+                self.calls.append({"language": language, "model": model})
+                return {"text": "hi", "segments": [], "provider": "gemini", "model": model}
+
+        stub = _NoHintsTranscriber()
+        mgr = ProviderManager(transcription_model="gemini-2.5-flash")
+        mgr._providers["gemini"] = stub
+
+        with caplog.at_level("WARNING"):
+            result = mgr.transcribe_audio("/tmp/test.wav", speaker_hints=["Alice", "Bob"])
+
+        assert result["text"] == "hi"
+        assert len(stub.calls) == 1
+        assert "speaker hints" in caplog.text
+        assert "speaker_hints" not in stub.calls[0]
+
+    @patch.dict("os.environ", {"DEEPGRAM_API_KEY": "test-key"})
+    def test_transcribe_passes_speaker_hints_when_supported(self):
+        class _HintsTranscriber:
+            def __init__(self):
+                self.calls = []
+
+            def transcribe_audio(self, audio_path, language=None, model=None, speaker_hints=None):
+                self.calls.append({"speaker_hints": speaker_hints})
+                return {"text": "hi", "segments": [], "provider": "deepgram", "model": model}
+
+        stub = _HintsTranscriber()
+        mgr = ProviderManager(transcription_model="nova-3")
+        mgr._providers["deepgram"] = stub
+
+        result = mgr.transcribe_audio("/tmp/test.wav", speaker_hints=["Alice", "Bob"])
+        assert result["text"] == "hi"
+        assert stub.calls[0]["speaker_hints"] == ["Alice", "Bob"]
+
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"})
+    def test_transcribe_maps_speaker_hints_to_openai_prompt(self):
+        class _PromptTranscriber:
+            def __init__(self):
+                self.calls = []
+
+            def transcribe_audio(self, audio_path, language=None, model=None, prompt=None):
+                self.calls.append({"prompt": prompt})
+                return {"text": "hi", "segments": [], "provider": "openai", "model": model}
+
+        stub = _PromptTranscriber()
+        mgr = ProviderManager(transcription_model="whisper-1")
+        mgr._providers["openai"] = stub
+
+        mgr.transcribe_audio("/tmp/test.wav", speaker_hints=["Alice", "Bob"])
+        assert stub.calls[0]["prompt"] == "Speakers: Alice, Bob."
+
     def test_get_models_used(self):
         mgr = ProviderManager(
             vision_model="gpt-4o",
@@ -448,6 +508,32 @@ class TestOllamaProvider:
         llama = [m for m in models if "llama" in m.id][0]
         assert "chat" in llama.capabilities
         assert "vision" not in llama.capabilities
+
+
+# ---------------------------------------------------------------------------
+# GeminiProvider
+# ---------------------------------------------------------------------------
+
+
+class TestGeminiProvider:
+    def test_transcribe_prompt_includes_speaker_hints(self, tmp_path):
+        from video_processor.providers.gemini_provider import GeminiProvider
+
+        provider = GeminiProvider(api_key="test-key")
+        provider.client = MagicMock()
+        response = MagicMock()
+        response.text = "hello world"
+        provider.client.models.generate_content.return_value = response
+
+        audio = tmp_path / "test.wav"
+        audio.write_bytes(b"\x00\x01")
+
+        result = provider.transcribe_audio(audio, speaker_hints=["Alice", "Bob"])
+
+        contents = provider.client.models.generate_content.call_args.kwargs["contents"]
+        prompt = contents[1]
+        assert "Speakers: Alice, Bob." in prompt
+        assert result["text"] == "hello world"
 
 
 # ---------------------------------------------------------------------------

--- a/video_processor/providers/gemini_provider.py
+++ b/video_processor/providers/gemini_provider.py
@@ -127,6 +127,7 @@ class GeminiProvider(BaseProvider):
         audio_path: str | Path,
         language: Optional[str] = None,
         model: Optional[str] = None,
+        speaker_hints: Optional[list[str]] = None,
     ) -> dict:
         from google.genai import types
 
@@ -149,8 +150,9 @@ class GeminiProvider(BaseProvider):
         audio_bytes = audio_path.read_bytes()
 
         lang_hint = f" The audio is in {language}." if language else ""
+        speaker_hint = f" Speakers: {', '.join(speaker_hints)}." if speaker_hints else ""
         prompt = (
-            f"Transcribe this audio accurately.{lang_hint} "
+            f"Transcribe this audio accurately.{lang_hint}{speaker_hint} "
             "Return only the verbatim transcript text — no JSON, no markdown, "
             "no preamble, no labels, no commentary."
         )

--- a/video_processor/providers/manager.py
+++ b/video_processor/providers/manager.py
@@ -1,5 +1,6 @@
 """ProviderManager - unified interface for routing API calls to the best available provider."""
 
+import inspect
 import logging
 from pathlib import Path
 from typing import Optional
@@ -40,6 +41,17 @@ def _ensure_providers_registered() -> None:
     import video_processor.providers.openai_provider  # noqa: F401
     import video_processor.providers.together_provider  # noqa: F401
     import video_processor.providers.xai_provider  # noqa: F401
+
+
+def _accepts_speaker_hints(provider: BaseProvider) -> bool:
+    """Check whether a provider's transcribe_audio() accepts a speaker_hints kwarg."""
+    try:
+        params = inspect.signature(provider.transcribe_audio).parameters
+    except (TypeError, ValueError):
+        return False
+    return "speaker_hints" in params or any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
+    )
 
 
 # Default model preference rankings (tried in order)
@@ -313,8 +325,12 @@ class ProviderManager:
             if prov_name == "openai":
                 # OpenAI Whisper supports a 'prompt' parameter for hints
                 transcribe_kwargs["prompt"] = "Speakers: " + ", ".join(speaker_hints) + "."
-            else:
+            elif _accepts_speaker_hints(provider):
                 transcribe_kwargs["speaker_hints"] = speaker_hints
+            else:
+                logger.warning(
+                    f"Transcriber '{prov_name}' does not support speaker hints; ignoring."
+                )
         result = provider.transcribe_audio(audio_path, **transcribe_kwargs)
         duration = result.get("duration") or 0
         self.usage.record(

--- a/video_processor/providers/openai_provider.py
+++ b/video_processor/providers/openai_provider.py
@@ -104,26 +104,31 @@ class OpenAIProvider(BaseProvider):
         audio_path: str | Path,
         language: Optional[str] = None,
         model: Optional[str] = None,
+        prompt: Optional[str] = None,
     ) -> dict:
         model = model or "whisper-1"
         audio_path = Path(audio_path)
         file_size = audio_path.stat().st_size
 
         if file_size <= self._MAX_FILE_SIZE:
-            return self._transcribe_single(audio_path, language, model)
+            return self._transcribe_single(audio_path, language, model, prompt)
 
         # File too large — split into chunks and transcribe each
         logger.info(
             f"Audio file {file_size / 1024 / 1024:.1f}MB exceeds Whisper 25MB limit, chunking..."
         )
-        return self._transcribe_chunked(audio_path, language, model)
+        return self._transcribe_chunked(audio_path, language, model, prompt)
 
-    def _transcribe_single(self, audio_path: Path, language: Optional[str], model: str) -> dict:
+    def _transcribe_single(
+        self, audio_path: Path, language: Optional[str], model: str, prompt: Optional[str] = None
+    ) -> dict:
         """Transcribe a single audio file."""
         with open(audio_path, "rb") as f:
             kwargs = {"model": model, "file": f}
             if language:
                 kwargs["language"] = language
+            if prompt:
+                kwargs["prompt"] = prompt
             response = self.client.audio.transcriptions.create(
                 **kwargs, response_format="verbose_json"
             )
@@ -143,7 +148,9 @@ class OpenAIProvider(BaseProvider):
             "model": model,
         }
 
-    def _transcribe_chunked(self, audio_path: Path, language: Optional[str], model: str) -> dict:
+    def _transcribe_chunked(
+        self, audio_path: Path, language: Optional[str], model: str, prompt: Optional[str] = None
+    ) -> dict:
         """Split audio into chunks under 25MB and transcribe each."""
         import tempfile
 
@@ -174,7 +181,7 @@ class OpenAIProvider(BaseProvider):
                 extractor.save_segment(chunk, chunk_path, sr)
 
                 logger.info(f"Transcribing chunk {i + 1}/{len(segments_data)}...")
-                result = self._transcribe_single(chunk_path, language, model)
+                result = self._transcribe_single(chunk_path, language, model, prompt)
 
                 all_text.append(result["text"])
                 for seg in result.get("segments", []):


### PR DESCRIPTION
## Summary

Fixes #127. `planopticon analyze --provider gemini --speakers "Alice,Bob"` crashed at the transcription step because `ProviderManager.transcribe_audio()` forwarded `speaker_hints` as a kwarg to every non-OpenAI provider, whether or not the provider's `transcribe_audio()` accepts it.

While fixing it I found the OpenAI branch was also broken: it mapped hints to a `prompt` kwarg that `OpenAIProvider.transcribe_audio()` never accepted, so `--speakers` crashed on OpenAI too — the issue understated the blast radius.

## Changes

- **`providers/manager.py`** — new `_accepts_speaker_hints()` helper inspects the provider's `transcribe_audio` signature; the kwarg is passed only when accepted (Deepgram/ElevenLabs), otherwise logged as a warning and dropped. OpenAI keeps its `prompt` mapping.
- **`providers/gemini_provider.py`** — `transcribe_audio()` now accepts `speaker_hints` and weaves the names into the transcription prompt.
- **`providers/openai_provider.py`** — `transcribe_audio()` now accepts `prompt` and threads it through both the single-file and chunked paths to the Whisper API.

## Test plan

- New regression tests in `tests/test_providers.py`: unsupporting provider gets the kwarg dropped with a warning (no TypeError), supporting provider still receives it, OpenAI receives `prompt="Speakers: Alice, Bob."`, and Gemini's generated prompt contains the speaker names.
- Full suite: 854 passed, 15 skipped. Ruff clean.