### PR TITLE
Add conflict-kg/v1 canonical graph export (JSON + SQLite)

### DIFF
--- a/docs/guide/export.md
+++ b/docs/guide/export.md
@@ -10,6 +10,7 @@ PlanOpticon provides multiple ways to export knowledge graph data into formats s
 | Obsidian vault | `planopticon export obsidian` | No | YAML frontmatter, `[[wiki-links]]`, tag pages, Map of Content |
 | Notion-compatible | `planopticon export notion` | No | Callout blocks, CSV database for bulk import |
 | PlanOpticonExchange JSON | `planopticon export exchange` | No | Canonical interchange format for merging and sharing |
+| conflict-kg/v1 | `planopticon export conflict-kg` | No | Cross-tool graph interchange format (JSON or SQLite) |
 | GitHub wiki | `planopticon wiki generate` | No | Home, Sidebar, entity pages, type indexes |
 | GitHub wiki push | `planopticon wiki push` | Git auth | Push generated wiki to a GitHub repo |
 
@@ -561,6 +562,68 @@ schema = PlanOpticonExchange.json_schema()
 ```
 
 This returns the full JSON Schema for validation and documentation purposes.
+
+## conflict-kg/v1 format
+
+`conflict-kg/v1` is the canonical knowledge-graph interchange format shared by
+all Conflict tools (PlanOpticon, Navegador, portal viewers) — a graph exported
+from any tool loads anywhere with no adapter. One schema, two encodings: JSON
+for small and medium graphs, SQLite for large ones (the SQLite file is
+Cloudflare D1-compatible for read-only portal queries).
+
+### CLI usage
+
+```
+planopticon export conflict-kg DB_PATH [OPTIONS]
+```
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--output` | `-o` | `./conflict_kg.json` (or `.db`) | Output file path |
+| `--sqlite` | | off | Emit the SQLite encoding instead of JSON |
+
+**Examples:**
+
+```bash
+# JSON encoding
+planopticon export conflict-kg knowledge_graph.db
+
+# SQLite encoding for large graphs / D1
+planopticon export conflict-kg knowledge_graph.db --sqlite -o graph.db
+```
+
+### Schema
+
+```json
+{
+  "format": "conflict-kg/v1",
+  "nodes": [
+    { "id": "python", "name": "Python", "type": "technology", "props": {} }
+  ],
+  "edges": [
+    { "source": "alice", "target": "python", "type": "uses", "props": {} }
+  ]
+}
+```
+
+- `id` is stable and unique — the entity's case-insensitive name, matching the
+  store's identity key.
+- Edges reference node `id`s (not names or prop dicts), so loaders are O(1).
+- Everything beyond the core fields lives under `props` (descriptions and
+  occurrences for nodes; `content_source` and `timestamp` for edges).
+
+The SQLite encoding is the same contract as two tables:
+
+```sql
+CREATE TABLE nodes (id TEXT PRIMARY KEY, name TEXT, type TEXT, props JSON);
+CREATE TABLE edges (source TEXT, target TEXT, type TEXT, props JSON);
+CREATE INDEX idx_edges_source ON edges(source);
+CREATE INDEX idx_edges_target ON edges(target);
+```
+
+The legacy `knowledge_graph.json` shape (`{nodes, relationships}`) is unchanged
+and remains supported for existing consumers; new integrations should read
+conflict-kg/v1.
 
 ## Python API for all exporters
 

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -155,3 +155,154 @@ class TestPPTXExport:
         monkeypatch.setattr(builtins, "__import__", mock_import)
         with pytest.raises(ImportError):
             generate_pptx(_sample_kg(), tmp_path / "fail.pptx")
