### PR TITLE
Pin opencv-python below 5.0 to unbreak CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 
 dependencies = [
     "numpy>=1.24.0",
-    "opencv-python>=4.8.0",
+    "opencv-python>=4.8.0,<5",
     "scipy>=1.10.0",
     "pillow>=10.0.0",
     "matplotlib>=3.7.0",

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -4,8 +4,8 @@ torchvision==0.26.0
 torchaudio==2.11.0
 
 # Additional CUDA dependencies
-opencv-contrib-python-headless>=4.7.0.72
+opencv-contrib-python-headless>=4.7.0.72,<5
 cupy-cuda11x>=12.0.0
 
 # Find packages at:
-# https://download.pytorch.org/whl/torch_stable.html 
+# https://download.pytorch.org/whl/torch_stable.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies
 numpy>=1.24.0
-opencv-python>=4.8.0
+opencv-python>=4.8.0,<5
 scipy>=1.10.0
 pillow>=10.0.0
 matplotlib>=3.7.0


### PR DESCRIPTION
## Summary

Fixes #137. opencv-python 5.0.0.93 shipped and removed `cv2.CascadeClassifier` from the main module; our open-ended `>=4.8.0` constraint pulled it in and broke test collection on every CI run since (first seen on the #135 merge push — last green main run predates the release, no repo change involved).

## Changes

Upper-bound all three opencv constraints (`pyproject.toml`, `requirements.txt`, `requirements-gpu.txt`) to `<5`. Migrating face detection to an OpenCV-5-compatible API is a separate, non-urgent task.

## Test plan

CI on this PR is the test — it reinstalls deps from the updated constraints and runs the full suite that currently fails at collection on main.