### PR TITLE
Add Replicate provider (chat, vision, transcription)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ PlanOpticon processes video recordings, documents, and 20+ online sources into s
 
 ## Features
 
-- **15+ AI providers** -- OpenAI, Anthropic, Gemini, Ollama, Azure, Together, Fireworks, Cerebras, xAI, Bedrock, Vertex, Mistral, Cohere, AI21, HuggingFace, Qianfan, and LiteLLM. Defaults to cheap models (Haiku, GPT-4o-mini, Gemini Flash).
+- **15+ AI providers** -- OpenAI, Anthropic, Gemini, Ollama, Azure, Together, Fireworks, Cerebras, xAI, Bedrock, Vertex, Mistral, Cohere, AI21, HuggingFace, Replicate, Qianfan, and LiteLLM. Defaults to cheap models (Haiku, GPT-4o-mini, Gemini Flash).
 - **20+ source connectors** -- YouTube, web pages, GitHub, Reddit, HackerNews, RSS, podcasts, arXiv, S3, Google Workspace, Microsoft 365, Obsidian, Notion, Apple Notes, Zoom, Teams, Google Meet, and more.
 - **Planning agent** -- 11 skills including project plans, PRDs, roadmaps, task breakdowns, and GitHub integration.
 - **Interactive companion** -- Chat REPL with 15 slash commands, auto-discovery of workspace knowledge, and runtime provider/model switching.

--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -16,6 +16,7 @@ PlanOpticon supports multiple AI providers through a unified abstraction layer. 
 | Fireworks AI | Llama, Mixtral, etc. | Llava | — | `FIREWORKS_API_KEY` |
 | Cerebras | Llama (fast inference) | — | — | `CEREBRAS_API_KEY` |
 | xAI | Grok | Grok | — | `XAI_API_KEY` |
+| Replicate | Llama 3, etc. | Llava | Whisper | `REPLICATE_API_TOKEN` |
 | Ollama (local) | Any installed model | llava, moondream, etc. | — (use local Whisper) | `OLLAMA_HOST` |
 
 ## Default models

--- a/tests/test_provider_modules.py
+++ b/tests/test_provider_modules.py
@@ -30,6 +30,7 @@ from video_processor.providers.huggingface_provider import HuggingFaceProvider
 from video_processor.providers.litellm_provider import LiteLLMProvider
 from video_processor.providers.mistral_provider import MistralProvider
 from video_processor.providers.qianfan_provider import QianfanProvider
+from video_processor.providers.replicate_provider import ReplicateProvider
 from video_processor.providers.vertex_provider import VertexProvider
 from video_processor.providers.whisper_local import WhisperLocal
 
@@ -915,3 +916,255 @@ class TestWhisperLocal:
             wl = WhisperLocal(model_size="base", device="cpu")
             with pytest.raises(ImportError, match="openai-whisper"):
                 wl.transcribe(audio)
