### PR TITLE
Fix hardcoded version assertion after v1.0.0 bump

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ class TestCLIRoot:
         result = runner.invoke(cli, ["--version"])
         assert result.exit_code == 0
         assert "PlanOpticon" in result.output
-        assert "0.6.0" in result.output  # matches @click.version_option
+        assert "1.0.0" in result.output  # matches @click.version_option
 
     def test_help(self):
         runner = CliRunner()


### PR DESCRIPTION
## Summary

Follow-up to #145: `tests/test_cli.py::test_version` pins the CLI version string and wasn't bumped with the release, so main's CI is red. This updates the assertion to 1.0.0.

Process note worth fixing separately: the PR-level matrix caught this, but the merge queue's required checks let it merge anyway — the queue's required-check list should include the test matrix.

## Test plan

`pytest tests/test_cli.py` green locally; full matrix on CI.