+
+
+class TestConflictKGExport:
+    def test_canonical_shape(self):
+        from video_processor.exporters.conflict_kg import FORMAT_ID, to_conflict_kg
+
+        data = to_conflict_kg(_sample_kg())
+        assert data["format"] == FORMAT_ID == "conflict-kg/v1"
+        assert len(data["nodes"]) == 5
+        assert len(data["edges"]) == 4
+
+        ids = [n["id"] for n in data["nodes"]]
+        assert len(ids) == len(set(ids))
+        assert ids == [n["name"].lower() for n in data["nodes"]]
+
+        python = next(n for n in data["nodes"] if n["id"] == "python")
+        assert python["name"] == "Python"
+        assert python["type"] == "technology"
+        assert python["props"]["descriptions"] == ["A programming language"]
+
+    def test_edges_reference_node_ids(self):
+        from video_processor.exporters.conflict_kg import to_conflict_kg
+
+        data = to_conflict_kg(_sample_kg())
+        node_ids = {n["id"] for n in data["nodes"]}
+        for edge in data["edges"]:
+            assert edge["source"] in node_ids
+            assert edge["target"] in node_ids
+
+    def test_edge_props_dropped_when_absent(self):
+        from video_processor.exporters.conflict_kg import to_conflict_kg
+
+        kg = {
+            "nodes": [{"name": "A", "type": "concept"}, {"name": "B", "type": "concept"}],
+            "relationships": [
+                {"source": "A", "target": "B", "type": "related_to", "timestamp": 5.0},
+                {"source": "B", "target": "A", "type": "related_to", "content_source": None},
+            ],
+        }
+        data = to_conflict_kg(kg)
+        assert data["edges"][0]["props"] == {"timestamp": 5.0}
+        assert data["edges"][1]["props"] == {}
+
+    def test_json_writer(self, tmp_path):
+        import json
+
+        from video_processor.exporters.conflict_kg import to_conflict_kg, write_conflict_kg_json
+
+        out = tmp_path / "conflict_kg.json"
+        write_conflict_kg_json(_sample_kg(), out)
+        assert json.loads(out.read_text()) == to_conflict_kg(_sample_kg())
+
+    def test_sqlite_writer_schema_and_rows(self, tmp_path):
+        import json
+        import sqlite3
+
+        from video_processor.exporters.conflict_kg import write_conflict_kg_sqlite
+
+        out = tmp_path / "conflict_kg.db"
+        write_conflict_kg_sqlite(_sample_kg(), out)
+
+        conn = sqlite3.connect(out)
+        try:
+            tables = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            assert tables == {"nodes", "edges"}
+            indexes = {
+                r[0]
+                for r in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx%'"
+                ).fetchall()
+            }
+            assert indexes == {"idx_edges_source", "idx_edges_target"}
+
+            nodes = conn.execute("SELECT id, name, type, props FROM nodes ORDER BY id").fetchall()
+            assert len(nodes) == 5
+            assert all(json.loads(props) is not None for *_rest, props in nodes)
+
+            edges = conn.execute("SELECT source, target, type FROM edges").fetchall()
+            assert len(edges) == 4
+            node_ids = {n[0] for n in nodes}
+            assert all(src in node_ids and tgt in node_ids for src, tgt, _ in edges)
+        finally:
+            conn.close()
+
+    def test_sqlite_matches_json_encoding(self, tmp_path):
+        import json
+        import sqlite3
+
+        from video_processor.exporters.conflict_kg import (
+            to_conflict_kg,
+            write_conflict_kg_sqlite,
+        )
+
+        out = tmp_path / "conflict_kg.db"
+        write_conflict_kg_sqlite(_sample_kg(), out)
+        canonical = to_conflict_kg(_sample_kg())
+
+        conn = sqlite3.connect(out)
+        try:
+            nodes = [
+                {"id": i, "name": n, "type": t, "props": json.loads(p)}
+                for i, n, t, p in conn.execute("SELECT id, name, type, props FROM nodes")
+            ]
+            edges = [
+                {"source": s, "target": t, "type": ty, "props": json.loads(p)}
+                for s, t, ty, p in conn.execute("SELECT source, target, type, props FROM edges")
+            ]
+        finally:
+            conn.close()
+        assert nodes == canonical["nodes"]
+        assert edges == canonical["edges"]
+
+    def test_cli_export_conflict_kg(self, tmp_path):
+        import json
+
+        from click.testing import CliRunner
+
+        from video_processor.cli.commands import cli
+        from video_processor.integrators.graph_store import SQLiteStore
+
+        db = tmp_path / "knowledge_graph.db"
+        store = SQLiteStore(db)
+        store.merge_entity("Alice", "person", ["Engineer"])
+        store.merge_entity("Python", "technology", [])
+        store.add_relationship("Alice", "Python", "uses")
+
+        runner = CliRunner()
+        out_json = tmp_path / "out.json"
+        result = runner.invoke(cli, ["export", "conflict-kg", str(db), "-o", str(out_json)])
+        assert result.exit_code == 0, result.output
+        data = json.loads(out_json.read_text())
+        assert data["format"] == "conflict-kg/v1"
+        assert {n["id"] for n in data["nodes"]} == {"alice", "python"}
+        assert data["edges"][0] == {
+            "source": "alice",
+            "target": "python",
+            "type": "uses",
+            "props": {},
+        }
+
+        out_db = tmp_path / "out.db"
+        result = runner.invoke(
+            cli, ["export", "conflict-kg", str(db), "--sqlite", "-o", str(out_db)]
+        )
+        assert result.exit_code == 0, result.output
+        assert out_db.exists()