+
+
+# ---------------------------------------------------------------------------
+# Replicate (no SDK: raw HTTP against the prediction API -> patch module requests)
+# ---------------------------------------------------------------------------
+
+
+def _replicate_response(payload, raise_exc=None):
+    """Build a stand-in for the requests.Response the prediction API returns."""
+    resp = MagicMock()
+    resp.json.return_value = payload
+    if raise_exc is not None:
+        resp.raise_for_status.side_effect = raise_exc
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+class TestReplicateProvider:
+    @patch.dict("os.environ", {}, clear=True)
+    def test_construction_requires_token(self):
+        with pytest.raises(ValueError, match="REPLICATE_API_TOKEN"):
+            ReplicateProvider()
+
+    @patch("video_processor.providers.replicate_provider.requests")
+    def test_chat_maps_request_and_response(self, mock_requests):
+        mock_requests.post.return_value = _replicate_response(
+            {"status": "succeeded", "output": ["meta", " says", " hi"]}
+        )
+        provider = ReplicateProvider(api_key="k")
+        out = provider.chat(USER_MSG, max_tokens=321, temperature=0.2)
+
+        assert out == "meta says hi"  # list of chunks joined
+        args, kwargs = mock_requests.post.call_args
+        assert (
+            args[0]
+            == "https://api.replicate.com/v1/models/meta/meta-llama-3-8b-instruct/predictions"
+        )
+        assert kwargs["headers"]["Authorization"] == "Bearer k"
+        assert kwargs["headers"]["Prefer"] == "wait"  # blocking prediction
+        model_input = kwargs["json"]["input"]
+        assert model_input["prompt"] == "hello"  # messages flattened to prompt
+        assert model_input["max_tokens"] == 321
+        assert model_input["temperature"] == 0.2
+        assert "system_prompt" not in model_input
+        assert provider._last_usage == {"input_tokens": 0, "output_tokens": 0}
+
+    @patch("video_processor.providers.replicate_provider.requests")
+    def test_chat_pulls_system_message_into_system_prompt(self, mock_requests):
+        mock_requests.post.return_value = _replicate_response(
+            {"status": "succeeded", "output": ["ok"]}
+        )
+        provider = ReplicateProvider(api_key="k")
+        provider.chat(
+            [
+                {"role": "system", "content": "be brief"},
+                {"role": "user", "content": "hello"},
+            ]
+        )
+        model_input = mock_requests.post.call_args.kwargs["json"]["input"]
+        assert model_input["prompt"] == "hello"
+        assert model_input["system_prompt"] == "be brief"
+
+    @patch("video_processor.providers.replicate_provider.requests")
+    def test_analyze_image_builds_data_uri_input(self, mock_requests):
+        mock_requests.post.return_value = _replicate_response(
+            {"status": "succeeded", "output": ["a", " cat"]}
+        )
+        provider = ReplicateProvider(api_key="k")
+        out = provider.analyze_image(b"\x89PNG", "what is this?")
+
+        assert out == "a cat"
+        args, kwargs = mock_requests.post.call_args
+        assert args[0] == "https://api.replicate.com/v1/models/yorickvp/llava-13b/predictions"
+        model_input = kwargs["json"]["input"]
+        assert model_input["prompt"] == "what is this?"
+        assert (
+            model_input["image"]
+            == "data:image/jpeg;base64," + base64.b64encode(b"\x89PNG").decode()
+        )
+
+    @patch("video_processor.providers.replicate_provider.requests")
+    def test_transcribe_immediate_success(self, mock_requests, tmp_path):
+        audio = tmp_path / "a.wav"
+        audio.write_bytes(b"\x00\x01\x02")
+        mock_requests.post.return_value = _replicate_response(
+            {
+                "id": "pred1",
+                "status": "succeeded",
+                "output": {
+                    "transcription": "  hello world  ",
+                    "detected_language": "english",
+                    "segments": [
+                        {"start": 0.0, "end": 1.5, "text": " hello world "},
+                        "not-a-dict-segment",  # malformed entries are skipped
+                    ],
+                },
+            }
+        )
+        provider = ReplicateProvider(api_key="k")
+        result = provider.transcribe_audio(audio)
+
+        assert result["text"] == "hello world"  # stripped
+        assert result["language"] == "english"
+        assert result["segments"] == [{"start": 0.0, "end": 1.5, "text": "hello world"}]
+        assert result["duration"] == 1.5  # last segment end
+        assert result["provider"] == "replicate"
+        assert result["model"] == "openai/whisper"  # default
+        mock_requests.get.assert_not_called()  # terminal already -> no polling
+        model_input = mock_requests.post.call_args.kwargs["json"]["input"]
+        assert model_input["audio"].startswith("data:audio/wav;base64,")
+        assert base64.b64encode(b"\x00\x01\x02").decode() in model_input["audio"]
+
+    @patch("video_processor.providers.replicate_provider.time")
+    @patch("video_processor.providers.replicate_provider.requests")
+    def test_transcribe_polls_until_success(self, mock_requests, mock_time, tmp_path):
+        audio = tmp_path / "a.mp3"
+        audio.write_bytes(b"\x00")
+        mock_requests.post.return_value = _replicate_response(
+            {"id": "pred2", "status": "processing", "output": None}
+        )
+        mock_requests.get.return_value = _replicate_response(
+            {
+                "id": "pred2",
+                "status": "succeeded",
+                "output": {"transcription": "done", "segments": []},
+            }
+        )
+        provider = ReplicateProvider(api_key="k")
+        result = provider.transcribe_audio(audio, language="en")
+
+        assert result["text"] == "done"
+        assert result["language"] == "en"  # falls back to the passed language
+        assert result["segments"] == []
+        mock_requests.get.assert_called_once()  # polled once
+        assert mock_requests.get.call_args.args[0].endswith("/predictions/pred2")
+        mock_time.sleep.assert_called()  # slept between polls
+
+    @patch("video_processor.providers.replicate_provider.requests")
+    def test_failed_prediction_raises_with_detail(self, mock_requests):
+        mock_requests.post.return_value = _replicate_response(
+            {"id": "p", "status": "failed", "error": "CUDA out of memory"}
+        )
+        provider = ReplicateProvider(api_key="k")
+        with pytest.raises(RuntimeError, match="CUDA out of memory"):
+            provider.chat(USER_MSG)
+
+    @patch("video_processor.providers.replicate_provider.requests")
+    def test_http_error_propagates(self, mock_requests):
+        mock_requests.post.return_value = _replicate_response(
+            {"status": "succeeded", "output": []},
+            raise_exc=RuntimeError("500 Server Error"),
+        )
+        provider = ReplicateProvider(api_key="k")
+        with pytest.raises(RuntimeError, match="500"):
+            provider.chat(USER_MSG)
+
+    @patch("video_processor.providers.replicate_provider.requests")
+    def test_strips_replicate_prefix(self, mock_requests, tmp_path):
+        audio = tmp_path / "a.wav"
+        audio.write_bytes(b"\x00")
+        mock_requests.post.return_value = _replicate_response(
+            {"id": "p", "status": "succeeded", "output": {"transcription": "x", "segments": []}}
+        )
+        provider = ReplicateProvider(api_key="k")
+        result = provider.transcribe_audio(audio, model="replicate/openai/whisper")
+
+        # replicate/openai/whisper -> owner "openai", name "whisper"
+        assert (
+            mock_requests.post.call_args.args[0]
+            == "https://api.replicate.com/v1/models/openai/whisper/predictions"
+        )
+        assert result["model"] == "openai/whisper"
+
+    @patch("video_processor.providers.replicate_provider.requests")
+    def test_list_models_maps_and_infers_capabilities(self, mock_requests):
+        mock_requests.get.return_value = _replicate_response(
+            {
+                "results": [
+                    {
+                        "owner": "openai",
+                        "name": "whisper",
+                        "description": "Whisper speech recognition",
+                    },
+                    {
+                        "owner": "yorickvp",
+                        "name": "llava-13b",
+                        "description": "LLaVA vision model",
+                    },
+                    {
+                        "owner": "meta",
+                        "name": "meta-llama-3-8b-instruct",
+                        "description": "Llama 3 chat",
+                    },
+                    {"owner": "", "name": "orphan", "description": "no owner"},
+                ]
+            }
+        )
+        provider = ReplicateProvider(api_key="k")
+        models = provider.list_models()
+
+        assert all(isinstance(m, ModelInfo) for m in models)
+        assert all(m.provider == "replicate" for m in models)
+        assert len(models) == 3  # the malformed (owner-less) entry is skipped
+        by_id = {m.id: m for m in models}
+        assert by_id["openai/whisper"].capabilities == ["audio"]
+        assert by_id["yorickvp/llava-13b"].capabilities == ["vision"]
+        assert by_id["meta/meta-llama-3-8b-instruct"].capabilities == ["chat"]
+
+    @patch("video_processor.providers.replicate_provider.requests")
+    def test_list_models_returns_empty_on_error(self, mock_requests):
+        mock_requests.get.side_effect = ConnectionError("no network")
+        provider = ReplicateProvider(api_key="k")
+        assert provider.list_models() == []
+
+    @patch("video_processor.providers.replicate_provider.requests")
+    def test_chat_handles_non_list_output(self, mock_requests):
+        # Some models return a single string (or null) instead of a chunk list.
+        provider = ReplicateProvider(api_key="k")
+        mock_requests.post.return_value = _replicate_response(
+            {"status": "succeeded", "output": "single string reply"}
+        )
+        assert provider.chat(USER_MSG) == "single string reply"
+        mock_requests.post.return_value = _replicate_response(
+            {"status": "succeeded", "output": None}
+        )
+        assert provider.chat(USER_MSG) == ""
+
+    @patch("video_processor.providers.replicate_provider.requests")
+    def test_transcribe_handles_bare_string_output(self, mock_requests, tmp_path):
+        # Some ASR models return just the transcript string, not a dict.
+        audio = tmp_path / "a.wav"
+        audio.write_bytes(b"\x00")
+        mock_requests.post.return_value = _replicate_response(
+            {"id": "p", "status": "succeeded", "output": "  bare transcript  "}
+        )
+        provider = ReplicateProvider(api_key="k")
+        result = provider.transcribe_audio(audio, language="fr")
+
+        assert result["text"] == "bare transcript"
+        assert result["segments"] == []
+        assert result["language"] == "fr"
+        assert result["duration"] is None
+
+    def test_registration_metadata(self):
+        info = ProviderRegistry.all_registered()["replicate"]
+        assert info["class"] is ReplicateProvider
+        assert info["env_var"] == "REPLICATE_API_TOKEN"
+        assert info["model_prefixes"] == ["replicate/"]
+        assert info["default_models"]["chat"] == "meta/meta-llama-3-8b-instruct"
+        assert info["default_models"]["vision"] == "yorickvp/llava-13b"
+        assert info["default_models"]["audio"] == "openai/whisper"

