### PR TITLE
Persist machine-readable usage.json per pipeline run

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -118,12 +118,12 @@ class TestExtractActionItems:
 
 def _make_mock_pm():
     """Build a mock ProviderManager with usage tracker and predictable responses."""
+    from video_processor.utils.usage_tracker import UsageTracker
+
     pm = MagicMock()
 
-    # Usage tracker stub
-    pm.usage = MagicMock()
-    pm.usage.start_step = MagicMock()
-    pm.usage.end_step = MagicMock()
+    # Real usage tracker — the pipeline serializes it to usage.json
+    pm.usage = UsageTracker()
 
     # transcribe_audio returns a simple transcript
     pm.transcribe_audio.return_value = {
@@ -266,6 +266,10 @@ class TestProcessSingleVideo:
         assert manifest.stats.frames_extracted == 2
         assert manifest.transcript_json == "transcript/transcript.json"
         assert manifest.knowledge_graph_json == "results/knowledge_graph.json"
+
+        usage = json.loads((output_dir / "usage.json").read_text())
+        for key in ("input_tokens", "output_tokens", "audio_minutes", "models", "steps"):
+            assert key in usage
 
     @patch("video_processor.pipeline.export_all_formats")
     @patch("video_processor.pipeline.PlanGenerator")

--- a/tests/test_usage_tracker.py
+++ b/tests/test_usage_tracker.py
@@ -196,3 +196,40 @@ class TestFmtDuration:
 
     def test_just_under_minute(self):
         assert _fmt_duration(59.9) == "59.9s"
+
+
+class TestToDict:
+    def test_to_dict_totals_and_breakdown(self):
+        tracker = UsageTracker()
+        tracker.record("openai", "gpt-4o", input_tokens=100, output_tokens=50)
+        tracker.record("openai", "gpt-4o", input_tokens=10, output_tokens=5)
+        tracker.record("openai", "whisper-1", audio_minutes=2.5)
+        tracker.start_step("Transcription")
+        tracker.end_step()
+
+        data = tracker.to_dict()
+        assert data["input_tokens"] == 110
+        assert data["output_tokens"] == 55
+        assert data["audio_minutes"] == 2.5
+        assert data["api_calls"] == 3
+        assert data["estimated_cost"] > 0
+        assert data["duration_seconds"] >= 0
+
+        models = {m["model"]: m for m in data["models"]}
+        assert models["gpt-4o"]["calls"] == 2
+        assert models["whisper-1"]["audio_minutes"] == 2.5
+        assert data["steps"][0]["name"] == "Transcription"
+
+    def test_to_dict_empty_tracker_and_json_serializable(self):
+        import json
+
+        data = UsageTracker().to_dict()
+        assert data["input_tokens"] == 0
+        assert data["models"] == []
+        assert json.loads(json.dumps(data)) == data
+
+    def test_to_dict_includes_open_step(self):
+        tracker = UsageTracker()
+        tracker.start_step("Frames")
+        data = tracker.to_dict()
+        assert [s["name"] for s in data["steps"]] == ["Frames"]

--- a/video_processor/pipeline.py
+++ b/video_processor/pipeline.py
@@ -405,6 +405,10 @@ def process_single_video(
     # Write manifest
     write_video_manifest(manifest, output_dir)
 
+    # Persist machine-readable usage for cost tracking (platform billing reads this)
+    usage_path = Path(output_dir) / "usage.json"
+    usage_path.write_text(json.dumps(pm.usage.to_dict(), indent=2))
+
     logger.info(
         f"Processing complete in {elapsed:.1f}s: {len(diagrams)} diagrams, "
         f"{len(screen_captures)} captures, {len(key_points)} key points, "

--- a/video_processor/utils/usage_tracker.py
+++ b/video_processor/utils/usage_tracker.py
@@ -138,6 +138,35 @@ class UsageTracker:
     def total_duration(self) -> float:
         return time.time() - self._start_time
 
+    def to_dict(self) -> dict:
+        """Machine-readable usage summary — persisted as usage.json per run.
+
+        Top-level key names are a contract with the planopticon.io platform's
+        cost extraction (input_tokens, output_tokens, audio_minutes).
+        """
+        steps = self._steps + ([self._current_step] if self._current_step else [])
+        return {
+            "input_tokens": self.total_input_tokens,
+            "output_tokens": self.total_output_tokens,
+            "audio_minutes": sum(u.audio_minutes for u in self._models.values()),
+            "api_calls": self.total_api_calls,
+            "estimated_cost": self.total_cost,
+            "duration_seconds": self.total_duration,
+            "models": [
+                {
+                    "provider": u.provider,
+                    "model": u.model,
+                    "calls": u.calls,
+                    "input_tokens": u.input_tokens,
+                    "output_tokens": u.output_tokens,
+                    "audio_minutes": u.audio_minutes,
+                    "estimated_cost": u.estimated_cost,
+                }
+                for u in self._models.values()
+            ],
+            "steps": [{"name": s.name, "duration_seconds": s.duration} for s in steps],
+        }
+
     def format_summary(self) -> str:
         """Format a human-readable summary for CLI output."""
         lines = []


### PR DESCRIPTION
## Summary

Fixes #142. `UsageTracker.to_dict()` (totals + per-model breakdown + step timings; top-level keys `input_tokens`/`output_tokens`/`audio_minutes` are the contract with planopticon.io's cost extraction) and the pipeline now writes `<output_dir>/usage.json` alongside the manifest.

Pipeline test mocks switched from a MagicMock usage stub to a real `UsageTracker` — the pipeline now serializes it, and the real object can't drift from the mock.

## Test plan

3 new to_dict tests (totals/breakdown, empty + JSON-serializable, open step included) + usage.json assertion in the pipeline manifest test. Full suite: 864 passed, 15 skipped. Ruff clean.