--- a/video_processor/cli/commands.py
+++ b/video_processor/cli/commands.py
@@ -1773,6 +1773,54 @@ def export_exchange(db_path, output, project_name, project_desc):
     )
 
 
+@export.command("conflict-kg")
+@click.argument("db_path", type=click.Path(exists=True))
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(),
+    default=None,
+    help="Output file path (default: conflict_kg.json or conflict_kg.db)",
+)
+@click.option(
+    "--sqlite",
+    "as_sqlite",
+    is_flag=True,
+    default=False,
+    help="Emit the SQLite encoding (for large graphs / Cloudflare D1)",
+)
+def export_conflict_kg(db_path, output, as_sqlite):
+    """Export a knowledge graph in the canonical conflict-kg/v1 format.
+
+    Examples:
+
+        planopticon export conflict-kg knowledge_graph.db
+
+        planopticon export conflict-kg knowledge_graph.db --sqlite -o graph.db
+    """
+    from video_processor.exporters.conflict_kg import (
+        write_conflict_kg_json,
+        write_conflict_kg_sqlite,
+    )
+    from video_processor.integrators.knowledge_graph import KnowledgeGraph
+
+    kg = KnowledgeGraph(db_path=Path(db_path))
+    kg_data = kg.to_dict()
+
+    if as_sqlite:
+        out_path = Path(output) if output else Path.cwd() / "conflict_kg.db"
+        write_conflict_kg_sqlite(kg_data, out_path)
+    else:
+        out_path = Path(output) if output else Path.cwd() / "conflict_kg.json"
+        write_conflict_kg_json(kg_data, out_path)
+
+    click.echo(
+        f"Exported conflict-kg/v1 to {out_path} "
+        f"({len(kg_data.get('nodes', []))} nodes, "
+        f"{len(kg_data.get('relationships', []))} edges)"
+    )
+
+
 @cli.group()
 def wiki():
     """Generate and push GitHub wikis from knowledge graphs."""