--- a/video_processor/providers/manager.py
+++ b/video_processor/providers/manager.py
@@ -39,6 +39,7 @@ def _ensure_providers_registered() -> None:
     import video_processor.providers.gemini_provider  # noqa: F401
     import video_processor.providers.ollama_provider  # noqa: F401
     import video_processor.providers.openai_provider  # noqa: F401
+    import video_processor.providers.replicate_provider  # noqa: F401
     import video_processor.providers.together_provider  # noqa: F401
     import video_processor.providers.xai_provider  # noqa: F401
 

--- a/video_processor/providers/replicate_provider.py
+++ b/video_processor/providers/replicate_provider.py
@@ -1,0 +1,261 @@
+"""Replicate provider — hosted model zoo via the prediction API.
+
+Uses Replicate's HTTP prediction API (https://api.replicate.com/v1) directly
+with plain ``requests`` and a ``Prefer: wait`` header, so the core stays lean
+(no ``replicate`` SDK dependency — same approach as the Deepgram/ElevenLabs
+providers). One API fronts many models: language models for chat, LLaVA-style
+models for vision, and Whisper variants for transcription.
+
+Model routing: an incoming id may carry a ``replicate/`` prefix, which is
+stripped before the API call. The remainder is ``owner/name`` (e.g.
+``replicate/openai/whisper`` -> owner ``openai``, name ``whisper``).
+"""
+
+import base64
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+import requests
+from dotenv import load_dotenv
+
+from video_processor.providers.base import BaseProvider, ModelInfo, ProviderRegistry
+
+load_dotenv()
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.replicate.com/v1"
+_PREFIX = "replicate/"
+_TIMEOUT = 900
+_POLL_INTERVAL = 2.0
+_MAX_POLLS = 60  # bounded: ~2 minutes of polling after the initial wait window
+_TERMINAL = {"succeeded", "failed", "canceled"}
+_MIME = {
+    ".wav": "audio/wav",
+    ".mp3": "audio/mpeg",
+    ".m4a": "audio/mp4",
+    ".mp4": "audio/mp4",
+    ".flac": "audio/flac",
+    ".ogg": "audio/ogg",
+    ".webm": "audio/webm",
+}
+
+
+def _join_output(output) -> str:
+    """Join a Replicate language-model output (list of string chunks) into text."""
+    if isinstance(output, list):
+        return "".join(str(chunk) for chunk in output)
+    if output is None:
+        return ""
+    return str(output)
+
+
+def _infer_capabilities(name: str, description: str) -> list[str]:
+    """Best-effort capability inference from a model's name/description."""
+    text = f"{name} {description}".lower()
+    caps: list[str] = []
+    if any(k in text for k in ("whisper", "transcri", "speech", "asr")):
+        caps.append("audio")
+    if any(k in text for k in ("llava", "vision", "caption", "clip", "blip")):
+        caps.append("vision")
+    if not caps:
+        caps.append("chat")
+    return caps
+
+
+class ReplicateProvider(BaseProvider):
+    """Replicate provider (chat, vision, transcription) via the prediction API."""
+
+    provider_name = "replicate"
+
+    def __init__(self, api_key: Optional[str] = None):
+        self.api_key = api_key or os.getenv("REPLICATE_API_TOKEN")
+        if not self.api_key:
+            raise ValueError("REPLICATE_API_TOKEN not set")
+        # Replicate bills per-second hardware time, not tokens, so there are no
+        # token counts to report — recorded as zeros (usage.json shows the call
+        # at $0 since there is no static token price for Replicate models).
+        self._last_usage = {"input_tokens": 0, "output_tokens": 0}
+
+    # --- internal helpers ---
+
+    def _headers(self, prefer_wait: bool = False) -> dict:
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        if prefer_wait:
+            headers["Prefer"] = "wait"
+        return headers
+
+    @staticmethod
+    def _strip_prefix(model: str) -> str:
+        return model[len(_PREFIX) :] if model.startswith(_PREFIX) else model
+
+    @staticmethod
+    def _split_model(model: str) -> tuple[str, str]:
+        owner, _, name = model.partition("/")
+        return owner, name
+
+    @staticmethod
+    def _raise_if_failed(prediction: dict) -> None:
+        status = prediction.get("status")
+        if status in ("failed", "canceled"):
+            detail = prediction.get("error") or status
+            raise RuntimeError(f"Replicate prediction {status}: {detail}")
+
+    def _poll(self, prediction: dict) -> dict:
+        """Poll GET /predictions/{id} until the prediction reaches a terminal state."""
+        status = prediction.get("status")
+        pred_id = prediction.get("id")
+        tries = 0
+        while status not in _TERMINAL and tries < _MAX_POLLS:
+            time.sleep(_POLL_INTERVAL)
+            resp = requests.get(
+                f"{_BASE_URL}/predictions/{pred_id}",
+                headers=self._headers(),
+                timeout=_TIMEOUT,
+            )
+            resp.raise_for_status()
+            prediction = resp.json()
+            status = prediction.get("status")
+            tries += 1
+        return prediction
+
+    def _predict(self, model: str, model_input: dict, poll: bool = False) -> dict:
+        """Create a prediction (blocking via Prefer: wait), optionally polling to completion."""
+        owner, name = self._split_model(model)
+        resp = requests.post(
+            f"{_BASE_URL}/models/{owner}/{name}/predictions",
+            headers=self._headers(prefer_wait=True),
+            json={"input": model_input},
+            timeout=_TIMEOUT,
+        )
+        resp.raise_for_status()
+        prediction = resp.json()
+        if poll:
+            prediction = self._poll(prediction)
+        self._raise_if_failed(prediction)
+        return prediction
+
+    # --- BaseProvider API ---
+
+    def chat(
+        self,
+        messages: list[dict],
+        max_tokens: int = 4096,
+        temperature: float = 0.7,
+        model: Optional[str] = None,
+    ) -> str:
+        model = self._strip_prefix(model or "meta/meta-llama-3-8b-instruct")
+        prompt = "\n".join(str(m.get("content", "")) for m in messages if m.get("role") != "system")
+        system_prompt = "\n".join(
+            str(m.get("content", "")) for m in messages if m.get("role") == "system"
+        )
+        model_input = {"prompt": prompt, "max_tokens": max_tokens, "temperature": temperature}
+        if system_prompt:
+            model_input["system_prompt"] = system_prompt
+        prediction = self._predict(model, model_input, poll=False)
+        self._last_usage = {"input_tokens": 0, "output_tokens": 0}
+        return _join_output(prediction.get("output"))
+
+    def analyze_image(
+        self,
+        image_bytes: bytes,
+        prompt: str,
+        max_tokens: int = 4096,
+        model: Optional[str] = None,
+    ) -> str:
+        model = self._strip_prefix(model or "yorickvp/llava-13b")
+        b64 = base64.b64encode(image_bytes).decode()
+        model_input = {"image": f"data:image/jpeg;base64,{b64}", "prompt": prompt}
+        prediction = self._predict(model, model_input, poll=False)
+        self._last_usage = {"input_tokens": 0, "output_tokens": 0}
+        return _join_output(prediction.get("output"))
+
+    def transcribe_audio(
+        self,
+        audio_path: str | Path,
+        language: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> dict:
+        model = self._strip_prefix(model or "openai/whisper")
+        audio_path = Path(audio_path)
+        mime = _MIME.get(audio_path.suffix.lower(), "application/octet-stream")
+        b64 = base64.b64encode(audio_path.read_bytes()).decode()
+        prediction = self._predict(model, {"audio": f"data:{mime};base64,{b64}"}, poll=True)
+        self._last_usage = {"input_tokens": 0, "output_tokens": 0}
+
+        output = prediction.get("output") or {}
+        if isinstance(output, str):
+            # Some ASR models return just the transcript string.
+            text, raw_segments, detected, duration = output, [], None, None
+        else:
+            text = output.get("transcription") or output.get("text") or ""
+            raw_segments = output.get("segments") or []
+            detected = output.get("detected_language") or output.get("language")
+            duration = output.get("duration")
+
+        segments = []
+        for seg in raw_segments:
+            if not isinstance(seg, dict):
+                continue
+            segments.append(
+                {
+                    "start": seg.get("start", 0.0),
+                    "end": seg.get("end", 0.0),
+                    "text": (seg.get("text") or "").strip(),
+                }
+            )
+        if duration is None and segments:
+            duration = segments[-1]["end"]
+
+        return {
+            "text": text.strip() if isinstance(text, str) else text,
+            "segments": segments,
+            "language": detected or language,
+            "duration": duration,
+            "provider": "replicate",
+            "model": model,
+        }
+
+    def list_models(self) -> list[ModelInfo]:
+        try:
+            resp = requests.get(f"{_BASE_URL}/models", headers=self._headers(), timeout=_TIMEOUT)
+            resp.raise_for_status()
+            results = resp.json().get("results", [])
+        except Exception as e:
+            logger.warning(f"Failed to list Replicate models: {e}")
+            return []
+
+        models = []
+        for m in results:
+            owner = m.get("owner", "")
+            name = m.get("name", "")
+            if not owner or not name:
+                continue
+            mid = f"{owner}/{name}"
+            models.append(
+                ModelInfo(
+                    id=mid,
+                    provider="replicate",
+                    display_name=mid,
+                    capabilities=_infer_capabilities(name, m.get("description") or ""),
+                )
+            )
+        return models
+
+
+ProviderRegistry.register(
+    name="replicate",
+    provider_class=ReplicateProvider,
+    env_var="REPLICATE_API_TOKEN",
+    model_prefixes=["replicate/"],
+    default_models={
+        "chat": "meta/meta-llama-3-8b-instruct",
+        "vision": "yorickvp/llava-13b",
+        "audio": "openai/whisper",
+    },
+)


### PR DESCRIPTION
## Summary

First slice of #148 — the Replicate backend. Raw `requests` against the predictions API (`Prefer: wait` + bounded polling), registry entry under `REPLICATE_API_TOKEN` with `replicate/` model-prefix routing, defaults: llama-3-8b (chat) / llava-13b (vision) / openai/whisper (audio). Failed predictions raise with the error detail; `_last_usage` records zero tokens deliberately — Replicate bills per-second hardware, so no static price entry (noted on the issue).

Runway and the ElevenLabs expansion remain open on #148.

## Test plan

14 boundary tests (auth header, prompt/system mapping, data-URI inputs, poll-then-succeed, failure raise, prefix strip, registry metadata); `replicate_provider.py` at 100%. Full suite 1037 passed, 0 skipped; TOTAL 68%. Ruff clean.