--- a/video_processor/exporters/conflict_kg.py
+++ b/video_processor/exporters/conflict_kg.py
@@ -1,0 +1,121 @@
+"""Export knowledge graphs in the canonical conflict-kg/v1 interchange format.
+
+One contract, two encodings: a JSON document for small/medium graphs and a
+two-table SQLite database (D1-compatible) for large ones. Every Conflict tool
+reads and writes this shape, so a graph from any tool loads anywhere without
+per-source adapters.
+
+Contract:
+    {
+      "format": "conflict-kg/v1",
+      "nodes": [{"id": str, "name": str, "type": str, "props": {}}],
+      "edges": [{"source": node-id, "target": node-id, "type": str, "props": {}}]
+    }
+
+Node `id` is the entity's case-insensitive name (the store's identity key);
+edge `source`/`target` reference node ids so loaders are O(1).
+"""
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+FORMAT_ID = "conflict-kg/v1"
+
+_SQLITE_SCHEMA = """
+CREATE TABLE nodes (id TEXT PRIMARY KEY, name TEXT, type TEXT, props JSON);
+CREATE TABLE edges (source TEXT, target TEXT, type TEXT, props JSON);
+CREATE INDEX idx_edges_source ON edges(source);
+CREATE INDEX idx_edges_target ON edges(target);
+"""
+
+
+def to_conflict_kg(kg_dict: Dict) -> Dict:
+    """Project a KnowledgeGraph.to_dict() payload onto the conflict-kg/v1 shape.
+
+    Node ids are the lowercased entity names — the store's real identity key —
+    and edge endpoints are normalized the same way so they always reference
+    node ids regardless of the casing stored on the relationship rows.
+    """
+    nodes = []
+    for node in kg_dict.get("nodes", []):
+        name = node.get("name", "")
+        props = {}
+        if node.get("descriptions"):
+            props["descriptions"] = node["descriptions"]
+        if node.get("occurrences"):
+            props["occurrences"] = node["occurrences"]
+        nodes.append(
+            {
+                "id": name.lower(),
+                "name": name,
+                "type": node.get("type", "concept"),
+                "props": props,
+            }
+        )
+
+    edges = []
+    for rel in kg_dict.get("relationships", []):
+        props = {}
+        if rel.get("content_source") is not None:
+            props["content_source"] = rel["content_source"]
+        if rel.get("timestamp") is not None:
+            props["timestamp"] = rel["timestamp"]
+        edges.append(
+            {
+                "source": rel.get("source", "").lower(),
+                "target": rel.get("target", "").lower(),
+                "type": rel.get("type", "related_to"),
+                "props": props,
+            }
+        )
+
+    return {"format": FORMAT_ID, "nodes": nodes, "edges": edges}
+
+
+def write_conflict_kg_json(kg_dict: Dict, output_path: Path) -> Path:
+    """Write the canonical JSON encoding. Returns the output path."""
+    output_path = Path(output_path)
+    data = to_conflict_kg(kg_dict)
+    output_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    logger.info(
+        f"Exported {len(data['nodes'])} nodes / {len(data['edges'])} edges "
+        f"to {output_path} ({FORMAT_ID} JSON)"
+    )
+    return output_path
+
+
+def write_conflict_kg_sqlite(kg_dict: Dict, output_path: Path) -> Path:
+    """Write the canonical SQLite encoding (same field names, two tables).
+
+    The output is a fresh database in the exact conflict-kg/v1 schema —
+    suitable for committing to a consuming repo and loading into Cloudflare D1.
+    """
+    output_path = Path(output_path)
+    if output_path.exists():
+        output_path.unlink()
+
+    data = to_conflict_kg(kg_dict)
+    conn = sqlite3.connect(output_path)
+    try:
+        conn.executescript(_SQLITE_SCHEMA)
+        conn.executemany(
+            "INSERT OR REPLACE INTO nodes (id, name, type, props) VALUES (?, ?, ?, ?)",
+            [(n["id"], n["name"], n["type"], json.dumps(n["props"])) for n in data["nodes"]],
+        )
+        conn.executemany(
+            "INSERT INTO edges (source, target, type, props) VALUES (?, ?, ?, ?)",
+            [(e["source"], e["target"], e["type"], json.dumps(e["props"])) for e in data["edges"]],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    logger.info(
+        f"Exported {len(data['nodes'])} nodes / {len(data['edges'])} edges "
+        f"to {output_path} ({FORMAT_ID} SQLite)"
+    )
+    return output_path


### PR DESCRIPTION
## Summary

Fixes #133 (the PlanOpticon asks). Adds the canonical `conflict-kg/v1` interchange export:

- **`exporters/conflict_kg.py`** — `to_conflict_kg()` projection plus JSON and SQLite writers. Node `id` = lowercased entity name (the store's real identity key); edge endpoints normalized to ids so loaders are O(1); descriptions/occurrences fold into node `props`, `content_source`/`timestamp` into edge `props`. SQLite writer emits exactly the schema from the issue (`nodes`/`edges` + source/target indexes), D1-compatible.
- **CLI** — `planopticon export conflict-kg DB_PATH [-o OUT] [--sqlite]`, following the existing `export` subcommand pattern.
- **Docs** — new format section in the Export guide + overview table row.

Checkbox notes:
- *Deprecated alias:* the current `knowledge_graph.json` shape is actually `{nodes, relationships}` (not `{nodes, edges}` as the issue assumed) — it is untouched and remains supported.
- *Existing .db mapping:* confirmed it does **not** map 1:1 (working schema has `entities` keyed on `name_lower`, plus `occurrences`/`sources`/`source_locations`); the canonical shape is produced as an export projection instead of views/migrations on the working DB.

## Test plan

7 new tests in `tests/test_exporters.py`: canonical shape + unique ids, edges-reference-ids invariant, prop pruning, JSON writer round-trip, SQLite schema/rows, JSON↔SQLite encoding equivalence, and an end-to-end CLI test (CliRunner against a real SQLiteStore, both encodings). Full suite: 861 passed, 15 skipped. Ruff clean.