### PR TITLE
Coverage slice 3: CLI, sources, exchange, agent (67% -> 85%)

### DIFF
--- a/tests/test_agent_export_cli.py
+++ b/tests/test_agent_export_cli.py
@@ -1,0 +1,169 @@
+"""Tests for the artifact_export and cli_adapter agent skills.
+
+Both are pure logic (no LLM). Only shutil.which / subprocess are mocked.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from video_processor.agent.skills.artifact_export import (
+    ArtifactExportSkill,
+    _write_artifact,
+    export_artifacts,
+)
+from video_processor.agent.skills.base import AgentContext, Artifact
+from video_processor.agent.skills.cli_adapter import (
+    CLIAdapterSkill,
+    _format_github,
+    _format_jira,
+    _format_linear,
+    run_commands,
+)
+
+
+def _artifact(name, content, artifact_type, fmt="markdown"):
+    return Artifact(name=name, content=content, artifact_type=artifact_type, format=fmt)
+
+
+class TestWriteArtifact:
+    def test_known_type_maps_to_fixed_filename(self, tmp_path):
+        art = _artifact("Plan", "# Plan\nbody", "project_plan")
+        entry = _write_artifact(art, tmp_path)
+        dest = tmp_path / "project_plan.md"
+        assert dest.read_text() == "# Plan\nbody"
+        assert entry["file"] == str(dest)
+        assert entry["artifact_type"] == "project_plan"
+
+    def test_document_type_goes_to_docs_subdir(self, tmp_path):
+        art = _artifact("My Notes", "content", "document", fmt="markdown")
+        entry = _write_artifact(art, tmp_path)
+        dest = tmp_path / "docs" / "my_notes.md"
+        assert dest.exists()
+        assert entry["file"] == str(dest)
+
+    def test_document_json_uses_json_extension(self, tmp_path):
+        art = _artifact("Data Set", "{}", "document", fmt="json")
+        _write_artifact(art, tmp_path)
+        assert (tmp_path / "docs" / "data_set.json").exists()
+
+    def test_unknown_type_falls_back_to_slugged_name(self, tmp_path):
+        art = _artifact("Weird/Thing Here", "x", "mystery", fmt="markdown")
+        entry = _write_artifact(art, tmp_path)
+        dest = tmp_path / "weird_thing_here.md"
+        assert dest.exists()
+        assert entry["name"] == "Weird/Thing Here"
+
+
+class TestExportArtifacts:
+    def test_export_writes_files_and_manifest(self, tmp_path):
+        artifacts = [
+            _artifact("Plan", "# Plan", "project_plan"),
+            _artifact("Tasks", "[]", "task_list", fmt="json"),
+        ]
+        manifest = export_artifacts(artifacts, tmp_path / "out")
+        out = tmp_path / "out"
+        assert manifest["artifact_count"] == 2
+        assert (out / "project_plan.md").exists()
+        assert (out / "tasks.json").exists()
+        written = json.loads((out / "manifest.json").read_text())
+        assert written["artifact_count"] == 2
+        assert len(written["files"]) == 2
+
+
+class TestArtifactExportSkill:
+    def test_execute_returns_manifest_artifact(self, tmp_path):
+        ctx = AgentContext()
+        ctx.artifacts = [_artifact("Roadmap", "# Roadmap", "roadmap")]
+        skill = ArtifactExportSkill()
+        result = skill.execute(ctx, output_dir=str(tmp_path / "plan"))
+        assert result.artifact_type == "export_manifest"
+        assert result.format == "json"
+        parsed = json.loads(result.content)
+        assert parsed["artifact_count"] == 1
+        assert (tmp_path / "plan" / "roadmap.md").exists()
+        assert (tmp_path / "plan" / "manifest.json").exists()
+
+
+class TestFormatters:
+    def test_format_github_builds_gh_commands(self):
+        art = _artifact(
+            "Issues",
+            json.dumps([{"title": "Bug A", "body": "broken", "labels": ["bug", "p1"]}]),
+            "issues",
+            fmt="json",
+        )
+        cmds = _format_github(art)
+        assert len(cmds) == 1
+        assert cmds[0].startswith("gh issue create --title ")
+        assert '"Bug A"' in cmds[0]
+        assert "--body" in cmds[0]
+        assert cmds[0].count("--label") == 2
+
+    def test_format_github_non_json_returns_empty(self):
+        art = _artifact("Issues", "not json", "issues", fmt="markdown")
+        assert _format_github(art) == []
+
+    def test_format_jira_and_linear(self):
+        content = json.dumps([{"title": "Task", "description": "do it"}])
+        jira = _format_jira(_artifact("t", content, "issues", fmt="json"))
+        linear = _format_linear(_artifact("t", content, "issues", fmt="json"))
+        assert jira[0].startswith("jira issue create --summary ")
+        assert '"do it"' in jira[0]
+        assert linear[0].startswith("linear issue create --title ")
+        assert '"do it"' in linear[0]
+
+
+class TestRunCommands:
+    def test_dry_run_reports_without_executing(self):
+        results = run_commands(["gh issue create --title x"], dry_run=True)
+        assert results == [{"command": "gh issue create --title x", "status": "dry_run"}]
+
+    def test_real_run_captures_output(self):
+        proc = MagicMock(returncode=0, stdout="created\n", stderr="")
+        with patch(
+            "video_processor.agent.skills.cli_adapter.subprocess.run", return_value=proc
+        ) as mock_run:
+            results = run_commands(["gh issue create --title x"], dry_run=False)
+        mock_run.assert_called_once()
+        assert results[0]["returncode"] == 0
+        assert results[0]["stdout"] == "created"
+
+
+class TestCLIAdapterSkill:
+    def test_no_artifact_returns_empty(self):
+        ctx = AgentContext()
+        ctx.artifacts = []
+        result = CLIAdapterSkill().execute(ctx)
+        assert result.content == "[]"
+
+    def test_unknown_tool_returns_error(self):
+        ctx = AgentContext()
+        art = _artifact("Issues", "[]", "issues", fmt="json")
+        result = CLIAdapterSkill().execute(ctx, tool="bitbucket", artifact=art)
+        assert json.loads(result.content)["error"] == "Unknown tool: bitbucket"
+
+    def test_github_tool_reports_availability_and_commands(self):
+        ctx = AgentContext()
+        art = _artifact(
+            "Issues",
+            json.dumps([{"title": "A"}, {"title": "B"}]),
+            "issues",
+            fmt="json",
+        )
+        with patch(
+            "video_processor.agent.skills.cli_adapter.shutil.which", return_value="/usr/bin/gh"
+        ):
+            result = CLIAdapterSkill().execute(ctx, tool="github", artifact=art)
+        parsed = json.loads(result.content)
+        assert parsed["tool"] == "github"
+        assert parsed["available"] is True
+        assert len(parsed["commands"]) == 2
+
+    def test_falls_back_to_last_context_artifact_when_unavailable(self):
+        ctx = AgentContext()
+        ctx.artifacts = [_artifact("Issues", json.dumps([{"title": "A"}]), "issues", fmt="json")]
+        with patch("video_processor.agent.skills.cli_adapter.shutil.which", return_value=None):
+            result = CLIAdapterSkill().execute(ctx, tool="github")
+        parsed = json.loads(result.content)
+        assert parsed["available"] is False
+        assert len(parsed["commands"]) == 1

--- a/tests/test_anthropic_provider.py
+++ b/tests/test_anthropic_provider.py
@@ -1,0 +1,133 @@
+"""Tests for AnthropicProvider (chat, vision, transcription guard, listing).
+
+Mocks only the anthropic SDK client so the real request/response mapping runs.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_processor.providers.anthropic_provider import AnthropicProvider
+
+
+def _provider():
+    """Build a provider with a fake key and a mock client attached."""
+    with patch("anthropic.Anthropic") as mock_cls:
+        client = MagicMock()
+        mock_cls.return_value = client
+        provider = AnthropicProvider(api_key="sk-ant-test")
+    provider.client = client
+    return provider, client
+
+
+def _message_response(text, input_tokens=8, output_tokens=16):
+    resp = MagicMock()
+    block = MagicMock()
+    block.text = text
+    resp.content = [block]
+    resp.usage.input_tokens = input_tokens
+    resp.usage.output_tokens = output_tokens
+    return resp
+
+
+class TestConstruction:
+    def test_missing_key_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="ANTHROPIC_API_KEY not set"):
+                AnthropicProvider(api_key=None)
+
+    @patch("anthropic.Anthropic")
+    def test_builds_client_with_key(self, mock_cls):
+        client = MagicMock()
+        mock_cls.return_value = client
+        provider = AnthropicProvider(api_key="sk-ant-test")
+        assert provider.client is client
+        mock_cls.assert_called_once_with(api_key="sk-ant-test")
+
+
+class TestChat:
+    def test_chat_returns_text_and_usage(self):
+        provider, client = _provider()
+        client.messages.create.return_value = _message_response("hi there", 8, 20)
+
+        out = provider.chat([{"role": "user", "content": "hi"}])
+        assert out == "hi there"
+        assert provider._last_usage == {"input_tokens": 8, "output_tokens": 20}
+        kwargs = client.messages.create.call_args.kwargs
+        assert kwargs["model"] == "claude-haiku-4-5-20251001"  # default
+        assert "system" not in kwargs  # no system message supplied
+
+    def test_chat_hoists_system_messages_to_top_level(self):
+        provider, client = _provider()
+        client.messages.create.return_value = _message_response("ok")
+
+        provider.chat(
+            [
+                {"role": "system", "content": "Be terse."},
+                {"role": "system", "content": "Answer in English."},
+                {"role": "user", "content": "hi"},
+            ],
+            model="claude-sonnet-4-5-20250929",
+        )
+        kwargs = client.messages.create.call_args.kwargs
+        # system parts are joined and lifted out of the messages list
+        assert kwargs["system"] == "Be terse.\n\nAnswer in English."
+        assert kwargs["messages"] == [{"role": "user", "content": "hi"}]
+        assert kwargs["model"] == "claude-sonnet-4-5-20250929"
+
+
+class TestAnalyzeImage:
+    def test_analyze_image_builds_base64_block(self):
+        provider, client = _provider()
+        client.messages.create.return_value = _message_response("a diagram", 120, 4)
+
+        out = provider.analyze_image(b"\x89PNGdata", "describe")
+        assert out == "a diagram"
+        assert provider._last_usage["input_tokens"] == 120
+
+        content = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        image_block = [b for b in content if b["type"] == "image"][0]
+        assert image_block["source"]["type"] == "base64"
+        assert image_block["source"]["media_type"] == "image/jpeg"
+        assert image_block["source"]["data"]  # non-empty base64 payload
+        text_block = [b for b in content if b["type"] == "text"][0]
+        assert text_block["text"] == "describe"
+
+
+class TestTranscribe:
+    def test_transcribe_not_supported(self):
+        provider, _ = _provider()
+        with pytest.raises(NotImplementedError, match="does not provide"):
+            provider.transcribe_audio("/tmp/audio.wav")
+
+
+class TestListModels:
+    def _model(self, mid, display=None):
+        m = MagicMock()
+        m.id = mid
+        m.display_name = display or mid
+        return m
+
+    def test_list_models_all_have_chat_and_vision(self):
+        provider, client = _provider()
+        page = MagicMock()
+        page.data = [
+            self._model("claude-sonnet-4-5-20250929", "Claude Sonnet 4.5"),
+            self._model("claude-haiku-4-5-20251001", "Claude Haiku 4.5"),
+        ]
+        client.models.list.return_value = page
+
+        models = provider.list_models()
+        assert len(models) == 2
+        for m in models:
+            assert m.provider == "anthropic"
+            assert m.capabilities == ["chat", "vision"]
+        # sorted by id
+        assert [m.id for m in models] == sorted(m.id for m in models)
+        client.models.list.assert_called_once_with(limit=100)
+
+    def test_list_models_handles_error(self):
+        provider, client = _provider()
+        client.models.list.side_effect = RuntimeError("network down")
+        assert provider.list_models() == []

--- a/tests/test_apple_notes_source.py
+++ b/tests/test_apple_notes_source.py
@@ -1,0 +1,183 @@
+"""Tests for AppleNotesSource: osascript listing, parsing, and download.
+
+Complements the constructor / authenticate-platform / _html_to_text cases in
+tests/test_sources.py by exercising list_videos (both folder scripts and the
+error branches), _parse_note_list, and download. osascript is never actually
+invoked -- subprocess.run and sys.platform are patched so the suite is
+deterministic on any OS.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_processor.sources.base import SourceFile
+
+_DARWIN = patch("video_processor.sources.apple_notes_source.sys.platform", "darwin")
+
+
+class TestAppleNotesAuthenticate:
+    def test_authenticate_non_darwin(self):
+        from video_processor.sources.apple_notes_source import AppleNotesSource
+
+        with patch("video_processor.sources.apple_notes_source.sys.platform", "linux"):
+            assert AppleNotesSource().authenticate() is False
+
+
+class TestAppleNotesListVideos:
+    def test_list_videos_non_darwin_returns_empty(self):
+        from video_processor.sources.apple_notes_source import AppleNotesSource
+
+        with patch("video_processor.sources.apple_notes_source.sys.platform", "linux"):
+            assert AppleNotesSource().list_videos() == []
+
+    @patch("video_processor.sources.apple_notes_source.subprocess.run")
+    def test_list_videos_default_account(self, mock_run):
+        from video_processor.sources.apple_notes_source import AppleNotesSource
+
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="x-coredata://1/p1|||First Note, x-coredata://2/p2|||Second Note",
+            stderr="",
+        )
+        with _DARWIN:
+            files = AppleNotesSource().list_videos()
+
+        assert len(files) == 2
+        assert files[0].name == "First Note"
+        assert files[0].id == "x-coredata://1/p1"
+        assert files[0].mime_type == "text/plain"
+        assert files[1].name == "Second Note"
+        # The default-account script (no folder filter) was used.
+        script = mock_run.call_args[0][0][2]
+        assert "notes of default account" in script
+
+    @patch("video_processor.sources.apple_notes_source.subprocess.run")
+    def test_list_videos_with_folder(self, mock_run):
+        from video_processor.sources.apple_notes_source import AppleNotesSource
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="id1|||Note A", stderr="")
+        with _DARWIN:
+            files = AppleNotesSource(folder="Work").list_videos()
+
+        assert len(files) == 1
+        assert files[0].name == "Note A"
+        # The folder-scoped script names the requested folder.
+        script = mock_run.call_args[0][0][2]
+        assert 'name of f is "Work"' in script
+
+    @patch(
+        "video_processor.sources.apple_notes_source.subprocess.run",
+        side_effect=FileNotFoundError,
+    )
+    def test_list_videos_osascript_missing(self, _mock_run):
+        from video_processor.sources.apple_notes_source import AppleNotesSource
+
+        with _DARWIN:
+            assert AppleNotesSource().list_videos() == []
+
+    @patch(
+        "video_processor.sources.apple_notes_source.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="osascript", timeout=30),
+    )
+    def test_list_videos_timeout(self, _mock_run):
+        from video_processor.sources.apple_notes_source import AppleNotesSource
+
+        with _DARWIN:
+            assert AppleNotesSource().list_videos() == []
+
+    @patch("video_processor.sources.apple_notes_source.subprocess.run")
+    def test_list_videos_nonzero_return(self, mock_run):
+        from video_processor.sources.apple_notes_source import AppleNotesSource
+
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="permission denied")
+        with _DARWIN:
+            assert AppleNotesSource().list_videos() == []
+
+
+class TestAppleNotesParseNoteList:
+    def test_parse_basic(self):
+        from video_processor.sources.apple_notes_source import AppleNotesSource
+
+        files = AppleNotesSource()._parse_note_list("id1|||Alpha, id2|||Beta")
+
+        assert [f.id for f in files] == ["id1", "id2"]
+        assert [f.name for f in files] == ["Alpha", "Beta"]
+        assert all(f.mime_type == "text/plain" for f in files)
+
+    def test_parse_empty(self):
+        from video_processor.sources.apple_notes_source import AppleNotesSource
+
+        assert AppleNotesSource()._parse_note_list("") == []
+
+    def test_parse_skips_malformed_entries(self):
+        from video_processor.sources.apple_notes_source import AppleNotesSource
+
+        files = AppleNotesSource()._parse_note_list("garbage without separator, id9|||Valid")
+
+        assert len(files) == 1
+        assert files[0].name == "Valid"
+
+    def test_parse_skips_empty_fields(self):
+        from video_processor.sources.apple_notes_source import AppleNotesSource
+
+        # "|||NoId" has an empty id; "idNoName|||" has an empty name -> both dropped.
+        files = AppleNotesSource()._parse_note_list("|||NoId, idNoName|||")
+
+        assert files == []
+
+
+class TestAppleNotesDownload:
+    @patch("video_processor.sources.apple_notes_source.subprocess.run")
+    def test_download_writes_note(self, mock_run, tmp_path):
+        from video_processor.sources.apple_notes_source import AppleNotesSource
+
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="<div>Hello <b>World</b></div><p>Second line.</p>",
+            stderr="",
+        )
+        f = SourceFile(name="My Note", id="x-coredata://1/note1", mime_type="text/plain")
+        dest = tmp_path / "notes" / "note.txt"
+
+        result = AppleNotesSource().download(f, dest)
+
+        assert result == dest
+        content = dest.read_text()
+        assert content.startswith("# My Note")
+        assert "Hello World" in content
+        assert "Second line." in content
+        # The note id is embedded in the AppleScript body request.
+        assert "x-coredata://1/note1" in mock_run.call_args[0][0][2]
+
+    @patch(
+        "video_processor.sources.apple_notes_source.subprocess.run",
+        side_effect=FileNotFoundError,
+    )
+    def test_download_osascript_missing(self, _mock_run, tmp_path):
+        from video_processor.sources.apple_notes_source import AppleNotesSource
+
+        f = SourceFile(name="N", id="id1")
+        with pytest.raises(RuntimeError, match="osascript not found"):
+            AppleNotesSource().download(f, tmp_path / "n.txt")
+
+    @patch(
+        "video_processor.sources.apple_notes_source.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="osascript", timeout=30),
+    )
+    def test_download_timeout(self, _mock_run, tmp_path):
+        from video_processor.sources.apple_notes_source import AppleNotesSource
+
+        f = SourceFile(name="N", id="id1")
+        with pytest.raises(RuntimeError, match="timed out"):
+            AppleNotesSource().download(f, tmp_path / "n.txt")
+
+    @patch("video_processor.sources.apple_notes_source.subprocess.run")
+    def test_download_nonzero_return(self, mock_run, tmp_path):
+        from video_processor.sources.apple_notes_source import AppleNotesSource
+
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="no such note")
+        f = SourceFile(name="N", id="id1")
+        with pytest.raises(RuntimeError, match="Failed to fetch note"):
+            AppleNotesSource().download(f, tmp_path / "n.txt")

--- a/tests/test_auth_manager.py
+++ b/tests/test_auth_manager.py
@@ -1,0 +1,434 @@
+"""Branch coverage for OAuthManager grant flows (complements test_auth.py).
+
+Covers the untested paths in video_processor.auth: client-credentials grant,
+OAuth2 PKCE authorize-url construction + code exchange, refresh failure modes,
+the authenticate() fallback chain ordering, and the missing-requests guards.
+Mocks only true boundaries: requests.post, webbrowser.open, builtins.input.
+Token files are written to real tmp_path files and read back.
+"""
+
+import json
+import os
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+from video_processor.auth import AuthConfig, OAuthManager
+
+
+def _mock_resp(payload):
+    """Build a fake requests.Response whose .json() returns *payload*."""
+    resp = MagicMock()
+    resp.json.return_value = payload
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+# -----------------------------------------------------------------------
+# AuthConfig.resolved_client_secret (line 84)
+# -----------------------------------------------------------------------
+
+
+class TestResolvedClientSecret:
+    def test_from_env(self):
+        config = AuthConfig(service="test", client_secret_env="TEST_SECRET")
+        with patch.dict(os.environ, {"TEST_SECRET": "shh"}, clear=True):
+            assert config.resolved_client_secret == "shh"
+
+    def test_explicit_wins(self):
+        config = AuthConfig(
+            service="test",
+            client_secret="explicit-secret",
+            client_secret_env="TEST_SECRET",
+        )
+        assert config.resolved_client_secret == "explicit-secret"
+
+    def test_none_when_unset(self):
+        config = AuthConfig(service="test", client_secret_env="TEST_SECRET")
+        with patch.dict(os.environ, {}, clear=True):
+            assert config.resolved_client_secret is None
+
+
+# -----------------------------------------------------------------------
+# Client Credentials grant (Server-to-Server)
+# -----------------------------------------------------------------------
+
+
+class TestClientCredentials:
+    def _config(self, tmp_path):
+        return AuthConfig(
+            service="svc",
+            oauth_authorize_url="https://svc.example/authorize",
+            oauth_token_url="https://svc.example/token",
+            client_id="cid",
+            client_secret="csec",
+            account_id="acct-1",
+            token_path=tmp_path / "cc_token.json",
+        )
+
+    def test_success_via_authenticate(self, tmp_path):
+        config = self._config(tmp_path)
+        manager = OAuthManager(config)
+        resp = _mock_resp({"access_token": "cc-tok", "expires_in": 3600})
+
+        with patch("requests.post", return_value=resp) as mock_post:
+            result = manager.authenticate()
+
+        assert result.success
+        assert result.method == "client_credentials"
+        assert result.access_token == "cc-tok"
+        # expires_at is now + expires_in - 60 (a minute of safety margin)
+        assert result.expires_at > time.time()
+
+        # Real token file was written and is readable.
+        saved = json.loads((tmp_path / "cc_token.json").read_text())
+        assert saved["access_token"] == "cc-tok"
+
+        # Correct grant params + HTTP basic auth were sent.
+        _, kwargs = mock_post.call_args
+        assert kwargs["params"]["grant_type"] == "account_credentials"
+        assert kwargs["params"]["account_id"] == "acct-1"
+        assert kwargs["auth"] == ("cid", "csec")
+
+    def test_missing_secret_returns_failure(self, tmp_path):
+        config = AuthConfig(
+            service="svc",
+            oauth_authorize_url="https://svc.example/authorize",
+            oauth_token_url="https://svc.example/token",
+            client_id="cid",
+            account_id="acct-1",
+            token_path=tmp_path / "tok.json",
+        )
+        manager = OAuthManager(config)
+        with patch.dict(os.environ, {}, clear=True):
+            result = manager._try_client_credentials()
+        assert not result.success
+
+    def test_http_error_returns_failure(self, tmp_path):
+        config = self._config(tmp_path)
+        manager = OAuthManager(config)
+        resp = MagicMock()
+        resp.raise_for_status.side_effect = RuntimeError("boom 500")
+
+        with patch("requests.post", return_value=resp):
+            result = manager._try_client_credentials()
+
+        assert not result.success
+        assert not (tmp_path / "cc_token.json").exists()
+
+    def test_requests_missing_returns_failure(self, tmp_path):
+        config = self._config(tmp_path)
+        manager = OAuthManager(config)
+        with patch.dict(sys.modules, {"requests": None}):
+            result = manager._try_client_credentials()
+        assert not result.success
+        assert result.error == "requests not installed"
+
+
+# -----------------------------------------------------------------------
+# OAuth2 Authorization Code + PKCE
+# -----------------------------------------------------------------------
+
+
+class TestOAuthPKCE:
+    def _config(self, tmp_path, scopes=None):
+        return AuthConfig(
+            service="pk",
+            oauth_authorize_url="https://pk.example/authorize",
+            oauth_token_url="https://pk.example/token",
+            client_id="pk-client",
+            client_secret="pk-secret",
+            scopes=scopes if scopes is not None else ["read", "write"],
+            token_path=tmp_path / "pk_token.json",
+        )
+
+    def test_success_via_authenticate(self, tmp_path):
+        config = self._config(tmp_path)
+        manager = OAuthManager(config)
+        resp = _mock_resp({"access_token": "pk-tok", "refresh_token": "pk-ref", "expires_in": 3600})
+
+        with (
+            patch("webbrowser.open") as mock_open,
+            patch("builtins.input", return_value="the-auth-code"),
+            patch("requests.post", return_value=resp) as mock_post,
+        ):
+            result = manager.authenticate()
+
+        assert result.success
+        assert result.method == "oauth_pkce"
+        assert result.access_token == "pk-tok"
+        assert result.refresh_token == "pk-ref"
+
+        # The authorize URL opened in the browser is a well-formed PKCE request.
+        authorize_url = mock_open.call_args[0][0]
+        assert authorize_url.startswith("https://pk.example/authorize?")
+        assert "response_type=code" in authorize_url
+        assert "client_id=pk-client" in authorize_url
+        assert "code_challenge=" in authorize_url
+        assert "code_challenge_method=S256" in authorize_url
+        assert "scope=read+write" in authorize_url
+
+        # The code exchange sent the verifier and the user's code.
+        _, kwargs = mock_post.call_args
+        assert kwargs["data"]["grant_type"] == "authorization_code"
+        assert kwargs["data"]["code"] == "the-auth-code"
+        assert kwargs["data"]["code_verifier"]
+        assert kwargs["auth"] == ("pk-client", "pk-secret")
+
+        # Token persisted to a real file with the client identity recorded.
+        saved = json.loads((tmp_path / "pk_token.json").read_text())
+        assert saved["access_token"] == "pk-tok"
+        assert saved["client_id"] == "pk-client"
+
+    def test_no_scopes_omits_scope_param(self, tmp_path):
+        config = self._config(tmp_path, scopes=[])
+        manager = OAuthManager(config)
+        resp = _mock_resp({"access_token": "pk-tok", "expires_in": 3600})
+
+        with (
+            patch("webbrowser.open") as mock_open,
+            patch("builtins.input", return_value="code"),
+            patch("requests.post", return_value=resp),
+        ):
+            result = manager.authenticate()
+
+        assert result.success
+        assert "scope=" not in mock_open.call_args[0][0]
+
+    def test_webbrowser_failure_still_proceeds(self, tmp_path):
+        config = self._config(tmp_path)
+        manager = OAuthManager(config)
+        resp = _mock_resp({"access_token": "pk-tok", "expires_in": 3600})
+
+        with (
+            patch("webbrowser.open", side_effect=RuntimeError("no display")),
+            patch("builtins.input", return_value="code"),
+            patch("requests.post", return_value=resp),
+        ):
+            result = manager._try_oauth_pkce()
+
+        assert result.success
+        assert result.access_token == "pk-tok"
+
+    def test_no_client_id_returns_failure(self, tmp_path):
+        config = AuthConfig(
+            service="pk",
+            oauth_authorize_url="https://pk.example/authorize",
+            oauth_token_url="https://pk.example/token",
+            token_path=tmp_path / "tok.json",
+        )
+        manager = OAuthManager(config)
+        with patch.dict(os.environ, {}, clear=True):
+            result = manager._try_oauth_pkce()
+        assert not result.success
+
+    def test_empty_code_returns_error(self, tmp_path):
+        config = self._config(tmp_path)
+        manager = OAuthManager(config)
+        with (
+            patch("webbrowser.open"),
+            patch("builtins.input", return_value="   "),
+        ):
+            result = manager._try_oauth_pkce()
+        assert not result.success
+        assert result.error == "No auth code provided"
+
+    def test_cancelled_by_user(self, tmp_path):
+        config = self._config(tmp_path)
+        manager = OAuthManager(config)
+        with (
+            patch("webbrowser.open"),
+            patch("builtins.input", side_effect=KeyboardInterrupt),
+        ):
+            result = manager._try_oauth_pkce()
+        assert not result.success
+        assert result.error == "Auth cancelled by user"
+
+    def test_code_exchange_error(self, tmp_path):
+        config = self._config(tmp_path)
+        manager = OAuthManager(config)
+        resp = MagicMock()
+        resp.raise_for_status.side_effect = RuntimeError("bad code")
+
+        with (
+            patch("webbrowser.open"),
+            patch("builtins.input", return_value="code"),
+            patch("requests.post", return_value=resp),
+        ):
+            result = manager._try_oauth_pkce()
+
+        assert not result.success
+        assert result.error is not None
+        assert not (tmp_path / "pk_token.json").exists()
+
+    def test_requests_missing_returns_failure(self, tmp_path):
+        config = self._config(tmp_path)
+        manager = OAuthManager(config)
+        with patch.dict(sys.modules, {"requests": None}):
+            result = manager._try_oauth_pkce()
+        assert not result.success
+        assert result.error == "requests not installed"
+
+
+# -----------------------------------------------------------------------
+# Refresh-token failure modes (test_auth.py covers the success path)
+# -----------------------------------------------------------------------
+
+
+class TestRefreshFailures:
+    def test_no_refresh_token_reused_from_response(self, tmp_path):
+        """When the refresh response omits refresh_token, the old one is kept."""
+        token_file = tmp_path / "token.json"
+        token_file.write_text(
+            json.dumps(
+                {
+                    "access_token": "old",
+                    "refresh_token": "keep-me",
+                    "expires_at": time.time() - 100,
+                    "client_id": "cid",
+                    "client_secret": "csec",
+                }
+            )
+        )
+        config = AuthConfig(
+            service="svc",
+            oauth_token_url="https://svc.example/token",
+            token_path=token_file,
+        )
+        manager = OAuthManager(config)
+        resp = _mock_resp({"access_token": "fresh", "expires_in": 3600})
+
+        with patch("requests.post", return_value=resp):
+            result = manager.authenticate()
+
+        assert result.success
+        assert result.access_token == "fresh"
+        # Old refresh token carried forward and persisted.
+        assert result.refresh_token == "keep-me"
+        assert json.loads(token_file.read_text())["refresh_token"] == "keep-me"
+
+    def test_missing_client_id_aborts_refresh(self, tmp_path):
+        token_file = tmp_path / "token.json"
+        token_file.write_text(
+            json.dumps(
+                {
+                    "access_token": "old",
+                    "refresh_token": "ref",
+                    "expires_at": time.time() - 100,
+                }
+            )
+        )
+        config = AuthConfig(
+            service="svc",
+            oauth_token_url="https://svc.example/token",
+            token_path=token_file,
+        )
+        manager = OAuthManager(config)
+        with patch.dict(os.environ, {}, clear=True):
+            result = manager.authenticate()
+        assert not result.success
+
+    def test_network_error_during_refresh(self, tmp_path):
+        token_file = tmp_path / "token.json"
+        token_file.write_text(
+            json.dumps(
+                {
+                    "access_token": "old",
+                    "refresh_token": "ref",
+                    "expires_at": time.time() - 100,
+                    "client_id": "cid",
+                    "client_secret": "csec",
+                }
+            )
+        )
+        config = AuthConfig(
+            service="svc",
+            oauth_token_url="https://svc.example/token",
+            token_path=token_file,
+        )
+        manager = OAuthManager(config)
+        with patch("requests.post", side_effect=RuntimeError("network down")):
+            result = manager.authenticate()
+        assert not result.success
+
+    def test_requests_missing_during_refresh(self, tmp_path):
+        data = {
+            "access_token": "old",
+            "refresh_token": "ref",
+            "expires_at": time.time() - 100,
+            "client_id": "cid",
+        }
+        config = AuthConfig(
+            service="svc",
+            oauth_token_url="https://svc.example/token",
+            token_path=tmp_path / "token.json",
+        )
+        manager = OAuthManager(config)
+        with patch.dict(sys.modules, {"requests": None}):
+            result = manager._refresh_token(data)
+        assert not result.success
+        assert result.error == "requests not installed"
+
+
+# -----------------------------------------------------------------------
+# Saved-token load failure + authenticate() chain ordering + error hints
+# -----------------------------------------------------------------------
+
+
+class TestAuthenticateChain:
+    def test_corrupt_saved_token_falls_through(self, tmp_path):
+        token_file = tmp_path / "token.json"
+        token_file.write_text("this is not valid json {{{")
+        config = AuthConfig(
+            service="svc",
+            api_key_env="SVC_KEY",
+            token_path=token_file,
+        )
+        manager = OAuthManager(config)
+        with patch.dict(os.environ, {"SVC_KEY": "sk-fallback"}):
+            result = manager.authenticate()
+        # Corrupt token is ignored; the chain continues to the API key fallback.
+        assert result.success
+        assert result.method == "api_key"
+        assert result.access_token == "sk-fallback"
+
+    def test_client_credentials_preferred_over_pkce(self, tmp_path):
+        """account_id present -> client-credentials grant is tried before PKCE."""
+        config = AuthConfig(
+            service="svc",
+            oauth_authorize_url="https://svc.example/authorize",
+            oauth_token_url="https://svc.example/token",
+            client_id="cid",
+            client_secret="csec",
+            account_id="acct",
+            token_path=tmp_path / "token.json",
+        )
+        manager = OAuthManager(config)
+        resp = _mock_resp({"access_token": "cc", "expires_in": 3600})
+
+        # input is NOT patched: if PKCE were reached it would try to read stdin.
+        with patch("requests.post", return_value=resp):
+            result = manager.authenticate()
+
+        assert result.success
+        assert result.method == "client_credentials"
+
+    def test_error_message_lists_all_hints(self, tmp_path):
+        config = AuthConfig(
+            service="svc",
+            oauth_authorize_url="https://svc.example/authorize",
+            oauth_token_url="https://svc.example/token",
+            client_id_env="SVC_CID",
+            client_secret_env="SVC_SEC",
+            api_key_env="SVC_KEY",
+            token_path=tmp_path / "nope.json",
+        )
+        manager = OAuthManager(config)
+        with patch.dict(os.environ, {}, clear=True):
+            result = manager.authenticate()
+
+        assert not result.success
+        assert "SVC_CID" in result.error
+        assert "SVC_SEC" in result.error
+        assert "SVC_KEY" in result.error
+        assert "OAuth" in result.error

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,446 @@
+"""Tests for CLI query and kg commands, list-models, clear-cache, and auth.
+
+These exercise real command paths against real on-disk graph fixtures
+(SQLiteStore / JSON) built the same way the app builds them. Only the LLM
+provider, model discovery, network auth, and cache boundaries are mocked.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from video_processor.cli.commands import _parse_filter_args, _print_result, cli
+from video_processor.integrators.graph_query import QueryResult
+from video_processor.integrators.graph_store import InMemoryStore, SQLiteStore
+from video_processor.integrators.knowledge_graph import KnowledgeGraph
+from video_processor.providers.base import ModelInfo
+
+
+def _populate(store):
+    store.merge_entity("Alice", "person", ["A software engineer"])
+    store.merge_entity("Bob", "person", ["A product manager"])
+    store.merge_entity("Python", "technology", ["A programming language"])
+    store.merge_entity("Django", "technology", ["A web framework"])
+    store.add_occurrence("Alice", "transcript_0", timestamp=1.0, text="Alice uses Python")
+    store.add_relationship("Alice", "Python", "uses", content_source="transcript_0", timestamp=1.0)
+    store.add_relationship("Alice", "Bob", "works_with")
+    store.add_relationship("Django", "Python", "built_on")
+
+
+def _build_db(path: Path) -> Path:
+    store = SQLiteStore(path)
+    _populate(store)
+    store.close()
+    return path
+
+
+def _build_json(path: Path) -> Path:
+    store = InMemoryStore()
+    _populate(store)
+    KnowledgeGraph(store=store).save(path)
+    return path
+
+
+class TestQueryCommand:
+    def test_no_graph_found_errors(self):
+        runner = CliRunner()
+        with patch(
+            "video_processor.integrators.graph_discovery.find_nearest_graph",
+            return_value=None,
+        ):
+            result = runner.invoke(cli, ["query", "--mode", "direct"])
+        assert result.exit_code == 1
+        assert "No knowledge graph found" in result.output
+
+    def test_db_path_missing_errors(self):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["query", "--db-path", "/nope/missing.db", "--mode", "direct", "stats"]
+        )
+        assert result.exit_code == 1
+        assert "file not found" in result.output
+
+    def test_stats_default_question_auto_mode(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        # No question -> defaults to "stats"; default (auto) mode builds a provider
+        # manager but never invokes it for the direct "stats" command.
+        result = runner.invoke(cli, ["query", "--db-path", str(db)])
+        assert result.exit_code == 0
+        assert "entity_count" in result.output
+        assert "relationship_count" in result.output
+
+    def test_entities_filtered_by_type(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["query", "--db-path", str(db), "--mode", "direct", "entities --type technology"],
+        )
+        assert result.exit_code == 0
+        assert "Python" in result.output
+        assert "Django" in result.output
+        assert "Alice" not in result.output
+
+    def test_entities_filtered_by_name(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["query", "--db-path", str(db), "--mode", "direct", "entities --name Alice"]
+        )
+        assert result.exit_code == 0
+        assert "Alice" in result.output
+
+    def test_neighbors(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["query", "--db-path", str(db), "--mode", "direct", "neighbors Alice"]
+        )
+        assert result.exit_code == 0
+        assert "Python" in result.output
+
+    def test_relationships_by_source(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["query", "--db-path", str(db), "--mode", "direct", "relationships --source Alice"],
+        )
+        assert result.exit_code == 0
+        assert "uses" in result.output or "works_with" in result.output
+
+    def test_sources_and_provenance(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        r1 = runner.invoke(cli, ["query", "--db-path", str(db), "--mode", "direct", "sources"])
+        r2 = runner.invoke(
+            cli, ["query", "--db-path", str(db), "--mode", "direct", "provenance Alice"]
+        )
+        assert r1.exit_code == 0
+        assert r2.exit_code == 0
+
+    def test_path_and_clusters(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        r1 = runner.invoke(
+            cli, ["query", "--db-path", str(db), "--mode", "direct", "path Alice Python"]
+        )
+        r2 = runner.invoke(cli, ["query", "--db-path", str(db), "--mode", "direct", "clusters"])
+        assert r1.exit_code == 0
+        assert r2.exit_code == 0
+
+    def test_format_json(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["query", "--db-path", str(db), "--mode", "direct", "--format", "json", "stats"]
+        )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert parsed["query_type"]
+
+    def test_format_mermaid(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "query",
+                "--db-path",
+                str(db),
+                "--mode",
+                "direct",
+                "--format",
+                "mermaid",
+                "neighbors Alice",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "graph LR" in result.output
+
+    def test_query_from_json_graph(self, tmp_path):
+        graph = _build_json(tmp_path / "kg.json")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["query", "--db-path", str(graph), "--mode", "direct", "stats"])
+        assert result.exit_code == 0
+        assert "entity_count" in result.output
+
+    def test_direct_mode_nl_falls_back_to_entity_search(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        # A non-command question in direct mode searches entities by name.
+        result = runner.invoke(cli, ["query", "--db-path", str(db), "--mode", "direct", "Alice"])
+        assert result.exit_code == 0
+        assert "Alice" in result.output
+
+    def test_interactive_repl(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["query", "--db-path", str(db), "--mode", "direct", "-I"],
+            input="stats\nquit\n",
+        )
+        assert result.exit_code == 0
+        assert "REPL" in result.output
+        assert "entity_count" in result.output
+        assert "Bye" in result.output
+
+
+class TestQueryHelpers:
+    def test_parse_filter_args_key_values(self):
+        assert _parse_filter_args(["--type", "technology", "--limit", "10"]) == {
+            "type": "technology",
+            "limit": "10",
+        }
+
+    def test_parse_filter_args_bare_name(self):
+        assert _parse_filter_args(["Alice"]) == {"name": "Alice"}
+
+    def test_parse_filter_args_mixed(self):
+        assert _parse_filter_args(["Alice", "--type", "person"]) == {
+            "name": "Alice",
+            "type": "person",
+        }
+
+    def test_parse_filter_args_dangling_flag_treated_as_name(self):
+        # A trailing "--flag" with no following value falls through to the name branch.
+        assert _parse_filter_args(["--type"]) == {"name": "--type"}
+
+    def test_print_result_json(self, capsys):
+        _print_result(QueryResult(data={"a": 1}, query_type="filter"), "json")
+        assert json.loads(capsys.readouterr().out)["query_type"] == "filter"
+
+    def test_print_result_mermaid(self, capsys):
+        data = [{"name": "A", "type": "person"}, {"name": "B", "type": "person"}]
+        _print_result(QueryResult(data=data, query_type="filter"), "mermaid")
+        assert "graph LR" in capsys.readouterr().out
+
+    def test_print_result_text(self, capsys):
+        _print_result(QueryResult(data={"entity_count": 4}, query_type="filter"), "text")
+        assert "entity_count: 4" in capsys.readouterr().out
+
+
+class TestKgConvert:
+    def test_db_to_json(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        dest = tmp_path / "out.json"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["kg", "convert", str(db), str(dest)])
+        assert result.exit_code == 0
+        assert "Converted" in result.output
+        assert dest.exists()
+        data = json.loads(dest.read_text())
+        assert any(n.get("name") == "Python" for n in data.get("nodes", []))
+
+    def test_json_to_db(self, tmp_path):
+        graph = _build_json(tmp_path / "kg.json")
+        dest = tmp_path / "out.db"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["kg", "convert", str(graph), str(dest)])
+        assert result.exit_code == 0
+        assert dest.exists()
+        # Confirm the round-tripped db is readable and populated.
+        store = SQLiteStore(dest)
+        assert store.get_entity_count() == 4
+        store.close()
+
+    def test_same_format_errors(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["kg", "convert", str(db), str(tmp_path / "other.db")])
+        assert result.exit_code == 1
+        assert "same format" in result.output
+
+    def test_unsupported_source_format_errors(self, tmp_path):
+        bad = tmp_path / "graph.txt"
+        bad.write_text("not a graph")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["kg", "convert", str(bad), str(tmp_path / "out.json")])
+        assert result.exit_code == 1
+        assert "Unsupported source format" in result.output
+
+
+class TestKgSync:
+    def test_db_to_json(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        out = tmp_path / "kg.json"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["kg", "sync", str(db), str(out), "--direction", "db-to-json"])
+        assert result.exit_code == 0
+        assert "Synced" in result.output
+        assert out.exists()
+
+    def test_json_to_db(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        graph = _build_json(tmp_path / "src.json")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["kg", "sync", str(db), str(graph), "--direction", "json-to-db"]
+        )
+        assert result.exit_code == 0
+        assert "Synced" in result.output
+
+    def test_auto_direction_defaults_json_path(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        # No json arg + auto: json sibling doesn't exist yet -> db-to-json.
+        result = runner.invoke(cli, ["kg", "sync", str(db)])
+        assert result.exit_code == 0
+        assert (tmp_path / "kg.json").exists()
+
+
+class TestKgInspect:
+    def test_inspect_db(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["kg", "inspect", str(db)])
+        assert result.exit_code == 0
+        assert "Entities:" in result.output
+        assert "Relationships:" in result.output
+        assert "Entity types:" in result.output
+
+
+class TestKgClassify:
+    def test_classify_heuristic_text(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        # provider=none skips the LLM entirely (heuristic-only classification).
+        result = runner.invoke(cli, ["kg", "classify", str(db), "--provider", "none"])
+        assert result.exit_code == 0
+
+    def test_classify_heuristic_json(self, tmp_path):
+        db = _build_db(tmp_path / "kg.db")
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["kg", "classify", str(db), "--provider", "none", "--format", "json"]
+        )
+        assert result.exit_code == 0
+        assert isinstance(json.loads(result.output), list)
+
+
+class TestKgFromExchange:
+    def test_from_exchange_imports_db(self, tmp_path):
+        from video_processor.exchange import PlanOpticonExchange, ProjectMeta
+        from video_processor.models import Entity, Relationship
+
+        ex = PlanOpticonExchange(
+            project=ProjectMeta(name="Demo"),
+            entities=[
+                Entity(name="Python", type="technology", descriptions=["A language"]),
+                Entity(name="Alice", type="person", descriptions=["Engineer"]),
+            ],
+            relationships=[Relationship(source="Alice", target="Python", type="uses")],
+        )
+        ex_path = tmp_path / "exchange.json"
+        ex.to_file(ex_path)
+
+        out_db = tmp_path / "imported.db"
+        runner = CliRunner()
+        result = runner.invoke(cli, ["kg", "from-exchange", str(ex_path), "-o", str(out_db)])
+        assert result.exit_code == 0
+        assert "Imported exchange" in result.output
+        assert out_db.exists()
+        store = SQLiteStore(out_db)
+        assert store.get_entity_count() == 2
+        store.close()
+
+
+class TestListModels:
+    def test_no_models_discovered(self):
+        runner = CliRunner()
+        with patch(
+            "video_processor.providers.discovery.discover_available_models", return_value=[]
+        ):
+            result = runner.invoke(cli, ["list-models"])
+        assert result.exit_code == 0
+        assert "No models discovered" in result.output
+
+    def test_lists_models_grouped_by_provider(self):
+        models = [
+            ModelInfo(id="gpt-4o", provider="openai", capabilities=["chat", "vision"]),
+            ModelInfo(id="claude-haiku", provider="anthropic", capabilities=["chat"]),
+        ]
+        runner = CliRunner()
+        with patch(
+            "video_processor.providers.discovery.discover_available_models", return_value=models
+        ):
+            result = runner.invoke(cli, ["list-models"])
+        assert result.exit_code == 0
+        assert "OPENAI" in result.output
+        assert "ANTHROPIC" in result.output
+        assert "gpt-4o" in result.output
+        assert "Total: 2 models across 2 providers" in result.output
+
+
+class TestClearCache:
+    def test_no_cache_dir_errors(self):
+        runner = CliRunner()
+        with patch.dict("os.environ", {}, clear=True):
+            result = runner.invoke(cli, ["clear-cache"])
+        assert result.exit_code == 1
+
+    def test_nonexistent_cache_dir_returns(self, tmp_path):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["clear-cache", "--cache-dir", str(tmp_path / "nope")])
+        assert result.exit_code == 0
+
+    def test_empty_cache_dir_no_namespaces(self, tmp_path):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir()
+        runner = CliRunner()
+        result = runner.invoke(cli, ["clear-cache", "--cache-dir", str(cache_dir)])
+        assert result.exit_code == 0
+
+    def test_clears_all_entries(self, tmp_path):
+        from video_processor.utils.api_cache import ApiCache
+
+        cache_dir = tmp_path / "cache"
+        cache = ApiCache(cache_dir, "openai")
+        cache.set("prompt-1", {"response": "hi"})
+        entry = cache.get_cache_path("prompt-1")
+        assert entry.exists()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["clear-cache", "--cache-dir", str(cache_dir), "--all"])
+        assert result.exit_code == 0
+        assert not entry.exists()
+
+
+class TestAuthCommand:
+    def test_unknown_service_manager_none(self):
+        runner = CliRunner()
+        with patch("video_processor.auth.get_auth_manager", return_value=None):
+            result = runner.invoke(cli, ["auth", "google"])
+        assert result.exit_code == 1
+        assert "Unknown service" in result.output
+
+    def test_logout_clears_token(self):
+        manager = MagicMock()
+        runner = CliRunner()
+        with patch("video_processor.auth.get_auth_manager", return_value=manager):
+            result = runner.invoke(cli, ["auth", "github", "--logout"])
+        assert result.exit_code == 0
+        manager.clear_token.assert_called_once()
+        assert "Cleared saved github token" in result.output
+
+    def test_authenticate_success(self):
+        manager = MagicMock()
+        manager.authenticate.return_value = MagicMock(success=True, method="oauth")
+        runner = CliRunner()
+        with patch("video_processor.auth.get_auth_manager", return_value=manager):
+            result = runner.invoke(cli, ["auth", "zoom"])
+        assert result.exit_code == 0
+        assert "Zoom authentication successful (oauth)" in result.output
+
+    def test_authenticate_failure(self):
+        manager = MagicMock()
+        manager.authenticate.return_value = MagicMock(success=False, error="bad creds")
+        runner = CliRunner()
+        with patch("video_processor.auth.get_auth_manager", return_value=manager):
+            result = runner.invoke(cli, ["auth", "notion"])
+        assert result.exit_code == 1
+        assert "authentication failed: bad creds" in result.output

--- a/tests/test_cli_ux.py
+++ b/tests/test_cli_ux.py
@@ -108,14 +108,24 @@ class TestInitWizard:
         assert "setup wizard" in result.output.lower() or "wizard" in result.output.lower()
 
     def test_wizard_provider_selection(self):
-        """Test the wizard runs with simulated input."""
+        """Test the wizard runs with simulated input.
+
+        Hermeticity: the canned input assumes a first-run environment with no
+        provider configured, so we (1) clear os.environ — otherwise an ambient
+        OPENAI_API_KEY (which any provider import pulls in via load_dotenv from a
+        developer .env) flips the wizard to an "Update it?" prompt the input can't
+        answer — and (2) use isolated_filesystem so the wizard writes .env into a
+        throwaway cwd instead of the repo root (a leftover .env there would add an
+        "Append new keys?" prompt). Either leak causes stdin EOF -> Abort (exit 1).
+        """
         runner = CliRunner()
-        # Select provider 1 (OpenAI), enter a key, decline additional providers
-        result = runner.invoke(
-            cli,
-            ["init"],
-            input="1\nsk-test-key-1234567890\nn\n",
-        )
+        with patch.dict(os.environ, {}, clear=True), runner.isolated_filesystem():
+            # Select provider 1 (OpenAI), enter a key, decline additional providers
+            result = runner.invoke(
+                cli,
+                ["init"],
+                input="1\nsk-test-key-1234567890\nn\n",
+            )
         assert result.exit_code == 0
         assert "Setup complete" in result.output
 

--- a/tests/test_companion_repl.py
+++ b/tests/test_companion_repl.py
@@ -1,0 +1,616 @@
+"""Branch coverage for CompanionREPL (complements test_companion.py + test_cli_ux.py).
+
+Drives the REPL against a REAL SQLiteStore knowledge graph (never a mock DB) for
+the KG-backed commands, exercises workspace discovery on real tmp files, and mocks
+only true boundaries: the ProviderManager/LLM, the auth stack's HTTP, and readline.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_processor.agent.skills.base import Artifact
+from video_processor.cli.companion import CompanionREPL
+from video_processor.integrators.graph_store import SQLiteStore
+
+
+def _make_graph_db(path: Path) -> Path:
+    """Create a populated real SQLite knowledge graph at *path* and return it."""
+    store = SQLiteStore(path)
+    store.merge_entity("Python", "technology", ["A programming language"])
+    store.merge_entity("Django", "technology", ["A web framework"])
+    store.merge_entity("Alice", "person", ["Software engineer"])
+    store.merge_entity("Bob", "person", ["Product manager"])
+    store.merge_entity("Acme Corp", "organization", ["A tech company"])
+    store.add_relationship("Alice", "Python", "uses")
+    store.add_relationship("Alice", "Bob", "works_with")
+    store.add_relationship("Django", "Python", "built_on")
+    store.add_relationship("Alice", "Acme Corp", "employed_by")
+    store.add_occurrence("Alice", "transcript_0", timestamp=1.0, text="Alice spoke")
+    store.close()
+    return path
+
+
+def _repl_with_graph(tmp_path: Path) -> CompanionREPL:
+    """Build a REPL with a real graph loaded (no LLM, no cwd scan)."""
+    db = _make_graph_db(tmp_path / "knowledge_graph.db")
+    repl = CompanionREPL(kb_paths=[str(db)])
+    repl._kg_path = db
+    repl._load_kg(db)
+    return repl
+
+
+def _close_kg(repl: CompanionREPL) -> None:
+    """Close a real SQLite connection held open by a loaded REPL, if any."""
+    if repl.kg is not None and hasattr(repl.kg, "close"):
+        repl.kg.close()
+
+
+@pytest.fixture
+def graph_repl(tmp_path):
+    """A REPL with a real SQLite graph loaded; connection closed on teardown."""
+    repl = _repl_with_graph(tmp_path)
+    yield repl
+    _close_kg(repl)
+
+
+# -----------------------------------------------------------------------
+# Workspace discovery + KG loading
+# -----------------------------------------------------------------------
+
+
+class TestDiscovery:
+    def test_discover_explicit_db_and_media(self, tmp_path, monkeypatch):
+        db = _make_graph_db(tmp_path / "knowledge_graph.db")
+        (tmp_path / "clip.mp4").write_bytes(b"fake video")
+        (tmp_path / "notes.md").write_text("# notes")
+        monkeypatch.chdir(tmp_path)
+
+        repl = CompanionREPL(kb_paths=[str(db)])
+        repl._discover()
+
+        assert repl._kg_path == db
+        assert repl.query_engine is not None
+        assert repl.kg is not None
+        assert any(p.name == "clip.mp4" for p in repl._videos)
+        assert any(p.name == "notes.md" for p in repl._docs)
+        _close_kg(repl)
+
+    def test_discover_json_graph(self, tmp_path, monkeypatch):
+        data = {
+            "nodes": [
+                {"name": "Python", "type": "technology", "descriptions": ["lang"]},
+                {"name": "Alice", "type": "person", "descriptions": ["eng"]},
+            ],
+            "relationships": [{"source": "Alice", "target": "Python", "type": "uses"}],
+        }
+        jf = tmp_path / "knowledge_graph.json"
+        jf.write_text(json.dumps(data))
+        monkeypatch.chdir(tmp_path)
+
+        repl = CompanionREPL(kb_paths=[str(jf)])
+        repl._discover()
+
+        assert repl.query_engine is not None
+        assert repl.query_engine.stats().data["entity_count"] == 2
+
+    def test_discover_swallows_permission_error(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        def _boom(self):
+            raise PermissionError("denied")
+
+        with (
+            patch(
+                "video_processor.integrators.graph_discovery.find_nearest_graph",
+                return_value=None,
+            ),
+            patch.object(Path, "iterdir", _boom),
+        ):
+            repl = CompanionREPL()
+            repl._discover()  # must not raise
+
+        assert repl._videos == []
+        assert repl._docs == []
+
+    def test_load_kg_handles_bad_file(self, tmp_path):
+        bad = tmp_path / "knowledge_graph.json"
+        bad.write_text("not valid json {{{")
+        repl = CompanionREPL(kb_paths=[str(bad)])
+        repl._kg_path = bad
+        repl._load_kg(bad)
+        # Parse failure is swallowed; nothing gets loaded.
+        assert repl.query_engine is None
+        assert repl.kg is None
+
+
+# -----------------------------------------------------------------------
+# Welcome banner
+# -----------------------------------------------------------------------
+
+
+class TestWelcomeBanner:
+    def test_banner_no_kg(self):
+        banner = CompanionREPL()._welcome_banner()
+        assert "PlanOpticon Companion" in banner
+        assert "No knowledge graph loaded." in banner
+        assert "LLM provider: none" in banner
+        assert "/help" in banner
+
+    def test_banner_with_kg(self, graph_repl):
+        banner = graph_repl._welcome_banner()
+        assert "Knowledge graph: knowledge_graph.db" in banner
+        assert "5 entities" in banner
+        assert "4 relationships" in banner
+
+    def test_banner_truncates_videos_and_lists_docs(self):
+        repl = CompanionREPL()
+        repl._videos = [Path(f"v{i}.mp4") for i in range(5)]
+        repl._docs = [Path("a.md"), Path("b.md")]
+        banner = repl._welcome_banner()
+        assert "Videos: v0.mp4, v1.mp4, v2.mp4 (+2 more)" in banner
+        assert "Docs: a.md, b.md" in banner
+
+    def test_banner_with_provider(self):
+        repl = CompanionREPL(chat_model="gpt-4o")
+        repl.provider_manager = MagicMock()
+        repl.provider_manager.provider = "openai"
+        banner = repl._welcome_banner()
+        assert "LLM provider: openai (model: gpt-4o)" in banner
+
+
+# -----------------------------------------------------------------------
+# KG-backed slash commands (real graph engine)
+# -----------------------------------------------------------------------
+
+
+class TestStatusWithKG:
+    def test_status_reports_counts_and_types(self, graph_repl):
+        out = graph_repl.handle_input("/status")
+        assert "KG:" in out
+        assert "5 entities" in out
+        assert "4 relationships" in out
+        assert "technology: 2" in out
+        assert "person: 2" in out
+
+
+class TestEntitiesWithKG:
+    def test_entities_all(self, graph_repl):
+        out = graph_repl.handle_input("/entities")
+        assert "Python" in out
+        assert "Alice" in out
+
+    def test_entities_filter_person(self, graph_repl):
+        out = graph_repl.handle_input("/entities --type person")
+        assert "Alice" in out
+        assert "Bob" in out
+        assert "Python" not in out
+
+    def test_entities_filter_technology(self, graph_repl):
+        out = graph_repl.handle_input("/entities --type technology")
+        assert "Python" in out
+        assert "Django" in out
+        assert "Alice" not in out
+
+
+class TestSearchWithKG:
+    def test_search_match(self, graph_repl):
+        out = graph_repl.handle_input("/search python")
+        assert "Python" in out
+
+    def test_search_empty_term(self, graph_repl):
+        out = graph_repl.handle_input("/search")
+        assert out == "Usage: /search TERM"
+
+    def test_search_no_results(self, graph_repl):
+        out = graph_repl.handle_input("/search zzznomatch")
+        assert "No results found" in out
+
+
+class TestNeighborsWithKG:
+    def test_neighbors_match(self, graph_repl):
+        out = graph_repl.handle_input("/neighbors Alice")
+        assert "Alice" in out
+        assert "Python" in out
+
+    def test_neighbors_empty(self, graph_repl):
+        out = graph_repl.handle_input("/neighbors")
+        assert out == "Usage: /neighbors ENTITY"
+
+    def test_neighbors_not_found(self, graph_repl):
+        out = graph_repl.handle_input("/neighbors Ghost")
+        assert "not found" in out
+
+
+class TestExport:
+    def test_export_empty(self):
+        out = CompanionREPL().handle_input("/export")
+        assert out.startswith("Usage: /export FORMAT")
+
+    def test_export_no_kg(self):
+        out = CompanionREPL().handle_input("/export markdown")
+        assert out == "No knowledge graph loaded."
+
+    def test_export_success(self, graph_repl):
+        out = graph_repl.handle_input("/export markdown")
+        assert "Export 'markdown' requested" in out
+        assert "planopticon export markdown" in out
+
+
+# -----------------------------------------------------------------------
+# analyze / ingest (real filesystem checks)
+# -----------------------------------------------------------------------
+
+
+class TestAnalyzeIngest:
+    def test_analyze_empty(self):
+        assert CompanionREPL().handle_input("/analyze") == "Usage: /analyze PATH"
+
+    def test_ingest_empty(self):
+        assert CompanionREPL().handle_input("/ingest") == "Usage: /ingest PATH"
+
+    def test_analyze_not_found(self):
+        out = CompanionREPL().handle_input("/analyze /no/such/file.mp4")
+        assert "File not found" in out
+
+    def test_analyze_success(self, tmp_path):
+        f = tmp_path / "vid.mp4"
+        f.write_bytes(b"x")
+        out = CompanionREPL().handle_input(f"/analyze {f}")
+        assert "Analyze requested for vid.mp4" in out
+
+    def test_ingest_not_found(self):
+        out = CompanionREPL().handle_input("/ingest /no/such/doc.md")
+        assert "File not found" in out
+
+    def test_ingest_success(self, tmp_path):
+        f = tmp_path / "doc.md"
+        f.write_text("hello")
+        out = CompanionREPL().handle_input(f"/ingest {f}")
+        assert "Ingest requested for doc.md" in out
+
+
+# -----------------------------------------------------------------------
+# /run skill dispatch (skill registry mocked; DB never mocked)
+# -----------------------------------------------------------------------
+
+
+class TestRunSkill:
+    def test_run_empty(self):
+        assert CompanionREPL().handle_input("/run") == "Usage: /run SKILL_NAME"
+
+    def test_unknown_skill(self):
+        out = CompanionREPL().handle_input("/run definitely_not_a_skill_xyz")
+        assert "Unknown skill" in out
+
+    def test_plan_prd_tasks_dispatch_to_named_skills(self):
+        # /plan, /prd, /tasks are shortcuts for specific skill names.
+        with patch(
+            "video_processor.agent.skills.base.get_skill",
+            return_value=None,
+        ):
+            repl = CompanionREPL()
+            assert repl.handle_input("/plan") == "Unknown skill: project_plan"
+            assert repl.handle_input("/prd") == "Unknown skill: prd"
+            assert repl.handle_input("/tasks") == "Unknown skill: task_breakdown"
+
+    def test_no_agent(self):
+        repl = CompanionREPL()
+        repl.agent = None
+        with patch(
+            "video_processor.agent.skills.base.get_skill",
+            return_value=MagicMock(),
+        ):
+            out = repl.handle_input("/run whatever")
+        assert "Agent not initialised" in out
+
+    def test_cannot_execute(self):
+        repl = CompanionREPL()
+        repl.agent = MagicMock()
+        skill = MagicMock()
+        skill.can_execute.return_value = False
+        with patch(
+            "video_processor.agent.skills.base.get_skill",
+            return_value=skill,
+        ):
+            out = repl.handle_input("/run roadmap")
+        assert "cannot execute" in out
+
+    def test_success_returns_artifact(self):
+        repl = CompanionREPL()
+        repl.agent = MagicMock()
+        skill = MagicMock()
+        skill.can_execute.return_value = True
+        skill.execute.return_value = Artifact(
+            name="Roadmap",
+            content="# Roadmap\n- item one",
+            artifact_type="roadmap",
+        )
+        with patch(
+            "video_processor.agent.skills.base.get_skill",
+            return_value=skill,
+        ):
+            out = repl.handle_input("/run roadmap")
+        assert "Roadmap" in out
+        assert "roadmap" in out
+        assert "# Roadmap" in out
+        skill.execute.assert_called_once_with(repl.agent.context)
+
+    def test_execution_error(self):
+        repl = CompanionREPL()
+        repl.agent = MagicMock()
+        skill = MagicMock()
+        skill.can_execute.return_value = True
+        skill.execute.side_effect = RuntimeError("boom")
+        with patch(
+            "video_processor.agent.skills.base.get_skill",
+            return_value=skill,
+        ):
+            out = repl.handle_input("/run roadmap")
+        assert "Skill execution failed: boom" in out
+
+
+# -----------------------------------------------------------------------
+# /auth (real auth stack; only env + token dir controlled)
+# -----------------------------------------------------------------------
+
+
+class TestAuthCommand:
+    def test_empty_lists_services(self):
+        out = CompanionREPL().handle_input("/auth")
+        assert "Usage: /auth SERVICE" in out
+        assert "zoom" in out
+        assert "notion" in out
+
+    def test_unknown_service(self):
+        out = CompanionREPL().handle_input("/auth notreal")
+        assert "Unknown service: notreal" in out
+
+    def test_success_via_api_key(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("video_processor.auth.TOKEN_DIR", tmp_path)
+        with patch.dict(os.environ, {"NOTION_API_KEY": "secret-notion"}, clear=True):
+            out = CompanionREPL().handle_input("/auth notion")
+        assert out == "Notion authenticated (api_key)"
+
+    def test_failure_when_no_credentials(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("video_processor.auth.TOKEN_DIR", tmp_path)
+        with patch.dict(os.environ, {}, clear=True):
+            out = CompanionREPL().handle_input("/auth zoom")
+        assert "Zoom auth failed" in out
+
+
+# -----------------------------------------------------------------------
+# provider / model switching (ProviderManager mocked)
+# -----------------------------------------------------------------------
+
+
+class TestProviderModelSwitch:
+    def test_provider_switch_success(self):
+        with patch("video_processor.providers.manager.ProviderManager"):
+            repl = CompanionREPL()
+            out = repl.handle_input("/provider openai")
+        assert out == "Switched to provider: openai"
+        assert repl._provider_name == "openai"
+        assert repl._chat_model is None
+        assert repl.provider_manager is not None
+
+    def test_provider_switch_failure(self):
+        with patch(
+            "video_processor.providers.manager.ProviderManager",
+            side_effect=RuntimeError("no key"),
+        ):
+            out = CompanionREPL().handle_input("/provider bogus")
+        assert out == "Failed to initialise provider: bogus"
+
+    def test_model_switch_success(self):
+        with patch("video_processor.providers.manager.ProviderManager"):
+            repl = CompanionREPL()
+            out = repl.handle_input("/model gpt-4o")
+        assert out == "Switched to model: gpt-4o"
+        assert repl._chat_model == "gpt-4o"
+
+    def test_model_switch_failure(self):
+        with patch(
+            "video_processor.providers.manager.ProviderManager",
+            side_effect=RuntimeError("no key"),
+        ):
+            out = CompanionREPL().handle_input("/model bogus-model")
+        assert out == "Failed to initialise with model: bogus-model"
+
+    def test_provider_list_marks_active(self):
+        repl = CompanionREPL()
+        repl.provider_manager = MagicMock()
+        repl.provider_manager.provider = "anthropic"
+        out = repl.handle_input("/provider")
+        assert "(active)" in out
+        assert "Current: anthropic" in out
+
+
+# -----------------------------------------------------------------------
+# chat with an initialised agent (LLM mocked)
+# -----------------------------------------------------------------------
+
+
+class TestChatWithAgent:
+    def test_chat_success(self):
+        repl = CompanionREPL()
+        repl.provider_manager = MagicMock()
+        repl.agent = MagicMock()
+        repl.agent.chat.return_value = "The answer is 42."
+        out = repl.handle_input("what is the answer?")
+        assert out == "The answer is 42."
+        repl.agent.chat.assert_called_once_with("what is the answer?")
+
+    def test_chat_error(self):
+        repl = CompanionREPL()
+        repl.provider_manager = MagicMock()
+        repl.agent = MagicMock()
+        repl.agent.chat.side_effect = RuntimeError("kaboom")
+        out = repl.handle_input("hi")
+        assert "Chat error: kaboom" in out
+
+
+# -----------------------------------------------------------------------
+# provider/agent init edge cases + misc dispatch
+# -----------------------------------------------------------------------
+
+
+class TestInitAndDispatch:
+    def test_init_provider_auto_maps_to_none(self):
+        with patch("video_processor.providers.manager.ProviderManager") as mock_pm:
+            repl = CompanionREPL()  # provider defaults to "auto"
+            repl._init_provider()
+        assert repl.provider_manager is mock_pm.return_value
+        assert mock_pm.call_args.kwargs["provider"] is None
+
+    def test_init_provider_failure(self):
+        with patch(
+            "video_processor.providers.manager.ProviderManager",
+            side_effect=RuntimeError("nope"),
+        ):
+            repl = CompanionREPL(provider="openai")
+            repl._init_provider()
+        assert repl.provider_manager is None
+
+    def test_init_agent_failure(self):
+        with patch(
+            "video_processor.agent.agent_loop.PlanningAgent",
+            side_effect=RuntimeError("nope"),
+        ):
+            repl = CompanionREPL()
+            repl._init_agent()
+        assert repl.agent is None
+
+    def test_empty_line_returns_empty(self):
+        repl = CompanionREPL()
+        assert repl.handle_input("") == ""
+        assert repl.handle_input("   ") == ""
+
+    def test_skills_none_registered(self):
+        with patch(
+            "video_processor.agent.skills.base.list_skills",
+            return_value=[],
+        ):
+            out = CompanionREPL().handle_input("/skills")
+        assert out == "No skills registered."
+
+
+# -----------------------------------------------------------------------
+# readline setup / history (readline is a boundary; home redirected to tmp)
+# -----------------------------------------------------------------------
+
+
+class TestReadline:
+    def test_setup_readline_missing_module(self):
+        repl = CompanionREPL()
+        with patch.dict(sys.modules, {"readline": None}):
+            repl._setup_readline()  # import readline -> ImportError -> early return
+        assert not hasattr(repl, "_history_path")
+
+    def test_completer_matches_commands(self, tmp_path, monkeypatch):
+        import readline
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        previous = readline.get_completer()
+        try:
+            repl = CompanionREPL()
+            repl._setup_readline()
+            completer = readline.get_completer()
+            assert completer("/he", 0) == "/help"
+            assert completer("he", 0) == "help"  # leading slash stripped
+            assert completer("/zzz", 0) is None
+        finally:
+            readline.set_completer(previous)
+
+    def test_setup_readline_gnu_binding(self, tmp_path, monkeypatch):
+        import readline
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        # Force the non-libedit (GNU readline) branch.
+        monkeypatch.setattr(readline, "__doc__", "GNU readline library")
+        with patch("readline.parse_and_bind") as mock_bind:
+            CompanionREPL()._setup_readline()
+        mock_bind.assert_any_call("tab: complete")
+
+    def test_setup_readline_reads_existing_history(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".planopticon_history").write_text("some old command\n")
+        repl = CompanionREPL()
+        repl._setup_readline()
+        assert repl._history_path == tmp_path / ".planopticon_history"
+
+    def test_setup_readline_history_read_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        (tmp_path / ".planopticon_history").write_text("cmd\n")
+        with patch("readline.read_history_file", side_effect=OSError("boom")):
+            CompanionREPL()._setup_readline()  # must not raise
+
+    def test_save_history_writes_file(self, tmp_path):
+        repl = CompanionREPL()
+        repl._history_path = tmp_path / ".hist"
+        repl._save_history()
+        assert (tmp_path / ".hist").exists()
+
+    def test_save_history_swallows_error(self, tmp_path):
+        repl = CompanionREPL()
+        repl._history_path = tmp_path / ".hist"
+        with patch("readline.write_history_file", side_effect=OSError("boom")):
+            repl._save_history()  # must not raise
+
+
+# -----------------------------------------------------------------------
+# run() main loop
+# -----------------------------------------------------------------------
+
+
+class TestRunLoop:
+    def _isolate(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    def test_run_immediate_eof(self, tmp_path, monkeypatch, capsys):
+        self._isolate(monkeypatch, tmp_path)
+        with (
+            patch(
+                "video_processor.integrators.graph_discovery.find_nearest_graph",
+                return_value=None,
+            ),
+            patch("video_processor.providers.manager.ProviderManager", MagicMock()),
+            patch("builtins.input", side_effect=EOFError),
+        ):
+            CompanionREPL().run()
+        out = capsys.readouterr().out
+        assert "PlanOpticon Companion" in out
+        assert "Bye." in out
+
+    def test_run_command_then_quit(self, tmp_path, monkeypatch, capsys):
+        self._isolate(monkeypatch, tmp_path)
+        with (
+            patch(
+                "video_processor.integrators.graph_discovery.find_nearest_graph",
+                return_value=None,
+            ),
+            patch("video_processor.providers.manager.ProviderManager", MagicMock()),
+            patch("builtins.input", side_effect=["/help", "/quit"]),
+        ):
+            CompanionREPL().run()
+        out = capsys.readouterr().out
+        assert "Available commands" in out
+        assert "Bye." in out
+
+    def test_run_keyboard_interrupt(self, tmp_path, monkeypatch, capsys):
+        self._isolate(monkeypatch, tmp_path)
+        with (
+            patch(
+                "video_processor.integrators.graph_discovery.find_nearest_graph",
+                return_value=None,
+            ),
+            patch("video_processor.providers.manager.ProviderManager", MagicMock()),
+            patch("builtins.input", side_effect=KeyboardInterrupt),
+        ):
+            CompanionREPL().run()
+        assert "Bye." in capsys.readouterr().out

--- a/tests/test_dropbox_source.py
+++ b/tests/test_dropbox_source.py
@@ -1,0 +1,271 @@
+"""Tests for DropboxSource: auth flows, listing, and download.
+
+Complements the constructor / not-authenticated / auth-no-sdk / saved-token
+cases already covered in tests/test_cloud_sources.py by exercising the
+untested access-token auth, OAuth flow, list_videos, and download paths.
+The dropbox SDK is installed, so real ``dropbox.files.FileMetadata`` and
+``FolderMetadata`` objects drive the isinstance-based filtering.
+"""
+
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_processor.sources.base import SourceFile
+
+
+def _file_meta(name, file_id, size, path_display, modified=datetime(2025, 1, 1)):
+    import dropbox
+
+    return dropbox.files.FileMetadata(
+        name=name,
+        id=file_id,
+        size=size,
+        server_modified=modified,
+        path_display=path_display,
+    )
+
+
+class TestDropboxAuthToken:
+    def test_authenticate_with_access_token(self):
+        from video_processor.sources.dropbox_source import DropboxSource
+
+        source = DropboxSource(access_token="tok")
+        mock_dbx = MagicMock()
+        with patch("dropbox.Dropbox", return_value=mock_dbx):
+            assert source.authenticate() is True
+        assert source.dbx is mock_dbx
+        mock_dbx.users_get_current_account.assert_called_once()
+
+    def test_authenticate_access_token_failure(self):
+        from video_processor.sources.dropbox_source import DropboxSource
+
+        source = DropboxSource(access_token="bad")
+        mock_dbx = MagicMock()
+        mock_dbx.users_get_current_account.side_effect = Exception("401 unauthorized")
+        with patch("dropbox.Dropbox", return_value=mock_dbx):
+            assert source.authenticate() is False
+
+
+class TestDropboxAuthSavedToken:
+    @patch.dict(os.environ, {}, clear=True)
+    def test_authenticate_saved_token(self, tmp_path):
+        from video_processor.sources.dropbox_source import DropboxSource
+
+        token_file = tmp_path / "token.json"
+        token_file.write_text(
+            json.dumps({"refresh_token": "rt", "app_key": "k", "app_secret": "s"})
+        )
+        source = DropboxSource(token_path=token_file)
+        mock_dbx = MagicMock()
+        with patch("dropbox.Dropbox", return_value=mock_dbx):
+            assert source.authenticate() is True
+        assert source.dbx is mock_dbx
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_authenticate_saved_token_invalid_falls_through(self, tmp_path):
+        from video_processor.sources.dropbox_source import DropboxSource
+
+        # Missing refresh_token => _auth_saved_token returns False, then OAuth is
+        # attempted, which fails because no app_key is configured.
+        token_file = tmp_path / "token.json"
+        token_file.write_text(json.dumps({"app_key": "k"}))
+        source = DropboxSource(token_path=token_file)
+        assert source.authenticate() is False
+
+    def test_auth_saved_token_corrupt_json(self, tmp_path):
+        import dropbox
+
+        from video_processor.sources.dropbox_source import DropboxSource
+
+        token_file = tmp_path / "token.json"
+        token_file.write_text("{not valid json")
+        source = DropboxSource(token_path=token_file, app_key="k", app_secret="s")
+        assert source._auth_saved_token(dropbox) is False
+
+
+class TestDropboxAuthOAuth:
+    @patch.dict(os.environ, {}, clear=True)
+    def test_authenticate_oauth_no_app_key(self, tmp_path):
+        from video_processor.sources.dropbox_source import DropboxSource
+
+        source = DropboxSource(token_path=tmp_path / "missing.json")
+        # No access token, no saved token, no app_key => OAuth bails out.
+        assert source.authenticate() is False
+
+    def test_auth_oauth_full_flow(self, tmp_path):
+        import dropbox
+
+        from video_processor.sources.dropbox_source import DropboxSource
+
+        token_file = tmp_path / "sub" / "token.json"
+        source = DropboxSource(app_key="appkey", app_secret="appsecret", token_path=token_file)
+
+        flow = MagicMock()
+        flow.start.return_value = "https://dropbox.com/authorize?x=1"
+        result = MagicMock()
+        result.refresh_token = "new_refresh"
+        flow.finish.return_value = result
+        mock_dbx = MagicMock()
+
+        # webbrowser.open raising (e.g. headless host) must be swallowed so the
+        # flow still completes via the printed URL + pasted code.
+        with (
+            patch("dropbox.DropboxOAuth2FlowNoRedirect", return_value=flow),
+            patch("dropbox.Dropbox", return_value=mock_dbx),
+            patch("builtins.input", return_value="authcode123"),
+            patch(
+                "video_processor.sources.dropbox_source.webbrowser.open",
+                side_effect=Exception("no display"),
+            ),
+        ):
+            assert source._auth_oauth(dropbox) is True
+
+        assert source.dbx is mock_dbx
+        flow.finish.assert_called_once_with("authcode123")
+        assert token_file.exists()
+        saved = json.loads(token_file.read_text())
+        assert saved["refresh_token"] == "new_refresh"
+        assert saved["app_key"] == "appkey"
+        assert saved["app_secret"] == "appsecret"
+
+    def test_auth_oauth_exception(self):
+        import dropbox
+
+        from video_processor.sources.dropbox_source import DropboxSource
+
+        source = DropboxSource(app_key="appkey")
+        with patch("dropbox.DropboxOAuth2FlowNoRedirect", side_effect=Exception("boom")):
+            assert source._auth_oauth(dropbox) is False
+
+
+class TestDropboxListVideos:
+    def test_list_videos_filters_and_normalizes_path(self):
+        import dropbox
+
+        from video_processor.sources.dropbox_source import DropboxSource
+
+        source = DropboxSource()
+        source.dbx = MagicMock()
+
+        entries = [
+            _file_meta("clip.mp4", "id:1", 1000, "/recordings/clip.mp4"),
+            _file_meta("notes.txt", "id:2", 50, "/recordings/notes.txt"),
+            dropbox.files.FolderMetadata(name="sub", id="id:3"),
+        ]
+        result = MagicMock()
+        result.entries = entries
+        result.has_more = False
+        source.dbx.files_list_folder.return_value = result
+
+        files = source.list_videos(folder_path="recordings")
+
+        # Only the video FileMetadata survives ext + isinstance filtering.
+        assert len(files) == 1
+        sf = files[0]
+        assert sf.name == "clip.mp4"
+        assert sf.id == "id:1"
+        assert sf.size_bytes == 1000
+        assert sf.path == "/recordings/clip.mp4"
+        assert sf.modified_at == "2025-01-01T00:00:00"
+        assert sf.mime_type is None
+        # A leading slash is added to a bare folder path.
+        source.dbx.files_list_folder.assert_called_once_with("/recordings", recursive=False)
+
+    def test_list_videos_pagination(self):
+        from video_processor.sources.dropbox_source import DropboxSource
+
+        source = DropboxSource()
+        source.dbx = MagicMock()
+
+        page1 = MagicMock()
+        page1.entries = [_file_meta("a.mov", "id:a", 10, "/a.mov")]
+        page1.has_more = True
+        page1.cursor = "cursor1"
+
+        page2 = MagicMock()
+        page2.entries = [_file_meta("b.mkv", "id:b", 20, "/b.mkv")]
+        page2.has_more = False
+
+        source.dbx.files_list_folder.return_value = page1
+        source.dbx.files_list_folder_continue.return_value = page2
+
+        files = source.list_videos()
+
+        assert {f.name for f in files} == {"a.mov", "b.mkv"}
+        # Empty folder path stays "" (no leading slash added).
+        source.dbx.files_list_folder.assert_called_once_with("", recursive=False)
+        source.dbx.files_list_folder_continue.assert_called_once_with("cursor1")
+
+    def test_list_videos_pattern_filter(self):
+        from video_processor.sources.dropbox_source import DropboxSource
+
+        source = DropboxSource()
+        source.dbx = MagicMock()
+
+        entries = [
+            _file_meta("clip.mp4", "id:1", 1, "/clip.mp4"),
+            _file_meta("movie.mov", "id:2", 1, "/movie.mov"),
+        ]
+        result = MagicMock()
+        result.entries = entries
+        result.has_more = False
+        source.dbx.files_list_folder.return_value = result
+
+        files = source.list_videos(patterns=["*.mp4"])
+
+        assert len(files) == 1
+        assert files[0].name == "clip.mp4"
+
+    def test_list_videos_error_reraises(self):
+        from video_processor.sources.dropbox_source import DropboxSource
+
+        source = DropboxSource()
+        source.dbx = MagicMock()
+        source.dbx.files_list_folder.side_effect = Exception("API error")
+
+        with pytest.raises(Exception, match="API error"):
+            source.list_videos(folder_path="/recordings")
+
+
+class TestDropboxDownload:
+    def test_download_writes_file(self, tmp_path):
+        from video_processor.sources.dropbox_source import DropboxSource
+
+        source = DropboxSource()
+        source.dbx = MagicMock()
+
+        def fake_download(dest, path):
+            Path(dest).write_bytes(b"video-bytes")
+
+        source.dbx.files_download_to_file.side_effect = fake_download
+
+        f = SourceFile(name="clip.mp4", id="id:1", path="/recordings/clip.mp4")
+        dest = tmp_path / "out" / "clip.mp4"
+        result = source.download(f, dest)
+
+        assert result == dest
+        assert dest.read_bytes() == b"video-bytes"
+        source.dbx.files_download_to_file.assert_called_once_with(str(dest), "/recordings/clip.mp4")
+
+    def test_download_path_fallback_to_name(self, tmp_path):
+        from video_processor.sources.dropbox_source import DropboxSource
+
+        source = DropboxSource()
+        source.dbx = MagicMock()
+
+        def fake_download(dest, path):
+            Path(dest).write_text("data")
+
+        source.dbx.files_download_to_file.side_effect = fake_download
+
+        f = SourceFile(name="video.mp4", id="id:1")  # no path
+        dest = tmp_path / "video.mp4"
+        source.download(f, dest)
+
+        # Falls back to "/{name}" when SourceFile.path is None.
+        source.dbx.files_download_to_file.assert_called_once_with(str(dest), "/video.mp4")

--- a/tests/test_gemini_provider.py
+++ b/tests/test_gemini_provider.py
@@ -1,0 +1,178 @@
+"""Tests for GeminiProvider (construction, chat, vision, transcription, listing).
+
+google-genai is a core dependency, so the real `types` build the request; only
+the genai.Client / provider.client boundary is mocked.
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_processor.providers.gemini_provider import GeminiProvider
+
+
+def _provider():
+    provider = GeminiProvider(api_key="test-key")
+    provider.client = MagicMock()
+    return provider
+
+
+def _content_response(text, prompt_tokens=11, candidates_tokens=22):
+    resp = MagicMock()
+    resp.text = text
+    resp.usage_metadata.prompt_token_count = prompt_tokens
+    resp.usage_metadata.candidates_token_count = candidates_tokens
+    return resp
+
+
+class TestConstruction:
+    def test_missing_key_and_creds_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="Neither GEMINI_API_KEY"):
+                GeminiProvider(api_key=None, credentials_path=None)
+
+    @patch("google.genai.Client")
+    def test_api_key_branch(self, mock_client):
+        GeminiProvider(api_key="test-key")
+        mock_client.assert_called_once_with(api_key="test-key")
+
+    @patch("google.genai.Client")
+    def test_service_account_uses_vertex(self, mock_client, tmp_path):
+        creds = tmp_path / "sa.json"
+        creds.write_text(json.dumps({"project_id": "my-proj"}))
+        with patch.dict(os.environ, {"GOOGLE_CLOUD_LOCATION": "europe-west1"}, clear=True):
+            GeminiProvider(api_key=None, credentials_path=str(creds))
+        mock_client.assert_called_once_with(
+            vertexai=True, project="my-proj", location="europe-west1"
+        )
+
+
+class TestChat:
+    def test_chat_maps_messages_and_records_usage(self):
+        provider = _provider()
+        provider.client.models.generate_content.return_value = _content_response("answer", 11, 22)
+
+        out = provider.chat(
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "prior"},
+            ]
+        )
+        assert out == "answer"
+        assert provider._last_usage == {"input_tokens": 11, "output_tokens": 22}
+
+        call = provider.client.models.generate_content.call_args
+        assert call.kwargs["model"] == "gemini-2.5-flash"  # default
+        contents = call.kwargs["contents"]
+        # user -> "user", assistant -> "model"
+        assert contents[0].role == "user"
+        assert contents[1].role == "model"
+
+    def test_chat_none_text_returns_empty(self):
+        provider = _provider()
+        resp = _content_response(None)
+        resp.usage_metadata = None
+        provider.client.models.generate_content.return_value = resp
+        assert provider.chat([{"role": "user", "content": "hi"}]) == ""
+        assert provider._last_usage == {"input_tokens": 0, "output_tokens": 0}
+
+
+class TestAnalyzeImage:
+    def test_analyze_image_returns_text(self):
+        provider = _provider()
+        provider.client.models.generate_content.return_value = _content_response("a chart", 90, 3)
+        out = provider.analyze_image(b"\x00\x01imagebytes", "describe", model="gemini-2.5-pro")
+        assert out == "a chart"
+        assert provider._last_usage["input_tokens"] == 90
+        assert provider.client.models.generate_content.call_args.kwargs["model"] == "gemini-2.5-pro"
+
+
+class TestTranscribe:
+    def test_transcribe_plain_text(self, tmp_path):
+        provider = _provider()
+        provider.client.models.generate_content.return_value = _content_response(
+            "  the verbatim transcript  "
+        )
+        audio = tmp_path / "a.mp3"
+        audio.write_bytes(b"\x00\x01")
+
+        result = provider.transcribe_audio(audio, language="en")
+        assert result["text"] == "the verbatim transcript"
+        assert result["provider"] == "gemini"
+        assert result["language"] == "en"
+        assert result["segments"] == []
+
+    def test_transcribe_unwraps_json_wrapped_text(self, tmp_path):
+        """Regression: Gemini sometimes returns a JSON object despite being asked
+        for plain text — the provider unwraps the inner 'text' value."""
+        provider = _provider()
+        provider.client.models.generate_content.return_value = _content_response(
+            '{"text": "unwrapped transcript"}'
+        )
+        audio = tmp_path / "a.wav"
+        audio.write_bytes(b"\x00")
+        result = provider.transcribe_audio(audio)
+        assert result["text"] == "unwrapped transcript"
+
+    def test_transcribe_unwraps_double_encoded_json(self, tmp_path):
+        provider = _provider()
+        inner = json.dumps({"text": "deep transcript"})
+        provider.client.models.generate_content.return_value = _content_response(
+            json.dumps({"text": inner})
+        )
+        audio = tmp_path / "a.wav"
+        audio.write_bytes(b"\x00")
+        result = provider.transcribe_audio(audio)
+        assert result["text"] == "deep transcript"
+
+    def test_transcribe_leaves_malformed_json_untouched(self, tmp_path):
+        provider = _provider()
+        provider.client.models.generate_content.return_value = _content_response("{not valid json")
+        audio = tmp_path / "a.wav"
+        audio.write_bytes(b"\x00")
+        result = provider.transcribe_audio(audio)
+        assert result["text"] == "{not valid json"
+
+    def test_transcribe_includes_speaker_hint_in_prompt(self, tmp_path):
+        provider = _provider()
+        provider.client.models.generate_content.return_value = _content_response("hi")
+        audio = tmp_path / "a.wav"
+        audio.write_bytes(b"\x00")
+        provider.transcribe_audio(audio, speaker_hints=["Alice", "Bob"])
+        prompt = provider.client.models.generate_content.call_args.kwargs["contents"][1]
+        assert "Speakers: Alice, Bob." in prompt
+
+
+class TestListModels:
+    def _model(self, name, display=None):
+        m = MagicMock()
+        m.name = name
+        m.display_name = display or name
+        return m
+
+    def test_list_models_strips_prefixes_and_infers_caps(self):
+        provider = _provider()
+        provider.client.models.list.return_value = [
+            self._model("models/gemini-2.5-flash", "Gemini 2.5 Flash"),
+            self._model("publishers/google/models/gemini-pro"),
+            self._model("models/text-embedding-004"),
+            self._model("models/imagen-3.0"),  # not gemini/embedding -> excluded
+        ]
+        models = provider.list_models()
+        by_id = {m.id: m for m in models}
+
+        assert "imagen-3.0" not in by_id
+        assert "gemini-2.5-flash" in by_id
+        assert "gemini-pro" in by_id  # publishers/ prefix stripped
+        assert "chat" in by_id["gemini-2.5-flash"].capabilities
+        assert "vision" in by_id["gemini-2.5-flash"].capabilities
+        assert "audio" in by_id["gemini-2.5-flash"].capabilities
+        assert by_id["text-embedding-004"].capabilities == ["embedding"]
+        assert [m.id for m in models] == sorted(m.id for m in models)
+
+    def test_list_models_handles_error(self):
+        provider = _provider()
+        provider.client.models.list.side_effect = RuntimeError("boom")
+        assert provider.list_models() == []

--- a/tests/test_github_integration.py
+++ b/tests/test_github_integration.py
@@ -1,0 +1,104 @@
+"""Tests for the github_issues agent skill (task -> issue conversion, gh push)."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from video_processor.agent.skills.base import AgentContext, Artifact
+from video_processor.agent.skills.github_integration import (
+    GitHubIssuesSkill,
+    _task_to_issue,
+    push_to_github,
+)
+
+
+class TestTaskToIssue:
+    def test_full_task_with_deps_and_labels(self):
+        task = {
+            "title": "Build API",
+            "description": "Implement the REST API",
+            "priority": "high",
+            "estimate": "3d",
+            "dependencies": ["Design schema", 2],
+            "labels": ["backend"],
+        }
+        issue = _task_to_issue(task)
+        assert issue["title"] == "Build API"
+        assert "## Description\nImplement the REST API" in issue["body"]
+        assert "**Priority:** high" in issue["body"]
+        assert "**Estimate:** 3d" in issue["body"]
+        assert "**Dependencies:** Design schema, 2" in issue["body"]
+        # priority is always the first label, custom labels appended
+        assert issue["labels"] == ["high", "backend"]
+
+    def test_minimal_task_uses_defaults(self):
+        issue = _task_to_issue({})
+        assert issue["title"] == "Untitled task"
+        assert "**Priority:** medium" in issue["body"]
+        assert "**Estimate:** unknown" in issue["body"]
+        assert "Dependencies" not in issue["body"]  # no deps -> no line
+        assert issue["labels"] == ["medium"]
+
+    def test_description_falls_back_to_title(self):
+        issue = _task_to_issue({"title": "Only a title"})
+        assert "## Description\nOnly a title" in issue["body"]
+
+
+class TestPushToGithub:
+    def test_returns_none_when_gh_missing(self):
+        with patch(
+            "video_processor.agent.skills.github_integration.shutil.which", return_value=None
+        ):
+            assert push_to_github(json.dumps([{"title": "x", "body": "y"}]), "org/repo") is None
+
+    def test_creates_issues_via_gh(self):
+        issues = json.dumps([{"title": "Bug", "body": "broken", "labels": ["bug", "p1"]}])
+        proc = MagicMock(returncode=0, stdout="https://github.com/org/repo/issues/1\n", stderr="")
+        with patch(
+            "video_processor.agent.skills.github_integration.shutil.which",
+            return_value="/usr/bin/gh",
+        ):
+            with patch(
+                "video_processor.agent.skills.github_integration.subprocess.run",
+                return_value=proc,
+            ) as mock_run:
+                results = push_to_github(issues, "org/repo")
+
+        assert results[0]["returncode"] == 0
+        assert results[0]["stdout"] == "https://github.com/org/repo/issues/1"
+        cmd = mock_run.call_args.args[0]
+        assert cmd[:5] == ["gh", "issue", "create", "--repo", "org/repo"]
+        assert "--title" in cmd and "Bug" in cmd
+        # both labels forwarded
+        assert cmd.count("--label") == 2
+
+
+class TestGitHubIssuesSkill:
+    def test_execute_from_task_list_artifact(self):
+        ctx = AgentContext()
+        tasks = [
+            {"title": "T1", "priority": "high"},
+            {"title": "T2", "priority": "low", "dependencies": ["T1"]},
+        ]
+        ctx.artifacts = [
+            Artifact(
+                name="Tasks",
+                content=json.dumps(tasks),
+                artifact_type="task_list",
+                format="json",
+            )
+        ]
+        result = GitHubIssuesSkill().execute(ctx)
+        assert result.artifact_type == "issues"
+        issues = json.loads(result.content)
+        assert [i["title"] for i in issues] == ["T1", "T2"]
+        assert issues[0]["labels"] == ["high"]
+
+    def test_execute_falls_back_to_planning_entities(self):
+        ctx = AgentContext()
+        ctx.artifacts = []
+        ctx.planning_entities = ["Ship MVP", "Write docs"]
+        result = GitHubIssuesSkill().execute(ctx)
+        issues = json.loads(result.content)
+        assert {i["title"] for i in issues} == {"Ship MVP", "Write docs"}
+        # inline-generated tasks default to medium priority
+        assert all(i["labels"] == ["medium"] for i in issues)

--- a/tests/test_google_drive_source.py
+++ b/tests/test_google_drive_source.py
@@ -1,0 +1,438 @@
+"""Tests for the Google Drive source: listing, download, and auth branch dispatch.
+
+The Google API Python client SDK is not installed in this environment, so the
+Drive service client is replaced with a fluent MagicMock and the lazily-imported
+``googleapiclient`` / ``google_auth_oauthlib`` modules are injected into
+``sys.modules``. The ``google.oauth2`` / ``google.auth`` packages *are* installed
+(via ``google-auth``), so those are patched at their real attributes instead.
+
+Constructors, the not-authenticated guards, and the basic ``_is_service_account``
+cases are already covered by ``tests/test_cloud_sources.py`` and are not repeated
+here; this module covers the untested listing/download/auth-branch code paths.
+"""
+
+import json
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+from video_processor.sources.base import SourceFile
+from video_processor.sources.google_drive import SCOPES, GoogleDriveSource
+
+
+def _fake_discovery_module(build_obj):
+    """Inject a fake ``googleapiclient.discovery`` exposing ``build``."""
+    pkg = types.ModuleType("googleapiclient")
+    disc = types.ModuleType("googleapiclient.discovery")
+    disc.build = build_obj
+    pkg.discovery = disc
+    return {"googleapiclient": pkg, "googleapiclient.discovery": disc}
+
+
+def _fake_oauthlib_module(flow_cls):
+    """Inject a fake ``google_auth_oauthlib.flow`` exposing ``InstalledAppFlow``."""
+    pkg = types.ModuleType("google_auth_oauthlib")
+    flowmod = types.ModuleType("google_auth_oauthlib.flow")
+    flowmod.InstalledAppFlow = flow_cls
+    pkg.flow = flowmod
+    return {"google_auth_oauthlib": pkg, "google_auth_oauthlib.flow": flowmod}
+
+
+def _fake_http_module(media_factory):
+    """Inject a fake ``googleapiclient.http`` exposing ``MediaIoBaseDownload``."""
+    pkg = types.ModuleType("googleapiclient")
+    httpmod = types.ModuleType("googleapiclient.http")
+    httpmod.MediaIoBaseDownload = media_factory
+    pkg.http = httpmod
+    return {"googleapiclient": pkg, "googleapiclient.http": httpmod}
+
+
+class TestGoogleDriveIsServiceAccount:
+    """The exception branch of ``_is_service_account`` (bad/missing file)."""
+
+    def test_missing_file_returns_false(self, tmp_path):
+        source = GoogleDriveSource(credentials_path=str(tmp_path / "does_not_exist.json"))
+        assert source._is_service_account() is False
+
+    def test_malformed_json_returns_false(self, tmp_path):
+        bad = tmp_path / "bad.json"
+        bad.write_text("{ this is not valid json")
+        source = GoogleDriveSource(credentials_path=str(bad))
+        assert source._is_service_account() is False
+
+
+class TestGoogleDriveAuthenticateDispatch:
+    """``authenticate`` routes to the right auth helper once the SDK imports resolve."""
+
+    def test_dispatch_service_account_forced(self):
+        source = GoogleDriveSource(use_service_account=True)
+        build_obj = MagicMock()
+        with patch.dict(sys.modules, _fake_discovery_module(build_obj)):
+            with patch.object(source, "_auth_service_account", return_value=True) as helper:
+                assert source.authenticate() is True
+        helper.assert_called_once()
+        # The build callable imported from googleapiclient is threaded through.
+        assert helper.call_args.args[0] is build_obj
+
+    def test_dispatch_autodetect_service_account(self, tmp_path):
+        creds = tmp_path / "sa.json"
+        creds.write_text(json.dumps({"type": "service_account"}))
+        source = GoogleDriveSource(credentials_path=str(creds))  # use_service_account is None
+        build_obj = MagicMock()
+        with patch.dict(sys.modules, _fake_discovery_module(build_obj)):
+            with patch.object(source, "_auth_service_account", return_value=True) as helper:
+                assert source.authenticate() is True
+        helper.assert_called_once()
+
+    def test_dispatch_oauth(self):
+        source = GoogleDriveSource(use_service_account=False)
+        build_obj = MagicMock()
+        with patch.dict(sys.modules, _fake_discovery_module(build_obj)):
+            with patch.object(source, "_auth_oauth", return_value=True) as helper:
+                assert source.authenticate() is True
+        helper.assert_called_once()
+        assert helper.call_args.args[0] is build_obj
+
+
+class TestGoogleDriveAuthServiceAccount:
+    def test_success_builds_service(self, tmp_path):
+        creds_file = tmp_path / "sa.json"
+        creds_file.write_text(json.dumps({"type": "service_account"}))
+        source = GoogleDriveSource(credentials_path=str(creds_file))
+        build_obj = MagicMock()
+        fake_creds = MagicMock()
+        with patch(
+            "google.oauth2.service_account.Credentials.from_service_account_file",
+            return_value=fake_creds,
+        ) as from_file:
+            assert source._auth_service_account(build_obj) is True
+        from_file.assert_called_once_with(str(creds_file), scopes=SCOPES)
+        build_obj.assert_called_once_with("drive", "v3", credentials=fake_creds)
+        assert source.service is build_obj.return_value
+        assert source._creds is fake_creds
+
+    def test_no_credentials_path_returns_false(self):
+        source = GoogleDriveSource()
+        source.credentials_path = None  # override any env-var fallback
+        assert source._auth_service_account(MagicMock()) is False
+
+    def test_exception_returns_false(self, tmp_path):
+        creds_file = tmp_path / "sa.json"
+        creds_file.write_text("{}")
+        source = GoogleDriveSource(credentials_path=str(creds_file))
+        with patch(
+            "google.oauth2.service_account.Credentials.from_service_account_file",
+            side_effect=ValueError("bad service account key"),
+        ):
+            assert source._auth_service_account(MagicMock()) is False
+        assert source.service is None
+
+
+class TestGoogleDriveAuthOAuth:
+    def test_import_error_returns_false(self):
+        # google_auth_oauthlib is not installed → the top-level import raises.
+        source = GoogleDriveSource()
+        assert source._auth_oauth(MagicMock()) is False
+
+    def test_new_flow_saves_token(self, tmp_path):
+        creds_file = tmp_path / "client.json"
+        creds_file.write_text(
+            json.dumps({"installed": {"client_id": "cid", "client_secret": "sec"}})
+        )
+        token_file = tmp_path / "token.json"  # does not exist yet
+        source = GoogleDriveSource(credentials_path=str(creds_file), token_path=token_file)
+        build_obj = MagicMock()
+        new_creds = MagicMock()
+        new_creds.to_json.return_value = json.dumps({"token": "abc"})
+        flow_inst = MagicMock()
+        flow_inst.run_local_server.return_value = new_creds
+        flow_cls = MagicMock()
+        flow_cls.from_client_config.return_value = flow_inst
+        with patch.dict(sys.modules, _fake_oauthlib_module(flow_cls)):
+            assert source._auth_oauth(build_obj) is True
+        # Token persisted to disk from the freshly minted credentials.
+        assert json.loads(token_file.read_text()) == {"token": "abc"}
+        # Client config was loaded from the provided secrets file.
+        cfg = flow_cls.from_client_config.call_args.args[0]
+        assert cfg["installed"]["client_id"] == "cid"
+        build_obj.assert_called_once_with("drive", "v3", credentials=new_creds)
+        assert source.service is build_obj.return_value
+
+    def test_valid_saved_token_skips_flow(self, tmp_path):
+        token_file = tmp_path / "token.json"
+        token_file.write_text(json.dumps({"token": "existing"}))
+        source = GoogleDriveSource(token_path=token_file)
+        build_obj = MagicMock()
+        good_creds = MagicMock()
+        good_creds.valid = True
+        good_creds.expired = False
+        flow_cls = MagicMock()
+        with patch.dict(sys.modules, _fake_oauthlib_module(flow_cls)):
+            with patch(
+                "google.oauth2.credentials.Credentials.from_authorized_user_file",
+                return_value=good_creds,
+            ):
+                assert source._auth_oauth(build_obj) is True
+        flow_cls.from_client_config.assert_not_called()
+        build_obj.assert_called_once_with("drive", "v3", credentials=good_creds)
+        assert source._creds is good_creds
+        # The existing token file is left untouched when no new flow runs.
+        assert json.loads(token_file.read_text()) == {"token": "existing"}
+
+    def test_expired_token_is_refreshed(self, tmp_path):
+        token_file = tmp_path / "token.json"
+        token_file.write_text("{}")
+        source = GoogleDriveSource(token_path=token_file)
+        build_obj = MagicMock()
+        creds = MagicMock()
+        creds.valid = True
+        creds.expired = True
+        creds.refresh_token = "refresh-token"
+        flow_cls = MagicMock()
+        with patch.dict(sys.modules, _fake_oauthlib_module(flow_cls)):
+            with patch(
+                "google.oauth2.credentials.Credentials.from_authorized_user_file",
+                return_value=creds,
+            ):
+                assert source._auth_oauth(build_obj) is True
+        creds.refresh.assert_called_once()
+        flow_cls.from_client_config.assert_not_called()
+
+    def test_refresh_failure_falls_back_to_flow(self, tmp_path):
+        token_file = tmp_path / "token.json"
+        token_file.write_text("{}")
+        creds_file = tmp_path / "client.json"
+        creds_file.write_text(json.dumps({"installed": {"client_id": "cid"}}))
+        source = GoogleDriveSource(credentials_path=str(creds_file), token_path=token_file)
+        build_obj = MagicMock()
+        stale = MagicMock()
+        stale.valid = False
+        stale.expired = True
+        stale.refresh_token = "refresh-token"
+        stale.refresh.side_effect = Exception("refresh boom")
+        new_creds = MagicMock()
+        new_creds.to_json.return_value = "{}"
+        flow_inst = MagicMock()
+        flow_inst.run_local_server.return_value = new_creds
+        flow_cls = MagicMock()
+        flow_cls.from_client_config.return_value = flow_inst
+        with patch.dict(sys.modules, _fake_oauthlib_module(flow_cls)):
+            with patch(
+                "google.oauth2.credentials.Credentials.from_authorized_user_file",
+                return_value=stale,
+            ):
+                assert source._auth_oauth(build_obj) is True
+        stale.refresh.assert_called_once()
+        flow_cls.from_client_config.assert_called_once()
+        build_obj.assert_called_once_with("drive", "v3", credentials=new_creds)
+
+    def test_no_client_id_returns_false(self, tmp_path):
+        token_file = tmp_path / "token.json"  # does not exist
+        source = GoogleDriveSource(credentials_path=None, token_path=token_file)
+        source.credentials_path = None  # override any env-var fallback
+        flow_cls = MagicMock()
+        with patch.dict(sys.modules, _fake_oauthlib_module(flow_cls)):
+            with patch(
+                "video_processor.sources.google_drive._DEFAULT_CLIENT_CONFIG",
+                {"installed": {"client_id": ""}},
+            ):
+                assert source._auth_oauth(MagicMock()) is False
+        flow_cls.from_client_config.assert_not_called()
+
+    def test_token_load_error_and_bad_config_fall_back_to_flow(self, tmp_path):
+        # Existing token that fails to parse + a malformed client-secrets file:
+        # both errors are swallowed and the default config drives a fresh flow.
+        token_file = tmp_path / "token.json"
+        token_file.write_text("not valid json")
+        creds_file = tmp_path / "client.json"
+        creds_file.write_text("{ broken json")
+        source = GoogleDriveSource(credentials_path=str(creds_file), token_path=token_file)
+        build_obj = MagicMock()
+        new_creds = MagicMock()
+        new_creds.to_json.return_value = "{}"
+        flow_inst = MagicMock()
+        flow_inst.run_local_server.return_value = new_creds
+        flow_cls = MagicMock()
+        flow_cls.from_client_config.return_value = flow_inst
+        with patch.dict(sys.modules, _fake_oauthlib_module(flow_cls)):
+            with patch(
+                "google.oauth2.credentials.Credentials.from_authorized_user_file",
+                side_effect=ValueError("corrupt token"),
+            ):
+                with patch(
+                    "video_processor.sources.google_drive._DEFAULT_CLIENT_CONFIG",
+                    {"installed": {"client_id": "cid"}},
+                ):
+                    assert source._auth_oauth(build_obj) is True
+        flow_cls.from_client_config.assert_called_once()
+
+
+class TestGoogleDriveListVideos:
+    def test_single_folder_non_recursive(self):
+        source = GoogleDriveSource()
+        source.service = MagicMock()
+        source.service.files.return_value.list.return_value.execute.return_value = {
+            "files": [
+                {
+                    "id": "a",
+                    "name": "one.mp4",
+                    "size": "1024",
+                    "mimeType": "video/mp4",
+                    "modifiedTime": "2025-01-01T00:00:00Z",
+                },
+                {
+                    "id": "b",
+                    "name": "two.webm",
+                    "size": "2048",
+                    "mimeType": "video/webm",
+                    "modifiedTime": "2025-02-02T00:00:00Z",
+                },
+            ],
+            "nextPageToken": None,
+        }
+        files = source.list_videos(folder_id="FOLDER", recursive=False)
+        assert [f.name for f in files] == ["one.mp4", "two.webm"]
+        assert files[0].id == "a"
+        assert files[0].size_bytes == 1024
+        assert files[0].mime_type == "video/mp4"
+        assert files[0].modified_at == "2025-01-01T00:00:00Z"
+        assert files[0].path == "one.mp4"
+        query = source.service.files.return_value.list.call_args.kwargs["q"]
+        assert "'FOLDER' in parents" in query
+        assert "trashed=false" in query
+        assert "video/mp4" in query
+
+    def test_pagination_follows_next_page_token(self):
+        source = GoogleDriveSource()
+        source.service = MagicMock()
+        source.service.files.return_value.list.return_value.execute.side_effect = [
+            {
+                "files": [{"id": "a", "name": "p1.mp4", "mimeType": "video/mp4"}],
+                "nextPageToken": "PAGE2",
+            },
+            {
+                "files": [{"id": "b", "name": "p2.mp4", "mimeType": "video/mp4"}],
+                "nextPageToken": None,
+            },
+        ]
+        files = source.list_videos(folder_id="F", recursive=False)
+        assert [f.name for f in files] == ["p1.mp4", "p2.mp4"]
+        calls = source.service.files.return_value.list.call_args_list
+        assert calls[0].kwargs["pageToken"] is None
+        assert calls[1].kwargs["pageToken"] == "PAGE2"
+
+    def test_pattern_filter_excludes_non_matches(self):
+        source = GoogleDriveSource()
+        source.service = MagicMock()
+        source.service.files.return_value.list.return_value.execute.return_value = {
+            "files": [
+                {"id": "a", "name": "keep.mp4", "mimeType": "video/mp4"},
+                {"id": "b", "name": "skip.mkv", "mimeType": "video/x-matroska"},
+            ],
+            "nextPageToken": None,
+        }
+        files = source.list_videos(folder_id="F", patterns=["*.mp4"], recursive=False)
+        assert [f.name for f in files] == ["keep.mp4"]
+
+    def test_missing_size_is_none(self):
+        source = GoogleDriveSource()
+        source.service = MagicMock()
+        source.service.files.return_value.list.return_value.execute.return_value = {
+            "files": [{"id": "a", "name": "nosize.mp4", "mimeType": "video/mp4"}],
+            "nextPageToken": None,
+        }
+        files = source.list_videos(folder_id="F", recursive=False)
+        assert files[0].size_bytes is None
+
+    def test_no_folder_id_omits_parents_clause(self):
+        source = GoogleDriveSource()
+        source.service = MagicMock()
+        source.service.files.return_value.list.return_value.execute.return_value = {
+            "files": [],
+            "nextPageToken": None,
+        }
+        source.list_videos(folder_id=None, recursive=False)
+        query = source.service.files.return_value.list.call_args.kwargs["q"]
+        assert "in parents" not in query
+
+    def test_recursive_descends_into_subfolders(self):
+        source = GoogleDriveSource()
+        source.service = MagicMock()
+        # Interleaved: root files, root subfolders, subfolder files, subfolder subfolders.
+        source.service.files.return_value.list.return_value.execute.side_effect = [
+            {
+                "files": [{"id": "r", "name": "root.mp4", "mimeType": "video/mp4"}],
+                "nextPageToken": None,
+            },
+            {"files": [{"id": "subA", "name": "SubA"}], "nextPageToken": None},
+            {
+                "files": [{"id": "s", "name": "sub.mp4", "mimeType": "video/mp4"}],
+                "nextPageToken": None,
+            },
+            {"files": [], "nextPageToken": None},
+        ]
+        files = source.list_videos(folder_id="root", recursive=True)
+        assert sorted(f.path for f in files) == ["SubA/sub.mp4", "root.mp4"]
+
+
+class TestGoogleDriveListSubfolders:
+    def test_returns_sorted_id_name_tuples(self):
+        source = GoogleDriveSource()
+        source.service = MagicMock()
+        source.service.files.return_value.list.return_value.execute.return_value = {
+            "files": [{"id": "2", "name": "Zebra"}, {"id": "1", "name": "Alpha"}],
+            "nextPageToken": None,
+        }
+        result = source._list_subfolders("parent")
+        assert result == [("1", "Alpha"), ("2", "Zebra")]
+        query = source.service.files.return_value.list.call_args.kwargs["q"]
+        assert "application/vnd.google-apps.folder" in query
+        assert "'parent' in parents" in query
+
+    def test_pagination_and_no_parent(self):
+        source = GoogleDriveSource()
+        source.service = MagicMock()
+        source.service.files.return_value.list.return_value.execute.side_effect = [
+            {"files": [{"id": "1", "name": "A"}], "nextPageToken": "T"},
+            {"files": [{"id": "2", "name": "B"}], "nextPageToken": None},
+        ]
+        result = source._list_subfolders(None)
+        assert result == [("1", "A"), ("2", "B")]
+        query = source.service.files.return_value.list.call_args_list[0].kwargs["q"]
+        assert "in parents" not in query
+
+
+class TestGoogleDriveDownload:
+    def test_download_writes_streamed_content(self, tmp_path):
+        source = GoogleDriveSource()
+        source.service = MagicMock()
+
+        status = MagicMock()
+        status.progress.return_value = 0.5
+        # Each entry: (bytes_to_write, status_object, done_flag) per next_chunk() call.
+        # First chunk exercises the `if status` progress branch; second (status None)
+        # exercises the skip branch and terminates the loop.
+        chunk_plan = [(b"hello ", status, False), (b"world", None, True)]
+
+        def media_factory(fh, request):
+            state = {"i": 0}
+            downloader = MagicMock()
+
+            def next_chunk():
+                data, chunk_status, done = chunk_plan[state["i"]]
+                state["i"] += 1
+                if data:
+                    fh.write(data)
+                return chunk_status, done
+
+            downloader.next_chunk.side_effect = next_chunk
+            return downloader
+
+        f = SourceFile(name="clip.mp4", id="file-42")
+        dest = tmp_path / "nested" / "clip.mp4"
+        with patch.dict(sys.modules, _fake_http_module(media_factory)):
+            result = source.download(f, dest)
+
+        assert result == dest
+        assert dest.read_bytes() == b"hello world"
+        source.service.files.return_value.get_media.assert_called_once_with(fileId="file-42")

--- a/tests/test_keep_source.py
+++ b/tests/test_keep_source.py
@@ -1,0 +1,201 @@
+"""Tests for GoogleKeepSource: gws CLI wrapper, listing, and download.
+
+Complements the constructor / no-gws-CLI / _note_to_text cases in
+tests/test_sources.py by exercising _run_gws (subprocess boundary),
+authenticate success/failure, list_videos result shapes, and download.
+The gws CLI is not invoked for real -- subprocess.run / _run_gws are mocked.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_processor.sources.base import SourceFile
+
+
+class TestRunGws:
+    @patch("video_processor.sources.google_keep_source.subprocess.run")
+    def test_run_gws_success_parses_json(self, mock_run):
+        from video_processor.sources.google_keep_source import _run_gws
+
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout='{"notes": [{"id": "n1"}]}', stderr=""
+        )
+        result = _run_gws(["keep", "notes", "list"])
+
+        assert result == {"notes": [{"id": "n1"}]}
+        assert mock_run.call_args[0][0] == ["gws", "keep", "notes", "list"]
+
+    @patch("video_processor.sources.google_keep_source.subprocess.run")
+    def test_run_gws_nonzero_raises(self, mock_run):
+        from video_processor.sources.google_keep_source import _run_gws
+
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="auth error")
+        with pytest.raises(RuntimeError, match="auth error"):
+            _run_gws(["auth", "status"])
+
+    @patch("video_processor.sources.google_keep_source.subprocess.run")
+    def test_run_gws_non_json_returns_raw(self, mock_run):
+        from video_processor.sources.google_keep_source import _run_gws
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="plain text output", stderr="")
+        result = _run_gws(["some", "command"])
+
+        assert result == {"raw": "plain text output"}
+
+
+class TestGoogleKeepAuthenticate:
+    @patch("video_processor.sources.google_keep_source._run_gws")
+    @patch("shutil.which", return_value="/usr/local/bin/gws")
+    def test_authenticate_success(self, _which, mock_run):
+        from video_processor.sources.google_keep_source import GoogleKeepSource
+
+        mock_run.return_value = {"connectedAs": "user@example.com"}
+        assert GoogleKeepSource().authenticate() is True
+
+    @patch("video_processor.sources.google_keep_source._run_gws")
+    @patch("shutil.which", return_value="/usr/local/bin/gws")
+    def test_authenticate_gws_not_authed(self, _which, mock_run):
+        from video_processor.sources.google_keep_source import GoogleKeepSource
+
+        mock_run.side_effect = RuntimeError("not authenticated")
+        assert GoogleKeepSource().authenticate() is False
+
+
+class TestGoogleKeepListVideos:
+    @patch("video_processor.sources.google_keep_source._run_gws")
+    def test_list_videos_list_result(self, mock_run):
+        from video_processor.sources.google_keep_source import GoogleKeepSource
+
+        mock_run.return_value = [
+            {
+                "id": "n1",
+                "title": "Meeting",
+                "body": "notes body",
+                "modifiedTime": "2026-01-01T00:00:00Z",
+            },
+            {"id": "n2", "title": "   ", "textContent": "untitled body"},
+        ]
+        files = GoogleKeepSource().list_videos()
+
+        assert len(files) == 2
+        assert files[0].name == "Meeting"
+        assert files[0].id == "n1"
+        assert files[0].mime_type == "text/plain"
+        assert files[0].modified_at == "2026-01-01T00:00:00Z"
+        assert files[0].size_bytes is not None and files[0].size_bytes > 0
+        # Blank title falls back to "Untitled Note".
+        assert files[1].name == "Untitled Note"
+
+    @patch("video_processor.sources.google_keep_source._run_gws")
+    def test_list_videos_passes_label(self, mock_run):
+        from video_processor.sources.google_keep_source import GoogleKeepSource
+
+        mock_run.return_value = []
+        GoogleKeepSource(label="meetings").list_videos()
+
+        passed = mock_run.call_args[0][0]
+        assert "--label" in passed
+        assert "meetings" in passed
+
+    @patch("video_processor.sources.google_keep_source._run_gws")
+    def test_list_videos_dict_items_key(self, mock_run):
+        from video_processor.sources.google_keep_source import GoogleKeepSource
+
+        mock_run.return_value = {"items": [{"noteId": "x1", "title": "From items"}]}
+        files = GoogleKeepSource().list_videos()
+
+        assert len(files) == 1
+        assert files[0].id == "x1"  # noteId fallback
+        assert files[0].name == "From items"
+
+    @patch("video_processor.sources.google_keep_source._run_gws")
+    def test_list_videos_single_note_dict(self, mock_run):
+        from video_processor.sources.google_keep_source import GoogleKeepSource
+
+        mock_run.return_value = {"id": "single1", "title": "Single", "body": "content"}
+        files = GoogleKeepSource().list_videos()
+
+        assert len(files) == 1
+        assert files[0].id == "single1"
+        assert files[0].name == "Single"
+
+    @patch("video_processor.sources.google_keep_source._run_gws")
+    def test_list_videos_error_returns_empty(self, mock_run):
+        from video_processor.sources.google_keep_source import GoogleKeepSource
+
+        mock_run.side_effect = RuntimeError("gws failed")
+        assert GoogleKeepSource().list_videos() == []
+
+
+class TestGoogleKeepDownload:
+    @patch("video_processor.sources.google_keep_source._run_gws")
+    def test_download_writes_note(self, mock_run, tmp_path):
+        from video_processor.sources.google_keep_source import GoogleKeepSource
+
+        mock_run.return_value = {
+            "title": "My Note",
+            "body": "Line one",
+            "listContent": [{"text": "todo", "checked": False}],
+        }
+        f = SourceFile(name="My Note", id="note123", mime_type="text/plain")
+        dest = tmp_path / "notes" / "note.txt"
+
+        result = GoogleKeepSource().download(f, dest)
+
+        assert result == dest
+        content = dest.read_text()
+        assert "My Note" in content
+        assert "Line one" in content
+        assert "- [ ] todo" in content
+        # noteId is threaded through to the gws call params.
+        assert "note123" in json.dumps(mock_run.call_args[0][0])
+
+    @patch("video_processor.sources.google_keep_source._run_gws")
+    def test_download_error_raises(self, mock_run, tmp_path):
+        from video_processor.sources.google_keep_source import GoogleKeepSource
+
+        mock_run.side_effect = RuntimeError("fetch failed")
+        f = SourceFile(name="X", id="n1")
+
+        with pytest.raises(RuntimeError, match="Failed to fetch Keep note"):
+            GoogleKeepSource().download(f, tmp_path / "x.txt")
+
+    @patch("video_processor.sources.google_keep_source._run_gws")
+    def test_download_empty_text_falls_back_to_raw(self, mock_run, tmp_path):
+        from video_processor.sources.google_keep_source import GoogleKeepSource
+
+        mock_run.return_value = {"raw": "unstructured content"}
+        f = SourceFile(name="Raw", id="n1")
+        dest = tmp_path / "raw.txt"
+
+        GoogleKeepSource().download(f, dest)
+
+        assert dest.read_text() == "unstructured content"
+
+    @patch("video_processor.sources.google_keep_source._run_gws")
+    def test_download_empty_text_falls_back_to_json(self, mock_run, tmp_path):
+        from video_processor.sources.google_keep_source import GoogleKeepSource
+
+        mock_run.return_value = {"unexpected": "shape"}
+        f = SourceFile(name="Odd", id="n1")
+        dest = tmp_path / "odd.txt"
+
+        GoogleKeepSource().download(f, dest)
+
+        # No extractable text and no raw key => JSON dump of the note.
+        assert "unexpected" in dest.read_text()
+
+    @patch("video_processor.sources.google_keep_source._run_gws")
+    def test_download_non_dict_result(self, mock_run, tmp_path):
+        from video_processor.sources.google_keep_source import GoogleKeepSource
+
+        mock_run.return_value = ["not", "a", "dict"]
+        f = SourceFile(name="Listy", id="n1")
+        dest = tmp_path / "listy.txt"
+
+        GoogleKeepSource().download(f, dest)
+
+        # Non-dict result => note treated as {} => JSON dump "{}".
+        assert dest.read_text() == "{}"

--- a/tests/test_m365_source.py
+++ b/tests/test_m365_source.py
@@ -1,0 +1,438 @@
+"""Tests for the Microsoft 365 (SharePoint/OneDrive) source connector.
+
+These modules talk to Microsoft Graph through the `m365` CLI (cli-microsoft365)
+via ``subprocess``, not the ``requests`` library. The real boundary is therefore
+``_run_m365`` (and ``subprocess.run`` inside it) plus ``shutil.which`` for auth —
+those are the only things mocked here. The filesystem is exercised for real via
+``tmp_path`` and injected fake extraction libraries run the real mapping code.
+"""
+
+import json
+import subprocess
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_processor.sources.base import SourceFile
+from video_processor.sources.m365_source import (
+    M365Source,
+    _extract_text,
+    _result_to_source_file,
+    _run_m365,
+)
+
+M365 = "video_processor.sources.m365_source"
+
+
+class TestRunM365:
+    @patch(f"{M365}.subprocess.run")
+    def test_returns_parsed_json(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout='{"connectedAs": "user@contoso.com"}', stderr=""
+        )
+        result = _run_m365(["status"], timeout=42)
+        assert result == {"connectedAs": "user@contoso.com"}
+        # Command is built as: m365 <args> --output json
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "m365"
+        assert cmd[1] == "status"
+        assert cmd[-2:] == ["--output", "json"]
+        # The timeout is forwarded to subprocess.run
+        assert mock_run.call_args.kwargs["timeout"] == 42
+
+    @patch(f"{M365}.subprocess.run")
+    def test_returns_stripped_string_on_non_json(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="  not-json output  ", stderr="")
+        result = _run_m365(["status"])
+        assert result == "not-json output"
+
+    @patch(f"{M365}.subprocess.run")
+    def test_raises_runtimeerror_on_failure(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="  login required  ")
+        with pytest.raises(RuntimeError, match="login required"):
+            _run_m365(["spo", "file", "list"])
+
+
+class TestM365Constructor:
+    def test_defaults(self):
+        src = M365Source(web_url="https://contoso.sharepoint.com/sites/proj")
+        assert src.web_url == "https://contoso.sharepoint.com/sites/proj"
+        assert src.folder_url is None
+        assert src.file_ids == []
+        assert src.recursive is False
+
+    def test_with_options(self):
+        src = M365Source(
+            web_url="https://contoso.sharepoint.com",
+            folder_url="/sites/proj/docs",
+            file_ids=["a", "b"],
+            recursive=True,
+        )
+        assert src.folder_url == "/sites/proj/docs"
+        assert src.file_ids == ["a", "b"]
+        assert src.recursive is True
+
+
+class TestM365Authenticate:
+    @patch(f"{M365}.shutil.which", return_value=None)
+    def test_cli_not_installed(self, _which):
+        src = M365Source(web_url="https://contoso.sharepoint.com")
+        assert src.authenticate() is False
+
+    @patch(f"{M365}._run_m365")
+    @patch(f"{M365}.shutil.which", return_value="/usr/local/bin/m365")
+    def test_connected_dict(self, _which, mock_run):
+        mock_run.return_value = {"connectedAs": "user@contoso.com"}
+        assert M365Source(web_url="https://x.sharepoint.com").authenticate() is True
+
+    @patch(f"{M365}._run_m365")
+    @patch(f"{M365}.shutil.which", return_value="/usr/local/bin/m365")
+    def test_logged_in_string(self, _which, mock_run):
+        mock_run.return_value = "Logged in to contoso"
+        assert M365Source(web_url="https://x.sharepoint.com").authenticate() is True
+
+    @patch(f"{M365}._run_m365")
+    @patch(f"{M365}.shutil.which", return_value="/usr/local/bin/m365")
+    def test_not_logged_in(self, _which, mock_run):
+        mock_run.return_value = {}
+        assert M365Source(web_url="https://x.sharepoint.com").authenticate() is False
+
+    @patch(f"{M365}._run_m365")
+    @patch(f"{M365}.shutil.which", return_value="/usr/local/bin/m365")
+    def test_runtime_error_returns_false(self, _which, mock_run):
+        mock_run.side_effect = RuntimeError("status failed")
+        assert M365Source(web_url="https://x.sharepoint.com").authenticate() is False
+
+    @patch(f"{M365}._run_m365")
+    @patch(f"{M365}.shutil.which", return_value="/usr/local/bin/m365")
+    def test_timeout_returns_false(self, _which, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired("m365", 10)
+        assert M365Source(web_url="https://x.sharepoint.com").authenticate() is False
+
+
+class TestM365ListVideos:
+    @patch(f"{M365}._run_m365")
+    def test_by_file_ids(self, mock_run):
+        mock_run.return_value = {
+            "Name": "report.pdf",
+            "UniqueId": "uid-1",
+            "Length": "50000",
+            "ServerRelativeUrl": "/sites/proj/report.pdf",
+        }
+        src = M365Source(web_url="https://x.sharepoint.com", file_ids=["uid-1"])
+        files = src.list_videos()
+        assert len(files) == 1
+        assert files[0].name == "report.pdf"
+        assert files[0].id == "uid-1"
+        assert files[0].path == "/sites/proj/report.pdf"
+        args = mock_run.call_args[0][0]
+        assert "spo" in args and "file" in args and "get" in args
+        assert "--id" in args and "uid-1" in args
+
+    @patch(f"{M365}._run_m365")
+    def test_file_ids_error_is_skipped(self, mock_run):
+        mock_run.side_effect = [
+            RuntimeError("not found"),
+            {"Name": "ok.docx", "UniqueId": "uid-2", "ServerRelativeUrl": "/f/ok.docx"},
+        ]
+        src = M365Source(web_url="https://x.sharepoint.com", file_ids=["bad", "uid-2"])
+        files = src.list_videos()
+        assert len(files) == 1
+        assert files[0].name == "ok.docx"
+
+    def test_no_folder_returns_empty(self):
+        src = M365Source(web_url="https://x.sharepoint.com")
+        assert src.list_videos() == []
+
+    @patch(f"{M365}._run_m365")
+    def test_folder_listing_filters_by_extension(self, mock_run):
+        mock_run.return_value = [
+            {"Name": "spec.docx", "UniqueId": "1", "ServerRelativeUrl": "/f/spec.docx"},
+            {"Name": "photo.png", "UniqueId": "2", "ServerRelativeUrl": "/f/photo.png"},
+            {"Name": "data.csv", "UniqueId": "3", "ServerRelativeUrl": "/f/data.csv"},
+        ]
+        src = M365Source(web_url="https://x.sharepoint.com", folder_url="/f")
+        files = src.list_videos()
+        # .png is not a document extension and is dropped.
+        assert [f.name for f in files] == ["spec.docx", "data.csv"]
+
+    @patch(f"{M365}._run_m365")
+    def test_folder_path_argument_overrides_none(self, mock_run):
+        mock_run.return_value = []
+        src = M365Source(web_url="https://x.sharepoint.com")  # no folder_url
+        src.list_videos(folder_path="/passed/folder")
+        args = mock_run.call_args[0][0]
+        assert "--folderUrl" in args
+        assert "/passed/folder" in args
+
+    @patch(f"{M365}._run_m365")
+    def test_recursive_flag_added(self, mock_run):
+        mock_run.return_value = []
+        src = M365Source(web_url="https://x.sharepoint.com", folder_url="/f", recursive=True)
+        src.list_videos()
+        assert "--recursive" in mock_run.call_args[0][0]
+
+    @patch(f"{M365}._run_m365")
+    def test_non_list_result_yields_no_files(self, mock_run):
+        mock_run.return_value = {"unexpected": "shape"}
+        src = M365Source(web_url="https://x.sharepoint.com", folder_url="/f")
+        assert src.list_videos() == []
+
+    @patch(f"{M365}._run_m365")
+    def test_listing_error_returns_empty(self, mock_run):
+        mock_run.side_effect = RuntimeError("list boom")
+        src = M365Source(web_url="https://x.sharepoint.com", folder_url="/f")
+        assert src.list_videos() == []
+
+
+class TestM365Download:
+    @patch(f"{M365}._run_m365")
+    def test_download_with_url(self, mock_run, tmp_path):
+        src = M365Source(web_url="https://x.sharepoint.com")
+        f = SourceFile(name="doc.docx", id="uid-1", path="/f/doc.docx")
+        dest = tmp_path / "nested" / "doc.docx"
+        result = src.download(f, dest)
+        assert result == dest
+        # download() really creates the parent directory (fs not mocked).
+        assert dest.parent.is_dir()
+        args = mock_run.call_args[0][0]
+        assert "--url" in args and "/f/doc.docx" in args
+        assert "--path" in args and str(dest) in args
+        assert "--id" not in args
+
+    @patch(f"{M365}._run_m365")
+    def test_download_with_id(self, mock_run, tmp_path):
+        src = M365Source(web_url="https://x.sharepoint.com")
+        f = SourceFile(name="doc.docx", id="uid-9")  # no path field
+        dest = tmp_path / "doc.docx"
+        src.download(f, dest)
+        args = mock_run.call_args[0][0]
+        assert "--id" in args and "uid-9" in args
+        assert "--url" not in args
+
+
+class TestM365DownloadAsText:
+    @patch(f"{M365}._run_m365")
+    def test_text_ext_returns_string(self, mock_run):
+        mock_run.return_value = "line one\nline two"
+        src = M365Source(web_url="https://x.sharepoint.com")
+        f = SourceFile(name="notes.txt", id="1", path="/f/notes.txt")
+        assert src.download_as_text(f) == "line one\nline two"
+        args = mock_run.call_args[0][0]
+        assert "--asString" in args and "--url" in args
+
+    @patch(f"{M365}._run_m365")
+    def test_text_ext_dict_result_is_json_dumped(self, mock_run):
+        mock_run.return_value = {"key": "value"}
+        src = M365Source(web_url="https://x.sharepoint.com")
+        f = SourceFile(name="data.csv", id="1")  # no path -> falls back to --id
+        result = src.download_as_text(f)
+        assert result == json.dumps({"key": "value"})
+        assert "--id" in mock_run.call_args[0][0]
+
+    @patch(f"{M365}._run_m365")
+    def test_text_ext_error_falls_back_to_binary_download(self, mock_run):
+        # First call (--asString) fails; the fallback download writes the file.
+        def fake(args, timeout=30):
+            if "--asString" in args:
+                raise RuntimeError("asString unsupported")
+            path = args[args.index("--path") + 1]
+            Path(path).write_text("recovered body text")
+            return None
+
+        mock_run.side_effect = fake
+        src = M365Source(web_url="https://x.sharepoint.com")
+        f = SourceFile(name="notes.txt", id="1", path="/f/notes.txt")
+        assert src.download_as_text(f) == "recovered body text"
+
+    @patch(f"{M365}._run_m365")
+    def test_binary_ext_uses_temp_and_extractor(self, mock_run):
+        mock_run.return_value = None
+        src = M365Source(web_url="https://x.sharepoint.com")
+        # .pptx skips the text branch; _extract_text has no pptx handler.
+        f = SourceFile(name="deck.pptx", id="1", path="/f/deck.pptx")
+        result = src.download_as_text(f)
+        assert "Unsupported format" in result
+
+
+class TestM365FetchAllTextAndCollate:
+    @patch(f"{M365}._run_m365")
+    def test_fetch_all_text_happy(self, mock_run):
+        mock_run.side_effect = [
+            # list_videos folder listing
+            [{"Name": "a.txt", "UniqueId": "1", "ServerRelativeUrl": "/f/a.txt"}],
+            # download_as_text (--asString) for a.txt
+            "content of A",
+        ]
+        src = M365Source(web_url="https://x.sharepoint.com", folder_url="/f")
+        assert src.fetch_all_text() == {"a.txt": "content of A"}
+
+    def test_fetch_all_text_captures_errors(self):
+        src = M365Source(web_url="https://x.sharepoint.com", folder_url="/f")
+        f = SourceFile(name="broken.txt", id="1")
+        with (
+            patch.object(src, "list_videos", return_value=[f]),
+            patch.object(src, "download_as_text", side_effect=Exception("kaboom")),
+        ):
+            result = src.fetch_all_text()
+        assert result == {"broken.txt": "[Error: kaboom]"}
+
+    def test_collate_joins_documents(self):
+        src = M365Source(web_url="https://x.sharepoint.com")
+        with patch.object(src, "fetch_all_text", return_value={"a.txt": "AAA", "b.md": "BBB"}):
+            result = src.collate(separator="\n===\n")
+        assert "# a.txt\n\nAAA" in result
+        assert "# b.md\n\nBBB" in result
+        assert "\n===\n" in result
+
+
+class TestResultToSourceFile:
+    def test_sharepoint_pascalcase(self):
+        sf = _result_to_source_file(
+            {
+                "Name": "spec.docx",
+                "UniqueId": "uid-1",
+                "Length": "2048",
+                "ServerRelativeUrl": "/f/spec.docx",
+                "TimeLastModified": "2026-01-01T00:00:00Z",
+            }
+        )
+        assert sf.name == "spec.docx"
+        assert sf.id == "uid-1"
+        assert sf.size_bytes == 2048
+        assert sf.path == "/f/spec.docx"
+        assert sf.modified_at == "2026-01-01T00:00:00Z"
+        assert sf.mime_type is None
+
+    def test_graph_camelcase(self):
+        sf = _result_to_source_file(
+            {
+                "name": "notes.md",
+                "uniqueId": "gid-2",
+                "length": "512",
+                "serverRelativeUrl": "/f/notes.md",
+                "lastModifiedDateTime": "2026-02-02",
+            }
+        )
+        assert sf.name == "notes.md"
+        assert sf.id == "gid-2"
+        assert sf.size_bytes == 512
+        assert sf.path == "/f/notes.md"
+        assert sf.modified_at == "2026-02-02"
+
+    def test_id_and_size_third_fallbacks(self):
+        sf = _result_to_source_file({"id": "plain-id", "size": 100})
+        assert sf.id == "plain-id"
+        assert sf.size_bytes == 100
+
+    def test_missing_fields_use_defaults(self):
+        sf = _result_to_source_file({})
+        assert sf.name == "Untitled"
+        assert sf.id == ""
+        assert sf.size_bytes is None
+        assert sf.path is None
+
+
+class TestExtractText:
+    def test_txt(self, tmp_path):
+        f = tmp_path / "a.txt"
+        f.write_text("plain text body")
+        assert _extract_text(f) == "plain text body"
+
+    def test_md(self, tmp_path):
+        f = tmp_path / "a.md"
+        f.write_text("# Heading\n\nsome body")
+        result = _extract_text(f)
+        assert "# Heading" in result
+        assert "some body" in result
+
+    def test_csv(self, tmp_path):
+        f = tmp_path / "a.csv"
+        f.write_text("a,b,c\n1,2,3")
+        assert "a,b,c" in _extract_text(f)
+
+    def test_html_strips_tags(self, tmp_path):
+        f = tmp_path / "a.html"
+        f.write_text("<html><body><p>Hello <b>World</b></p></body></html>")
+        result = _extract_text(f)
+        assert "Hello" in result and "World" in result
+        assert "<p>" not in result
+
+    def test_pdf_missing_dependency(self, tmp_path):
+        f = tmp_path / "a.pdf"
+        f.write_bytes(b"%PDF-fake")
+        # Force the ImportError branch even though pymupdf is installed.
+        with patch.dict(sys.modules, {"fitz": None}):
+            result = _extract_text(f)
+        assert "install pymupdf" in result
+
+    def test_pdf_extracts_with_fake_fitz(self, tmp_path):
+        f = tmp_path / "a.pdf"
+        f.write_bytes(b"%PDF-fake")
+        page1 = MagicMock()
+        page1.get_text.return_value = "Page one text"
+        page2 = MagicMock()
+        page2.get_text.return_value = "Page two text"
+        fake_fitz = types.ModuleType("fitz")
+        fake_fitz.open = MagicMock(return_value=[page1, page2])
+        with patch.dict(sys.modules, {"fitz": fake_fitz}):
+            result = _extract_text(f)
+        assert "Page one text" in result
+        assert "Page two text" in result
+        fake_fitz.open.assert_called_once_with(str(f))
+
+    def test_docx_missing_dependency(self, tmp_path):
+        f = tmp_path / "a.docx"
+        f.write_bytes(b"PK\x03\x04")
+        result = _extract_text(f)  # python-docx is not installed
+        assert "install python-docx" in result
+
+    def test_docx_extracts_with_fake_lib(self, tmp_path):
+        f = tmp_path / "a.docx"
+        f.write_bytes(b"PK\x03\x04")
+        para1 = MagicMock(text="First para")
+        para_blank = MagicMock(text="   ")
+        para2 = MagicMock(text="Second para")
+        fake_doc = MagicMock(paragraphs=[para1, para_blank, para2])
+        fake_docx = types.ModuleType("docx")
+        fake_docx.Document = MagicMock(return_value=fake_doc)
+        with patch.dict(sys.modules, {"docx": fake_docx}):
+            result = _extract_text(f)
+        # Whitespace-only paragraph is filtered out.
+        assert result == "First para\n\nSecond para"
+
+    def test_xlsx_missing_dependency(self, tmp_path):
+        f = tmp_path / "a.xlsx"
+        f.write_bytes(b"PK\x03\x04")
+        result = _extract_text(f)  # openpyxl is not installed
+        assert "install python-docx/openpyxl" in result
+
+    def test_xlsx_extracts_with_fake_lib(self, tmp_path):
+        f = tmp_path / "a.xlsx"
+        f.write_bytes(b"PK\x03\x04")
+        ws = MagicMock()
+        ws.iter_rows.return_value = [("Name", "Score"), ("Alice", 10), (None, None)]
+        fake_wb = MagicMock()
+        fake_wb.sheetnames = ["Sheet1"]
+        fake_wb.__getitem__.return_value = ws
+        fake_openpyxl = types.ModuleType("openpyxl")
+        fake_openpyxl.load_workbook = MagicMock(return_value=fake_wb)
+        with patch.dict(sys.modules, {"openpyxl": fake_openpyxl}):
+            result = _extract_text(f)
+        assert "Name\tScore" in result
+        assert "Alice\t10" in result
+        # The all-empty row is skipped entirely.
+        assert result == "Name\tScore\nAlice\t10"
+
+    def test_pptx_is_unsupported(self, tmp_path):
+        f = tmp_path / "a.pptx"
+        f.write_bytes(b"PK\x03\x04")
+        assert "Unsupported format" in _extract_text(f)
+
+    def test_unknown_extension_is_unsupported(self, tmp_path):
+        f = tmp_path / "a.xyz"
+        f.write_bytes(b"stuff")
+        assert "Unsupported format" in _extract_text(f)

--- a/tests/test_meet_source.py
+++ b/tests/test_meet_source.py
@@ -1,0 +1,240 @@
+"""Tests for the Google Meet recording source.
+
+The Meet source shells out to the ``gws`` CLI via ``_run_gws`` (imported into the
+module namespace) and probes ``shutil.which``. Those are the external boundaries,
+so they are the only things patched. Downloads are written to real ``tmp_path``
+files and read back.
+"""
+
+import json
+import subprocess
+from unittest.mock import patch
+
+from video_processor.sources.base import SourceFile
+from video_processor.sources.meet_recording_source import MeetRecordingSource
+
+_RUN_GWS = "video_processor.sources.meet_recording_source._run_gws"
+
+
+class TestMeetConstruction:
+    def test_defaults(self):
+        src = MeetRecordingSource()
+        assert src.drive_folder_id is None
+
+    def test_with_folder(self):
+        src = MeetRecordingSource(drive_folder_id="folder123")
+        assert src.drive_folder_id == "folder123"
+
+
+class TestMeetAuthenticate:
+    @patch("shutil.which", return_value=None)
+    def test_no_gws_cli_returns_false(self, _mock_which):
+        src = MeetRecordingSource()
+        assert src.authenticate() is False
+
+    @patch(_RUN_GWS)
+    @patch("shutil.which", return_value="/usr/local/bin/gws")
+    def test_success(self, _mock_which, mock_run):
+        mock_run.return_value = {"connectedAs": "me@example.com"}
+        src = MeetRecordingSource()
+        assert src.authenticate() is True
+        assert mock_run.call_args.args[0] == ["auth", "status"]
+
+    @patch(_RUN_GWS, side_effect=RuntimeError("not logged in"))
+    @patch("shutil.which", return_value="/usr/local/bin/gws")
+    def test_runtime_error_returns_false(self, _mock_which, _mock_run):
+        src = MeetRecordingSource()
+        assert src.authenticate() is False
+
+    @patch(_RUN_GWS, side_effect=subprocess.TimeoutExpired(cmd="gws", timeout=10))
+    @patch("shutil.which", return_value="/usr/local/bin/gws")
+    def test_timeout_returns_false(self, _mock_which, _mock_run):
+        src = MeetRecordingSource()
+        assert src.authenticate() is False
+
+
+class TestMeetListVideos:
+    @patch(_RUN_GWS)
+    def test_success_with_constructor_folder(self, mock_run):
+        mock_run.side_effect = [
+            {
+                "files": [
+                    {
+                        "id": "r1",
+                        "name": "Meet Recording 2026-03-07",
+                        "mimeType": "video/mp4",
+                        "size": "2048",
+                        "modifiedTime": "2026-03-07T00:00:00Z",
+                    },
+                    {"id": "r2", "name": "Meet Recording 2026-03-08"},
+                ]
+            },
+            {"files": [{"id": "t1", "name": "Transcript 2026-03-07"}]},
+        ]
+        src = MeetRecordingSource(drive_folder_id="folderX")
+        files = src.list_videos()
+        assert len(files) == 2
+        assert files[0].id == "r1"
+        assert files[0].name == "Meet Recording 2026-03-07"
+        assert files[0].size_bytes == 2048
+        assert files[0].mime_type == "video/mp4"
+        assert files[0].modified_at == "2026-03-07T00:00:00Z"
+        assert files[1].size_bytes is None
+        assert files[1].mime_type == "video/mp4"
+        params = json.loads(mock_run.call_args_list[0].args[0][4])
+        assert "'folderX' in parents" in params["q"]
+
+    @patch(_RUN_GWS)
+    def test_success_with_folder_param(self, mock_run):
+        mock_run.side_effect = [
+            {"files": [{"id": "r1", "name": "Meet Recording 2026-03-07"}]},
+            {"files": []},
+        ]
+        src = MeetRecordingSource()
+        files = src.list_videos(folder_id="paramFolder")
+        assert len(files) == 1
+        params = json.loads(mock_run.call_args_list[0].args[0][4])
+        assert "'paramFolder' in parents" in params["q"]
+
+    @patch(_RUN_GWS, side_effect=RuntimeError("drive down"))
+    def test_recordings_query_error_returns_empty(self, mock_run):
+        src = MeetRecordingSource()
+        assert src.list_videos() == []
+        assert mock_run.call_count == 1
+
+    @patch(_RUN_GWS)
+    def test_transcript_query_error_still_returns_recordings(self, mock_run):
+        mock_run.side_effect = [
+            {"files": [{"id": "r1", "name": "Meet Recording 2026-03-07"}]},
+            RuntimeError("transcript query failed"),
+        ]
+        src = MeetRecordingSource()
+        files = src.list_videos()
+        assert len(files) == 1
+        assert mock_run.call_count == 2
+
+    @patch(_RUN_GWS)
+    def test_no_recordings_found_returns_empty(self, mock_run):
+        mock_run.side_effect = [{"files": []}, {"files": []}]
+        src = MeetRecordingSource()
+        assert src.list_videos() == []
+
+
+class TestMeetDownload:
+    @patch(_RUN_GWS)
+    def test_success_dict_raw(self, mock_run, tmp_path):
+        mock_run.return_value = {"raw": "video-content"}
+        src = MeetRecordingSource()
+        f = SourceFile(name="rec.mp4", id="r1")
+        dest = tmp_path / "sub" / "rec.mp4"
+        result = src.download(f, dest)
+        assert result == dest
+        assert dest.read_text() == "video-content"
+        params = json.loads(mock_run.call_args.args[0][4])
+        assert params["fileId"] == "r1"
+        assert params["alt"] == "media"
+
+    @patch(_RUN_GWS)
+    def test_non_dict_result_is_stringified(self, mock_run, tmp_path):
+        mock_run.return_value = "plain-content"
+        src = MeetRecordingSource()
+        f = SourceFile(name="rec.mp4", id="r1")
+        dest = tmp_path / "rec.mp4"
+        src.download(f, dest)
+        assert dest.read_text() == "plain-content"
+
+    @patch(_RUN_GWS)
+    def test_dict_without_raw_writes_empty(self, mock_run, tmp_path):
+        mock_run.return_value = {"unexpected": "x"}
+        src = MeetRecordingSource()
+        f = SourceFile(name="rec.mp4", id="r1")
+        dest = tmp_path / "rec.mp4"
+        src.download(f, dest)
+        assert dest.read_text() == ""
+
+
+class TestMeetFetchTranscript:
+    @patch(_RUN_GWS)
+    def test_success_extracts_text(self, mock_run):
+        mock_run.side_effect = [
+            {"files": [{"id": "doc1", "name": "Transcript 2026-03-07"}]},
+            {
+                "body": {
+                    "content": [
+                        {"paragraph": {"elements": [{"textRun": {"content": "Hello world\n"}}]}},
+                        {"paragraph": {"elements": [{"textRun": {"content": "Second line\n"}}]}},
+                    ]
+                }
+            },
+        ]
+        src = MeetRecordingSource()
+        text = src.fetch_transcript("Meet Recording 2026-03-07")
+        assert text == "Hello world\nSecond line\n"
+        assert mock_run.call_count == 2
+
+    @patch(_RUN_GWS)
+    def test_no_matching_transcript_returns_none(self, mock_run):
+        mock_run.side_effect = [{"files": []}]
+        src = MeetRecordingSource()
+        assert src.fetch_transcript("Meet Recording 2026-03-07") is None
+        assert mock_run.call_count == 1
+
+    @patch(_RUN_GWS, side_effect=RuntimeError("search failed"))
+    def test_find_transcript_error_returns_none(self, _mock_run):
+        src = MeetRecordingSource()
+        assert src.fetch_transcript("Meet Recording 2026-03-07") is None
+
+    @patch(_RUN_GWS)
+    def test_docs_fetch_error_returns_none(self, mock_run):
+        mock_run.side_effect = [
+            {"files": [{"id": "doc1", "name": "Transcript 2026-03-07"}]},
+            RuntimeError("docs api down"),
+        ]
+        src = MeetRecordingSource()
+        assert src.fetch_transcript("Meet Recording 2026-03-07") is None
+
+    @patch(_RUN_GWS)
+    def test_no_extractable_text_returns_none(self, mock_run):
+        mock_run.side_effect = [
+            {"files": [{"id": "doc1", "name": "Transcript 2026-03-07"}]},
+            {
+                "body": {
+                    "content": [
+                        {"paragraph": {"elements": [{"textRun": {"content": "   \n"}}]}},
+                    ]
+                }
+            },
+        ]
+        src = MeetRecordingSource()
+        assert src.fetch_transcript("Meet Recording 2026-03-07") is None
+
+
+class TestMeetFindMatchingTranscript:
+    @patch(_RUN_GWS)
+    def test_match_returns_id_and_uses_date(self, mock_run):
+        mock_run.return_value = {"files": [{"id": "doc9", "name": "T"}]}
+        src = MeetRecordingSource()
+        assert src._find_matching_transcript("Meet Recording 2026-03-07") == "doc9"
+        query = json.loads(mock_run.call_args.args[0][4])["q"]
+        assert "2026-03-07" in query
+
+    @patch(_RUN_GWS)
+    def test_no_date_falls_back_to_full_name(self, mock_run):
+        mock_run.return_value = {"files": []}
+        src = MeetRecordingSource()
+        assert src._find_matching_transcript("NoDateRecording") is None
+        query = json.loads(mock_run.call_args.args[0][4])["q"]
+        assert "NoDateRecording" in query
+
+    @patch(_RUN_GWS, side_effect=RuntimeError("boom"))
+    def test_runtime_error_returns_none(self, _mock_run):
+        src = MeetRecordingSource()
+        assert src._find_matching_transcript("2026-03-07") is None
+
+    @patch(_RUN_GWS)
+    def test_folder_id_scopes_query(self, mock_run):
+        mock_run.return_value = {"files": [{"id": "doc1", "name": "T"}]}
+        src = MeetRecordingSource(drive_folder_id="FID")
+        src._find_matching_transcript("2026-03-07")
+        query = json.loads(mock_run.call_args.args[0][4])["q"]
+        assert "'FID' in parents" in query

--- a/tests/test_notion_source.py
+++ b/tests/test_notion_source.py
@@ -1,0 +1,589 @@
+"""Tests for the Notion API source connector.
+
+Covers the pure markdown/property helpers plus the HTTP-backed methods.
+The real ``requests`` module (and its exception classes) is left intact so
+that ``except requests.RequestException`` still catches; only the ``get`` /
+``post`` attributes on the module are patched.
+"""
+
+import logging
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from video_processor.sources.base import SourceFile
+from video_processor.sources.notion_source import (
+    NOTION_VERSION,
+    NotionSource,
+    _extract_page_title,
+    _extract_property_value,
+    _rich_text_to_str,
+)
+
+# ---------------------------------------------------------------------------
+# _rich_text_to_str
+# ---------------------------------------------------------------------------
+
+
+class TestRichTextToStr:
+    def test_joins_plain_text(self):
+        rich = [{"plain_text": "Hello "}, {"plain_text": "World"}]
+        assert _rich_text_to_str(rich) == "Hello World"
+
+    def test_empty_list(self):
+        assert _rich_text_to_str([]) == ""
+
+    def test_missing_plain_text_key(self):
+        rich = [{"annotations": {}}, {"plain_text": "kept"}]
+        assert _rich_text_to_str(rich) == "kept"
+
+
+# ---------------------------------------------------------------------------
+# _extract_page_title
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPageTitle:
+    def test_title_present(self):
+        page = {"properties": {"Name": {"type": "title", "title": [{"plain_text": "My Page"}]}}}
+        assert _extract_page_title(page) == "My Page"
+
+    def test_untitled_fallback_when_no_title_prop(self):
+        page = {
+            "properties": {
+                "Tags": {"type": "multi_select", "multi_select": []},
+            }
+        }
+        assert _extract_page_title(page) == "Untitled"
+
+    def test_untitled_fallback_when_no_properties(self):
+        assert _extract_page_title({}) == "Untitled"
+
+
+# ---------------------------------------------------------------------------
+# _extract_property_value — one assertion per property type branch
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPropertyValue:
+    def test_title(self):
+        prop = {"type": "title", "title": [{"plain_text": "The Title"}]}
+        assert _extract_property_value(prop) == "The Title"
+
+    def test_rich_text(self):
+        prop = {"type": "rich_text", "rich_text": [{"plain_text": "some text"}]}
+        assert _extract_property_value(prop) == "some text"
+
+    def test_number(self):
+        assert _extract_property_value({"type": "number", "number": 42}) == "42"
+
+    def test_number_none(self):
+        assert _extract_property_value({"type": "number", "number": None}) == ""
+
+    def test_select(self):
+        prop = {"type": "select", "select": {"name": "Done"}}
+        assert _extract_property_value(prop) == "Done"
+
+    def test_select_none(self):
+        assert _extract_property_value({"type": "select", "select": None}) == ""
+
+    def test_multi_select(self):
+        prop = {
+            "type": "multi_select",
+            "multi_select": [{"name": "alpha"}, {"name": "beta"}],
+        }
+        assert _extract_property_value(prop) == "alpha; beta"
+
+    def test_date_start_only(self):
+        prop = {"type": "date", "date": {"start": "2025-01-01"}}
+        assert _extract_property_value(prop) == "2025-01-01"
+
+    def test_date_with_end(self):
+        prop = {
+            "type": "date",
+            "date": {"start": "2025-01-01", "end": "2025-01-31"},
+        }
+        assert _extract_property_value(prop) == "2025-01-01 - 2025-01-31"
+
+    def test_date_none(self):
+        assert _extract_property_value({"type": "date", "date": None}) == ""
+
+    def test_checkbox_true(self):
+        assert _extract_property_value({"type": "checkbox", "checkbox": True}) == "True"
+
+    def test_checkbox_false(self):
+        prop = {"type": "checkbox", "checkbox": False}
+        assert _extract_property_value(prop) == "False"
+
+    def test_url(self):
+        prop = {"type": "url", "url": "https://example.com"}
+        assert _extract_property_value(prop) == "https://example.com"
+
+    def test_url_none(self):
+        assert _extract_property_value({"type": "url", "url": None}) == ""
+
+    def test_email(self):
+        prop = {"type": "email", "email": "person@example.com"}
+        assert _extract_property_value(prop) == "person@example.com"
+
+    def test_phone_number(self):
+        prop = {"type": "phone_number", "phone_number": "555-1234"}
+        assert _extract_property_value(prop) == "555-1234"
+
+    def test_status(self):
+        prop = {"type": "status", "status": {"name": "In Progress"}}
+        assert _extract_property_value(prop) == "In Progress"
+
+    def test_status_none(self):
+        assert _extract_property_value({"type": "status", "status": None}) == ""
+
+    def test_people(self):
+        prop = {"type": "people", "people": [{"name": "Bob"}, {"name": "Carol"}]}
+        assert _extract_property_value(prop) == "Bob; Carol"
+
+    def test_relation(self):
+        prop = {"type": "relation", "relation": [{"id": "rel-1"}, {"id": "rel-2"}]}
+        assert _extract_property_value(prop) == "rel-1; rel-2"
+
+    def test_formula_string(self):
+        prop = {"type": "formula", "formula": {"type": "string", "string": "computed"}}
+        assert _extract_property_value(prop) == "computed"
+
+    def test_formula_number(self):
+        prop = {"type": "formula", "formula": {"type": "number", "number": 7}}
+        assert _extract_property_value(prop) == "7"
+
+    def test_unknown_type(self):
+        assert _extract_property_value({"type": "button"}) == ""
+
+    def test_empty_prop(self):
+        assert _extract_property_value({}) == ""
+
+
+# ---------------------------------------------------------------------------
+# NotionSource._blocks_to_text
+# ---------------------------------------------------------------------------
+
+
+class TestBlocksToText:
+    def test_common_block_types(self):
+        src = NotionSource(token="tok")
+        blocks = [
+            {"type": "paragraph", "paragraph": {"rich_text": [{"plain_text": "Para"}]}},
+            {"type": "heading_1", "heading_1": {"rich_text": [{"plain_text": "H1"}]}},
+            {"type": "heading_2", "heading_2": {"rich_text": [{"plain_text": "H2"}]}},
+            {"type": "heading_3", "heading_3": {"rich_text": [{"plain_text": "H3"}]}},
+            {
+                "type": "bulleted_list_item",
+                "bulleted_list_item": {"rich_text": [{"plain_text": "Bullet"}]},
+            },
+            {"type": "quote", "quote": {"rich_text": [{"plain_text": "Quoted"}]}},
+            {"type": "toggle", "toggle": {"rich_text": [{"plain_text": "Toggle"}]}},
+            {"type": "divider", "divider": {}},
+        ]
+        result = src._blocks_to_text(blocks)
+        assert "Para" in result
+        assert "# H1" in result
+        assert "## H2" in result
+        assert "### H3" in result
+        assert "- Bullet" in result
+        assert "> Quoted" in result
+        assert "<details><summary>Toggle</summary></details>" in result
+        assert "---" in result
+
+    def test_numbered_list_increments_and_resets(self):
+        src = NotionSource(token="tok")
+        blocks = [
+            {
+                "type": "numbered_list_item",
+                "numbered_list_item": {"rich_text": [{"plain_text": "First"}]},
+            },
+            {
+                "type": "numbered_list_item",
+                "numbered_list_item": {"rich_text": [{"plain_text": "Second"}]},
+            },
+            {"type": "paragraph", "paragraph": {"rich_text": [{"plain_text": "Break"}]}},
+            {
+                "type": "numbered_list_item",
+                "numbered_list_item": {"rich_text": [{"plain_text": "Reset"}]},
+            },
+        ]
+        lines = src._blocks_to_text(blocks).split("\n\n")
+        assert lines == ["1. First", "2. Second", "Break", "1. Reset"]
+
+    def test_to_do_checked_and_unchecked(self):
+        src = NotionSource(token="tok")
+        blocks = [
+            {
+                "type": "to_do",
+                "to_do": {"rich_text": [{"plain_text": "Done task"}], "checked": True},
+            },
+            {
+                "type": "to_do",
+                "to_do": {"rich_text": [{"plain_text": "Pending task"}]},
+            },
+        ]
+        result = src._blocks_to_text(blocks)
+        assert "- [x] Done task" in result
+        assert "- [ ] Pending task" in result
+
+    def test_code_block_with_language(self):
+        src = NotionSource(token="tok")
+        blocks = [
+            {
+                "type": "code",
+                "code": {
+                    "rich_text": [{"plain_text": "print('hi')"}],
+                    "language": "python",
+                },
+            }
+        ]
+        result = src._blocks_to_text(blocks)
+        assert "```python" in result
+        assert "print('hi')" in result
+        # opening fence + closing fence
+        assert result.count("```") == 2
+
+    def test_callout_with_emoji(self):
+        src = NotionSource(token="tok")
+        blocks = [
+            {
+                "type": "callout",
+                "callout": {
+                    "rich_text": [{"plain_text": "Heads up"}],
+                    "icon": {"emoji": "\N{ELECTRIC LIGHT BULB}"},
+                },
+            }
+        ]
+        result = src._blocks_to_text(blocks)
+        assert result == "> \N{ELECTRIC LIGHT BULB} Heads up"
+
+    def test_callout_without_emoji(self):
+        src = NotionSource(token="tok")
+        blocks = [
+            {
+                "type": "callout",
+                "callout": {"rich_text": [{"plain_text": "Plain callout"}]},
+            }
+        ]
+        result = src._blocks_to_text(blocks)
+        assert result == "> Plain callout"
+
+    def test_unknown_block_with_rich_text(self):
+        src = NotionSource(token="tok")
+        blocks = [{"type": "image", "image": {"rich_text": [{"plain_text": "caption text"}]}}]
+        assert src._blocks_to_text(blocks) == "caption text"
+
+    def test_unknown_block_without_text_is_dropped(self):
+        src = NotionSource(token="tok")
+        blocks = [{"type": "image", "image": {}}]
+        assert src._blocks_to_text(blocks) == ""
+
+    def test_empty_block_list(self):
+        src = NotionSource(token="tok")
+        assert src._blocks_to_text([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# NotionSource construction + headers
+# ---------------------------------------------------------------------------
+
+
+class TestNotionSourceInit:
+    def test_explicit_arguments(self):
+        src = NotionSource(token="tok", database_id="db-1", page_ids=["p1", "p2"])
+        assert src.token == "tok"
+        assert src.database_id == "db-1"
+        assert src.page_ids == ["p1", "p2"]
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_defaults_without_env(self):
+        src = NotionSource()
+        assert src.token == ""
+        assert src.database_id is None
+        assert src.page_ids == []
+
+    @patch.dict(os.environ, {"NOTION_API_KEY": "env-token"}, clear=True)
+    def test_token_from_env(self):
+        src = NotionSource()
+        assert src.token == "env-token"
+
+    def test_headers(self):
+        src = NotionSource(token="tok123")
+        headers = src._headers()
+        assert headers["Authorization"] == "Bearer tok123"
+        assert headers["Notion-Version"] == NOTION_VERSION
+        assert headers["Content-Type"] == "application/json"
+
+
+# ---------------------------------------------------------------------------
+# NotionSource.authenticate
+# ---------------------------------------------------------------------------
+
+
+class TestNotionSourceAuthenticate:
+    @patch("video_processor.sources.notion_source.requests.get")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_no_token_returns_false_without_http(self, mock_get):
+        src = NotionSource(token="")
+        assert src.authenticate() is False
+        assert mock_get.call_count == 0
+
+    @patch("video_processor.sources.notion_source.requests.get")
+    def test_success(self, mock_get):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {"name": "Test Bot"}
+        mock_get.return_value = resp
+
+        src = NotionSource(token="tok")
+        assert src.authenticate() is True
+        mock_get.assert_called_once()
+
+    @patch("video_processor.sources.notion_source.requests.get")
+    def test_http_error_returns_false(self, mock_get):
+        resp = MagicMock()
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError("boom")
+        mock_get.return_value = resp
+
+        src = NotionSource(token="tok")
+        assert src.authenticate() is False
+
+
+# ---------------------------------------------------------------------------
+# NotionSource.list_videos
+# ---------------------------------------------------------------------------
+
+
+class TestNotionSourceListVideos:
+    @patch("video_processor.sources.notion_source.requests.post")
+    def test_database_paginates(self, mock_post):
+        page1 = MagicMock()
+        page1.raise_for_status.return_value = None
+        page1.json.return_value = {
+            "results": [
+                {
+                    "id": "p1",
+                    "last_edited_time": "t1",
+                    "properties": {"Name": {"type": "title", "title": [{"plain_text": "First"}]}},
+                }
+            ],
+            "has_more": True,
+            "next_cursor": "cursor-2",
+        }
+        page2 = MagicMock()
+        page2.raise_for_status.return_value = None
+        page2.json.return_value = {
+            "results": [
+                {
+                    "id": "p2",
+                    "last_edited_time": "t2",
+                    "properties": {"Name": {"type": "title", "title": [{"plain_text": "Second"}]}},
+                }
+            ],
+            "has_more": False,
+            "next_cursor": None,
+        }
+        mock_post.side_effect = [page1, page2]
+
+        src = NotionSource(token="tok", database_id="db-1")
+        files = src.list_videos()
+
+        assert len(files) == 2
+        assert files[0].name == "First"
+        assert files[0].id == "p1"
+        assert files[0].mime_type == "text/markdown"
+        assert files[0].modified_at == "t1"
+        assert files[1].name == "Second"
+        assert files[1].id == "p2"
+        assert mock_post.call_count == 2
+        # second page must carry the cursor returned by the first page
+        assert mock_post.call_args_list[1].kwargs["json"] == {"start_cursor": "cursor-2"}
+
+    @patch("video_processor.sources.notion_source.requests.get")
+    def test_from_page_ids(self, mock_get):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = {
+            "id": "page-9",
+            "last_edited_time": "t9",
+            "properties": {"Title": {"type": "title", "title": [{"plain_text": "Page Nine"}]}},
+        }
+        mock_get.return_value = resp
+
+        src = NotionSource(token="tok", page_ids=["page-9"])
+        files = src.list_videos()
+
+        assert len(files) == 1
+        assert files[0].name == "Page Nine"
+        assert files[0].id == "page-9"
+        assert files[0].mime_type == "text/markdown"
+
+    def test_no_source_returns_empty_and_warns(self, caplog):
+        src = NotionSource(token="tok")
+        with caplog.at_level(logging.WARNING):
+            files = src.list_videos()
+        assert files == []
+        assert any("No pages found" in r.getMessage() for r in caplog.records)
+
+    @patch("video_processor.sources.notion_source.requests.get")
+    def test_page_ids_partial_failure(self, mock_get):
+        good = MagicMock()
+        good.raise_for_status.return_value = None
+        good.json.return_value = {
+            "id": "good-1",
+            "last_edited_time": "t",
+            "properties": {"Title": {"type": "title", "title": [{"plain_text": "Good Page"}]}},
+        }
+
+        def side_effect(url, **kwargs):
+            if "bad-1" in url:
+                raise requests.exceptions.ConnectionError("network down")
+            return good
+
+        mock_get.side_effect = side_effect
+
+        src = NotionSource(token="tok", page_ids=["bad-1", "good-1"])
+        files = src.list_videos()
+
+        assert len(files) == 1
+        assert files[0].name == "Good Page"
+        assert files[0].id == "good-1"
+
+    @patch("video_processor.sources.notion_source.requests.post")
+    def test_database_error_propagates(self, mock_post):
+        mock_post.side_effect = requests.exceptions.HTTPError("500")
+        src = NotionSource(token="tok", database_id="db-1")
+        with pytest.raises(requests.exceptions.HTTPError):
+            src.list_videos()
+
+
+# ---------------------------------------------------------------------------
+# NotionSource.download / _fetch_all_blocks
+# ---------------------------------------------------------------------------
+
+
+class TestNotionSourceDownload:
+    def test_download_writes_markdown_file(self, tmp_path):
+        src = NotionSource(token="tok")
+        blocks = [
+            {"type": "heading_1", "heading_1": {"rich_text": [{"plain_text": "Section"}]}},
+            {
+                "type": "paragraph",
+                "paragraph": {"rich_text": [{"plain_text": "Body text."}]},
+            },
+        ]
+        f = SourceFile(name="My Page", id="pg-1", mime_type="text/markdown")
+        # destination parent does not exist yet — download must create it
+        dest = tmp_path / "out" / "page.md"
+
+        with patch.object(src, "_fetch_all_blocks", return_value=blocks) as mock_fetch:
+            result = src.download(f, dest)
+
+        assert result == dest
+        assert dest.exists()
+        content = dest.read_text(encoding="utf-8")
+        assert content.startswith("# My Page")
+        assert "# Section" in content
+        assert "Body text." in content
+        mock_fetch.assert_called_once_with("pg-1")
+
+    @patch("video_processor.sources.notion_source.requests.get")
+    def test_fetch_all_blocks_paginates(self, mock_get):
+        page1 = MagicMock()
+        page1.raise_for_status.return_value = None
+        page1.json.return_value = {
+            "results": [{"type": "paragraph", "paragraph": {"rich_text": [{"plain_text": "A"}]}}],
+            "has_more": True,
+            "next_cursor": "cur-2",
+        }
+        page2 = MagicMock()
+        page2.raise_for_status.return_value = None
+        page2.json.return_value = {
+            "results": [{"type": "paragraph", "paragraph": {"rich_text": [{"plain_text": "B"}]}}],
+            "has_more": False,
+            "next_cursor": None,
+        }
+        mock_get.side_effect = [page1, page2]
+
+        src = NotionSource(token="tok")
+        blocks = src._fetch_all_blocks("pg-1")
+
+        assert len(blocks) == 2
+        assert mock_get.call_count == 2
+        # the second request must carry the cursor from the first page
+        second_url = mock_get.call_args_list[1].args[0]
+        assert "start_cursor=cur-2" in second_url
+
+
+# ---------------------------------------------------------------------------
+# NotionSource.fetch_database_as_table
+# ---------------------------------------------------------------------------
+
+
+class TestFetchDatabaseAsTable:
+    @patch("video_processor.sources.notion_source.requests.post")
+    @patch("video_processor.sources.notion_source.requests.get")
+    def test_builds_sorted_csv_across_pages(self, mock_get, mock_post):
+        schema = MagicMock()
+        schema.raise_for_status.return_value = None
+        schema.json.return_value = {
+            "properties": {
+                "Name": {"type": "title"},
+                "Age": {"type": "number"},
+            }
+        }
+        mock_get.return_value = schema
+
+        page1 = MagicMock()
+        page1.raise_for_status.return_value = None
+        page1.json.return_value = {
+            "results": [
+                {
+                    "properties": {
+                        "Name": {
+                            "type": "title",
+                            "title": [{"plain_text": "Alice"}],
+                        },
+                        "Age": {"type": "number", "number": 30},
+                    }
+                }
+            ],
+            "has_more": True,
+            "next_cursor": "c2",
+        }
+        page2 = MagicMock()
+        page2.raise_for_status.return_value = None
+        page2.json.return_value = {
+            "results": [
+                {
+                    "properties": {
+                        "Name": {"type": "title", "title": [{"plain_text": "Bob"}]},
+                        "Age": {"type": "number", "number": 25},
+                    }
+                },
+                {
+                    # Carol has no Age property — the missing column renders empty
+                    "properties": {
+                        "Name": {"type": "title", "title": [{"plain_text": "Carol"}]},
+                    }
+                },
+            ],
+            "has_more": False,
+            "next_cursor": None,
+        }
+        mock_post.side_effect = [page1, page2]
+
+        src = NotionSource(token="tok")
+        table = src.fetch_database_as_table("db-1")
+        lines = table.split("\n")
+
+        # columns are sorted alphabetically: Age before Name
+        assert lines[0] == "Age,Name"
+        assert lines[1] == "30,Alice"
+        assert lines[2] == "25,Bob"
+        assert lines[3] == ",Carol"
+        assert mock_post.call_count == 2
+        assert mock_post.call_args_list[1].kwargs["json"] == {"start_cursor": "c2"}

--- a/tests/test_onenote_source.py
+++ b/tests/test_onenote_source.py
@@ -1,0 +1,312 @@
+"""Tests for the OneNote source.
+
+NOTE: despite the connector's module docstring, this source does NOT use the
+Microsoft Graph ``requests`` API. It shells out to the ``m365`` CLI
+(cli-microsoft365) via ``subprocess`` and parses its JSON output. These tests
+therefore patch ``subprocess.run`` (for the ``_run_m365`` helper) and the
+``_run_m365`` / ``shutil.which`` module attributes (for higher-level methods);
+the real CLI and network are never touched. Page downloads are written to real
+``tmp_path`` files and asserted against their parsed text content.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_processor.sources.base import SourceFile
+from video_processor.sources.onenote_source import OneNoteSource, _html_to_text, _run_m365
+
+MODULE = "video_processor.sources.onenote_source"
+
+
+class TestRunM365:
+    def test_success_parses_json(self):
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stdout = '{"connectedAs": "user@example.com"}'
+        proc.stderr = ""
+        with patch(f"{MODULE}.subprocess.run", return_value=proc) as run:
+            result = _run_m365(["status"], timeout=10)
+        assert result == {"connectedAs": "user@example.com"}
+        cmd = run.call_args.args[0]
+        assert cmd == ["m365", "status", "--output", "json"]
+        assert run.call_args.kwargs["timeout"] == 10
+
+    def test_non_json_output_returned_as_stripped_text(self):
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stdout = "Logged in as user@example.com\n"
+        proc.stderr = ""
+        with patch(f"{MODULE}.subprocess.run", return_value=proc):
+            result = _run_m365(["status"])
+        assert result == "Logged in as user@example.com"
+
+    def test_nonzero_exit_raises_runtime_error(self):
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.stdout = ""
+        proc.stderr = "  authentication required  "
+        with patch(f"{MODULE}.subprocess.run", return_value=proc):
+            with pytest.raises(RuntimeError, match="authentication required"):
+                _run_m365(["onenote", "notebook", "list"])
+
+
+class TestHtmlToText:
+    def test_strips_script_and_style_blocks(self):
+        html = "<style>p{color:red}</style><script>alert(1)</script>Visible"
+        assert _html_to_text(html) == "Visible"
+
+    def test_block_close_tags_become_newlines(self):
+        assert _html_to_text("<p>alpha</p><p>beta</p>") == "alpha\nbeta"
+
+    def test_br_becomes_newline(self):
+        assert _html_to_text("line1<br>line2<br/>line3") == "line1\nline2\nline3"
+
+    def test_named_entities_decoded(self):
+        assert _html_to_text("Tom &amp; Jerry &lt;3 &quot;x&quot;") == 'Tom & Jerry <3 "x"'
+
+    def test_nbsp_and_apostrophe_entities(self):
+        assert _html_to_text("a&nbsp;b&#39;c&apos;d") == "a b'c'd"
+
+    def test_numeric_entities_decimal_and_hex(self):
+        assert _html_to_text("&#65;&#x42;&#67;") == "ABC"
+
+    def test_inline_tags_stripped(self):
+        assert _html_to_text("<b>bold</b> and <i>italic</i>") == "bold and italic"
+
+    def test_collapses_excess_blank_lines(self):
+        assert _html_to_text("a<br><br><br><br>b") == "a\n\nb"
+
+    def test_realistic_page(self):
+        html = (
+            "<html><head><style>x{}</style></head><body>"
+            "<h1>Meeting Notes</h1>"
+            "<p>Discussed &amp; agreed on the <b>roadmap</b>.</p>"
+            "<div>Action: ship v1</div>"
+            "</body></html>"
+        )
+        text = _html_to_text(html)
+        assert "<" not in text
+        assert ">" not in text
+        assert "Meeting Notes" in text
+        assert "Discussed & agreed on the roadmap." in text
+        assert "Action: ship v1" in text
+
+
+class TestOneNoteInit:
+    def test_defaults(self):
+        source = OneNoteSource()
+        assert source.notebook_name is None
+        assert source.section_name is None
+
+    def test_with_names(self):
+        source = OneNoteSource(notebook_name="Work", section_name="Meetings")
+        assert source.notebook_name == "Work"
+        assert source.section_name == "Meetings"
+
+
+class TestOneNoteAuthenticate:
+    def test_cli_not_installed_returns_false(self):
+        source = OneNoteSource()
+        with patch(f"{MODULE}.shutil.which", return_value=None):
+            assert source.authenticate() is False
+
+    def test_connected_via_dict_status(self):
+        source = OneNoteSource()
+        with patch(f"{MODULE}.shutil.which", return_value="/usr/bin/m365"):
+            with patch(f"{MODULE}._run_m365", return_value={"connectedAs": "user@x.com"}):
+                assert source.authenticate() is True
+
+    def test_connected_via_text_status(self):
+        source = OneNoteSource()
+        with patch(f"{MODULE}.shutil.which", return_value="/usr/bin/m365"):
+            with patch(f"{MODULE}._run_m365", return_value="Logged in as user@x.com"):
+                assert source.authenticate() is True
+
+    def test_not_logged_in_dict_returns_false(self):
+        source = OneNoteSource()
+        with patch(f"{MODULE}.shutil.which", return_value="/usr/bin/m365"):
+            with patch(f"{MODULE}._run_m365", return_value={"foo": "bar"}):
+                assert source.authenticate() is False
+
+    def test_runtime_error_treated_as_not_logged_in(self):
+        source = OneNoteSource()
+        with patch(f"{MODULE}.shutil.which", return_value="/usr/bin/m365"):
+            with patch(f"{MODULE}._run_m365", side_effect=RuntimeError("boom")):
+                assert source.authenticate() is False
+
+    def test_timeout_treated_as_not_logged_in(self):
+        source = OneNoteSource()
+        with patch(f"{MODULE}.shutil.which", return_value="/usr/bin/m365"):
+            with patch(
+                f"{MODULE}._run_m365",
+                side_effect=subprocess.TimeoutExpired(cmd="m365", timeout=10),
+            ):
+                assert source.authenticate() is False
+
+
+class TestOneNoteListVideos:
+    def test_notebook_listing_failure_returns_empty(self):
+        source = OneNoteSource()
+        with patch(f"{MODULE}._run_m365", side_effect=RuntimeError("graph unreachable")):
+            assert source.list_videos() == []
+
+    def test_full_traversal_builds_sourcefiles(self):
+        source = OneNoteSource()
+        responses = [
+            [{"id": "nb1", "displayName": "Work"}],  # notebook list
+            [{"id": "sec1", "displayName": "Meetings"}],  # section list
+            [
+                {
+                    "id": "pg1",
+                    "title": "Standup",
+                    "lastModifiedDateTime": "2025-03-01T09:00:00Z",
+                }
+            ],  # page list
+        ]
+        with patch(f"{MODULE}._run_m365", side_effect=responses):
+            files = source.list_videos()
+        assert len(files) == 1
+        page = files[0]
+        assert page.name == "Standup"
+        assert page.id == "pg1"
+        assert page.mime_type == "text/html"
+        assert page.modified_at == "2025-03-01T09:00:00Z"
+        assert page.size_bytes is None
+        assert page.path == "Work/Meetings/Standup"
+
+    def test_notebook_name_filter(self):
+        source = OneNoteSource(notebook_name="work")
+        responses = [
+            [
+                {"id": "nb1", "displayName": "Work Notes"},
+                {"id": "nb2", "displayName": "Personal"},
+            ],
+            [{"id": "sec1", "displayName": "General"}],  # sections for Work Notes only
+            [{"id": "pg1", "title": "Note A"}],  # pages for that section
+        ]
+        with patch(f"{MODULE}._run_m365", side_effect=responses) as run:
+            files = source.list_videos()
+        assert [f.path for f in files] == ["Work Notes/General/Note A"]
+        # Only the matching notebook is traversed: notebook + section + page = 3 calls.
+        assert run.call_count == 3
+
+    def test_section_name_filter(self):
+        source = OneNoteSource(section_name="meet")
+        responses = [
+            [{"id": "nb1", "displayName": "Work"}],
+            [
+                {"id": "sec1", "displayName": "Meetings"},
+                {"id": "sec2", "displayName": "Scratch"},
+            ],
+            [{"id": "pg1", "title": "Kickoff"}],  # pages for Meetings only
+        ]
+        with patch(f"{MODULE}._run_m365", side_effect=responses) as run:
+            files = source.list_videos()
+        assert [f.path for f in files] == ["Work/Meetings/Kickoff"]
+        assert run.call_count == 3
+
+    def test_notebooks_not_a_list_returns_empty(self):
+        source = OneNoteSource()
+        with patch(f"{MODULE}._run_m365", return_value="unexpected string"):
+            assert source.list_videos() == []
+
+    def test_section_listing_failure_skips_notebook(self):
+        source = OneNoteSource()
+        responses = [
+            [{"id": "nb1", "displayName": "Work"}],
+            RuntimeError("section list failed"),
+        ]
+        with patch(f"{MODULE}._run_m365", side_effect=responses):
+            assert source.list_videos() == []
+
+    def test_sections_not_a_list_skips(self):
+        source = OneNoteSource()
+        responses = [
+            [{"id": "nb1", "displayName": "Work"}],
+            {"unexpected": "dict"},
+        ]
+        with patch(f"{MODULE}._run_m365", side_effect=responses):
+            assert source.list_videos() == []
+
+    def test_page_listing_failure_skips_section(self):
+        source = OneNoteSource()
+        responses = [
+            [{"id": "nb1", "displayName": "Work"}],
+            [{"id": "sec1", "displayName": "Meetings"}],
+            RuntimeError("page list failed"),
+        ]
+        with patch(f"{MODULE}._run_m365", side_effect=responses):
+            assert source.list_videos() == []
+
+    def test_pages_not_a_list_skips(self):
+        source = OneNoteSource()
+        responses = [
+            [{"id": "nb1", "displayName": "Work"}],
+            [{"id": "sec1", "displayName": "Meetings"}],
+            "not a list",
+        ]
+        with patch(f"{MODULE}._run_m365", side_effect=responses):
+            assert source.list_videos() == []
+
+    def test_untitled_page_fallback(self):
+        source = OneNoteSource()
+        responses = [
+            [{"id": "nb1", "displayName": "Work"}],
+            [{"id": "sec1", "displayName": "Meetings"}],
+            [
+                {"id": "pg1", "title": "   "},  # whitespace-only title
+                {"id": "pg2"},  # missing title entirely
+            ],
+        ]
+        with patch(f"{MODULE}._run_m365", side_effect=responses):
+            files = source.list_videos()
+        assert [f.name for f in files] == ["Untitled Page", "Untitled Page"]
+
+
+class TestOneNoteDownload:
+    def test_dict_content_written_as_text(self, tmp_path):
+        source = OneNoteSource()
+        dest = tmp_path / "notes" / "page.txt"
+        with patch(f"{MODULE}._run_m365", return_value={"content": "<p>Hello &amp; welcome</p>"}):
+            result = source.download(SourceFile(name="Page", id="pg1"), dest)
+        assert result == dest
+        assert dest.read_text(encoding="utf-8") == "Hello & welcome"
+
+    def test_body_content_fallback(self, tmp_path):
+        source = OneNoteSource()
+        dest = tmp_path / "page.txt"
+        with patch(f"{MODULE}._run_m365", return_value={"body": {"content": "<b>Body text</b>"}}):
+            result = source.download(SourceFile(name="P", id="pg1"), dest)
+        assert result.read_text(encoding="utf-8") == "Body text"
+
+    def test_empty_dict_serialized_as_json(self, tmp_path):
+        source = OneNoteSource()
+        dest = tmp_path / "page.txt"
+        with patch(f"{MODULE}._run_m365", return_value={"id": "pg1", "misc": 5}):
+            source.download(SourceFile(name="P", id="pg1"), dest)
+        text = dest.read_text(encoding="utf-8")
+        assert '"id": "pg1"' in text
+        assert '"misc": 5' in text
+
+    def test_string_result_written(self, tmp_path):
+        source = OneNoteSource()
+        dest = tmp_path / "page.txt"
+        with patch(f"{MODULE}._run_m365", return_value="raw <i>text</i> here"):
+            source.download(SourceFile(name="P", id="pg1"), dest)
+        assert dest.read_text(encoding="utf-8") == "raw text here"
+
+    def test_other_type_result_stringified(self, tmp_path):
+        source = OneNoteSource()
+        dest = tmp_path / "page.txt"
+        with patch(f"{MODULE}._run_m365", return_value=[1, 2, 3]):
+            source.download(SourceFile(name="P", id="pg1"), dest)
+        assert dest.read_text(encoding="utf-8") == "[1, 2, 3]"
+
+    def test_fetch_failure_raises_runtime_error(self, tmp_path):
+        source = OneNoteSource()
+        dest = tmp_path / "page.txt"
+        with patch(f"{MODULE}._run_m365", side_effect=RuntimeError("network down")):
+            with pytest.raises(RuntimeError, match="Failed to fetch OneNote page pg1"):
+                source.download(SourceFile(name="P", id="pg1"), dest)

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -1,0 +1,251 @@
+"""Tests for the concrete OpenAIProvider (chat, vision, transcription, listing).
+
+The base OpenAICompatibleProvider is covered in test_providers.py; this file
+exercises video_processor.providers.openai_provider.OpenAIProvider, mocking only
+the OpenAI SDK entrypoint so the real request/response mapping runs.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_processor.providers.openai_provider import OpenAIProvider
+
+
+def _make_client(mock_cls):
+    client = MagicMock()
+    mock_cls.return_value = client
+    return client
+
+
+def _chat_response(text, prompt_tokens=5, completion_tokens=10):
+    resp = MagicMock()
+    choice = MagicMock()
+    choice.message.content = text
+    resp.choices = [choice]
+    resp.usage.prompt_tokens = prompt_tokens
+    resp.usage.completion_tokens = completion_tokens
+    return resp
+
+
+class TestConstruction:
+    def test_missing_key_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="OPENAI_API_KEY not set"):
+                OpenAIProvider(api_key=None)
+
+    @patch("video_processor.providers.openai_provider.OpenAI")
+    def test_explicit_key_builds_client(self, mock_cls):
+        client = _make_client(mock_cls)
+        provider = OpenAIProvider(api_key="sk-test")
+        assert provider.api_key == "sk-test"
+        assert provider.client is client
+        mock_cls.assert_called_once_with(api_key="sk-test")
+
+    @patch("video_processor.providers.openai_provider.OpenAI")
+    def test_key_from_env(self, mock_cls):
+        _make_client(mock_cls)
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-env"}, clear=True):
+            provider = OpenAIProvider()
+        assert provider.api_key == "sk-env"
+
+
+class TestChat:
+    @patch("video_processor.providers.openai_provider.OpenAI")
+    def test_chat_returns_text_and_records_usage(self, mock_cls):
+        client = _make_client(mock_cls)
+        client.chat.completions.create.return_value = _chat_response("hello back", 5, 12)
+
+        provider = OpenAIProvider(api_key="sk-test")
+        out = provider.chat([{"role": "user", "content": "hi"}])
+
+        assert out == "hello back"
+        assert provider._last_usage == {"input_tokens": 5, "output_tokens": 12}
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["model"] == "gpt-4o-mini"  # default
+        assert kwargs["messages"] == [{"role": "user", "content": "hi"}]
+
+    @patch("video_processor.providers.openai_provider.OpenAI")
+    def test_chat_honours_explicit_model_and_params(self, mock_cls):
+        client = _make_client(mock_cls)
+        client.chat.completions.create.return_value = _chat_response("x")
+
+        provider = OpenAIProvider(api_key="sk-test")
+        provider.chat(
+            [{"role": "user", "content": "hi"}],
+            max_tokens=256,
+            temperature=0.1,
+            model="gpt-4.1",
+        )
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["model"] == "gpt-4.1"
+        assert kwargs["max_tokens"] == 256
+        assert kwargs["temperature"] == 0.1
+
+    @patch("video_processor.providers.openai_provider.OpenAI")
+    def test_chat_none_content_returns_empty_string(self, mock_cls):
+        client = _make_client(mock_cls)
+        client.chat.completions.create.return_value = _chat_response(None)
+
+        provider = OpenAIProvider(api_key="sk-test")
+        assert provider.chat([{"role": "user", "content": "hi"}]) == ""
+
+    @patch("video_processor.providers.openai_provider.OpenAI")
+    def test_chat_missing_usage_defaults_to_zero(self, mock_cls):
+        client = _make_client(mock_cls)
+        resp = _chat_response("ok")
+        resp.usage = None
+        client.chat.completions.create.return_value = resp
+
+        provider = OpenAIProvider(api_key="sk-test")
+        provider.chat([{"role": "user", "content": "hi"}])
+        assert provider._last_usage == {"input_tokens": 0, "output_tokens": 0}
+
+
+class TestAnalyzeImage:
+    @patch("video_processor.providers.openai_provider.OpenAI")
+    def test_analyze_image_encodes_and_returns_text(self, mock_cls):
+        client = _make_client(mock_cls)
+        client.chat.completions.create.return_value = _chat_response("a cat", 100, 5)
+
+        provider = OpenAIProvider(api_key="sk-test")
+        out = provider.analyze_image(b"\x89PNGdata", "what is this?", model="gpt-4o")
+
+        assert out == "a cat"
+        assert provider._last_usage["input_tokens"] == 100
+        # The image is passed as a base64 data URL inside the content parts.
+        content = client.chat.completions.create.call_args.kwargs["messages"][0]["content"]
+        image_part = [p for p in content if p["type"] == "image_url"][0]
+        assert image_part["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+
+class TestTranscribe:
+    def _verbose_response(self, text="hello world"):
+        seg = MagicMock()
+        seg.start = 0.0
+        seg.end = 1.5
+        seg.text = "hello world"
+        resp = MagicMock()
+        resp.text = text
+        resp.segments = [seg]
+        resp.language = "en"
+        resp.duration = 1.5
+        return resp
+
+    @patch("video_processor.providers.openai_provider.OpenAI")
+    def test_transcribe_single_small_file(self, mock_cls, tmp_path):
+        client = _make_client(mock_cls)
+        client.audio.transcriptions.create.return_value = self._verbose_response()
+
+        audio = tmp_path / "clip.wav"
+        audio.write_bytes(b"\x00\x01\x02\x03")
+
+        provider = OpenAIProvider(api_key="sk-test")
+        result = provider.transcribe_audio(audio, language="en")
+
+        assert result["text"] == "hello world"
+        assert result["provider"] == "openai"
+        assert result["model"] == "whisper-1"
+        assert result["segments"] == [{"start": 0.0, "end": 1.5, "text": "hello world"}]
+        # language kwarg was forwarded to the SDK
+        assert client.audio.transcriptions.create.call_args.kwargs["language"] == "en"
+
+    @patch("video_processor.providers.openai_provider.OpenAI")
+    def test_transcribe_forwards_prompt(self, mock_cls, tmp_path):
+        client = _make_client(mock_cls)
+        client.audio.transcriptions.create.return_value = self._verbose_response()
+
+        audio = tmp_path / "clip.wav"
+        audio.write_bytes(b"\x00")
+
+        provider = OpenAIProvider(api_key="sk-test")
+        provider.transcribe_audio(audio, prompt="Speakers: Alice, Bob.")
+        assert (
+            client.audio.transcriptions.create.call_args.kwargs["prompt"] == "Speakers: Alice, Bob."
+        )
+
+    @patch("video_processor.providers.openai_provider.OpenAI")
+    def test_transcribe_large_file_chunks(self, mock_cls, tmp_path):
+        """A file over the 25MB limit is split and each chunk transcribed,
+        with segment timestamps offset by the running chunk duration."""
+        _make_client(mock_cls)
+
+        audio = tmp_path / "big.wav"
+        audio.write_bytes(b"\x00" * 100)
+
+        provider = OpenAIProvider(api_key="sk-test")
+        provider._MAX_FILE_SIZE = 10  # force the chunked path
+
+        fake_extractor = MagicMock()
+        sr = 16000
+        fake_extractor.load_audio.return_value = ([0] * (sr * 2), sr)  # 2.0s total
+        fake_extractor.segment_audio.return_value = [[0] * sr, [0] * sr]  # two 1s chunks
+
+        per_chunk = [
+            {
+                "text": "first",
+                "segments": [{"start": 0.0, "end": 1.0, "text": "first"}],
+                "language": "en",
+            },
+            {
+                "text": "second",
+                "segments": [{"start": 0.0, "end": 1.0, "text": "second"}],
+                "language": None,
+            },
+        ]
+
+        with patch(
+            "video_processor.extractors.audio_extractor.AudioExtractor",
+            return_value=fake_extractor,
+        ):
+            with patch.object(OpenAIProvider, "_transcribe_single", side_effect=per_chunk):
+                result = provider.transcribe_audio(audio)
+
+        assert result["text"] == "first second"
+        assert result["language"] == "en"
+        assert result["duration"] == 2.0
+        # Second chunk's segment is shifted by the 1.0s first-chunk offset.
+        assert result["segments"][0] == {"start": 0.0, "end": 1.0, "text": "first"}
+        assert result["segments"][1] == {"start": 1.0, "end": 2.0, "text": "second"}
+
+
+class TestListModels:
+    def _model(self, mid):
+        m = MagicMock()
+        m.id = mid
+        return m
+
+    @patch("video_processor.providers.openai_provider.OpenAI")
+    def test_list_models_infers_capabilities(self, mock_cls):
+        client = _make_client(mock_cls)
+        client.models.list.return_value = [
+            self._model("gpt-4o"),
+            self._model("whisper-1"),
+            self._model("text-embedding-3-small"),
+            self._model("o1"),
+            self._model("dall-e-3"),  # no inferred caps -> excluded
+        ]
+
+        provider = OpenAIProvider(api_key="sk-test")
+        models = provider.list_models()
+        by_id = {m.id: m for m in models}
+
+        assert "dall-e-3" not in by_id
+        assert "vision" in by_id["gpt-4o"].capabilities
+        assert "chat" in by_id["gpt-4o"].capabilities
+        assert by_id["whisper-1"].capabilities == ["audio"]
+        assert by_id["text-embedding-3-small"].capabilities == ["embedding"]
+        # "o1" is itself listed in _VISION_MODELS, so the substring check tags it
+        # vision as well as chat — assert the module's actual inference.
+        assert by_id["o1"].capabilities == ["chat", "vision"]
+        # sorted by id
+        assert [m.id for m in models] == sorted(m.id for m in models)
+
+    @patch("video_processor.providers.openai_provider.OpenAI")
+    def test_list_models_handles_error(self, mock_cls):
+        client = _make_client(mock_cls)
+        client.models.list.side_effect = RuntimeError("boom")
+
+        provider = OpenAIProvider(api_key="sk-test")
+        assert provider.list_models() == []

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,413 @@
+"""Tests for the agentic orchestrator's execution, retry, and reporting logic.
+
+These exercise the parts of ``AgentOrchestrator`` not already covered by
+``tests/test_agent.py`` (which covers ``_create_plan``, ``_adapt_plan``,
+``_get_fallback``, ``_deep_analysis``, ``_build_manifest`` and ``insights``):
+the ``_run_step`` dispatcher, ``_execute_step`` retry/fallback handling,
+``_cross_reference``, ``_generate_reports`` and the top-level ``process`` flow.
+
+The LLM boundary is the only thing mocked — a ``MagicMock`` ProviderManager is
+passed in so the real orchestration, parsing, knowledge-graph and reporting code
+runs. The knowledge graph is a real SQLite/in-memory store and all files land in
+``tmp_path``.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from video_processor.agent.orchestrator import AgentOrchestrator
+from video_processor.integrators.knowledge_graph import KnowledgeGraph
+from video_processor.models import DiagramResult, KeyPoint
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pm(chat="[]", analyze_image="{}", transcribe=None):
+    """Build a mock ProviderManager with representative return values.
+
+    Only the LLM boundary is mocked; callers override ``chat`` /
+    ``transcribe_audio`` per test to drive the real parsing branches.
+    """
+    pm = MagicMock()
+    pm.chat.return_value = chat
+    pm.analyze_image.return_value = analyze_image
+    pm.transcribe_audio.return_value = (
+        transcribe if transcribe is not None else {"text": "", "segments": []}
+    )
+    pm.get_models_used.return_value = {"chat": "mock-chat", "vision": "mock-vision"}
+    return pm
+
+
+# ---------------------------------------------------------------------------
+# _run_step — per-step dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestRunStep:
+    def test_transcribe_writes_transcript_files(self, tmp_path):
+        pm = _make_pm()
+        pm.transcribe_audio.return_value = {
+            "text": "hello world",
+            "segments": [{"start": 0.0, "end": 1.0, "text": "hello world"}],
+        }
+        agent = AgentOrchestrator(provider_manager=pm)
+        agent._results["extract_audio"] = {"audio_path": "/audio/talk.wav"}
+
+        result = agent._run_step("transcribe", Path("talk.mp4"), tmp_path)
+
+        assert result["text"] == "hello world"
+        pm.transcribe_audio.assert_called_once_with("/audio/talk.wav")
+        tj = tmp_path / "transcript" / "transcript.json"
+        tt = tmp_path / "transcript" / "transcript.txt"
+        assert tt.read_text() == "hello world"
+        assert json.loads(tj.read_text())["text"] == "hello world"
+
+    def test_transcribe_without_audio_raises(self, tmp_path):
+        agent = AgentOrchestrator(provider_manager=_make_pm())
+        # No extract_audio result recorded → transcription has no input.
+        with pytest.raises(RuntimeError, match="No audio available"):
+            agent._run_step("transcribe", Path("talk.mp4"), tmp_path)
+
+    def test_detect_diagrams_no_frames_returns_empty(self, tmp_path):
+        agent = AgentOrchestrator(provider_manager=_make_pm())
+        agent._results["extract_frames"] = {"paths": []}
+        result = agent._run_step("detect_diagrams", Path("talk.mp4"), tmp_path)
+        assert result == {"diagrams": [], "captures": []}
+
+    def test_extract_key_points_parses_llm_json(self, tmp_path):
+        pm = _make_pm(
+            chat=json.dumps(
+                [
+                    {"point": "Adopt microservices", "topic": "arch", "details": "split monolith"},
+                    {"point": "Ship by Q3", "topic": "timeline"},
+                ]
+            )
+        )
+        agent = AgentOrchestrator(provider_manager=pm)
+        agent._results["transcribe"] = {"text": "a long enough transcript to analyze"}
+
+        result = agent._run_step("extract_key_points", Path("talk.mp4"), tmp_path)
+
+        kps = result["key_points"]
+        assert [kp.point for kp in kps] == ["Adopt microservices", "Ship by Q3"]
+        assert isinstance(kps[0], KeyPoint)
+
+    def test_extract_key_points_empty_transcript_skips_llm(self, tmp_path):
+        pm = _make_pm()
+        agent = AgentOrchestrator(provider_manager=pm)
+        agent._results["transcribe"] = {"text": ""}
+        result = agent._run_step("extract_key_points", Path("talk.mp4"), tmp_path)
+        assert result == {"key_points": []}
+        pm.chat.assert_not_called()
+
+    def test_extract_action_items_parses_llm_json(self, tmp_path):
+        pm = _make_pm(
+            chat=json.dumps(
+                [{"action": "Email the report", "assignee": "Alice", "deadline": "Friday"}]
+            )
+        )
+        agent = AgentOrchestrator(provider_manager=pm)
+        agent._results["transcribe"] = {"text": "please email the report to the team"}
+
+        result = agent._run_step("extract_action_items", Path("talk.mp4"), tmp_path)
+
+        items = result["action_items"]
+        assert len(items) == 1
+        assert items[0].action == "Email the report"
+        assert items[0].assignee == "Alice"
+
+    def test_extract_action_items_empty_transcript_skips_llm(self, tmp_path):
+        pm = _make_pm()
+        agent = AgentOrchestrator(provider_manager=pm)
+        agent._results["transcribe"] = {"text": ""}
+        result = agent._run_step("extract_action_items", Path("talk.mp4"), tmp_path)
+        assert result == {"action_items": []}
+        pm.chat.assert_not_called()
+
+    def test_build_knowledge_graph_persists_real_graph(self, tmp_path):
+        pm = _make_pm(
+            chat=json.dumps(
+                {
+                    "entities": [
+                        {"name": "Alice", "type": "person", "description": "the lead"},
+                        {"name": "Python", "type": "technology", "description": "language"},
+                    ],
+                    "relationships": [
+                        {"source": "Alice", "target": "Python", "type": "uses"},
+                    ],
+                }
+            )
+        )
+        agent = AgentOrchestrator(provider_manager=pm)
+        agent._results["transcribe"] = {
+            "segments": [{"start": 0.0, "end": 5.0, "text": "Alice uses Python every day"}],
+        }
+        # A detected diagram with text is folded into the same graph.
+        agent._results["detect_diagrams"] = {
+            "diagrams": [
+                DiagramResult(
+                    frame_index=1,
+                    description="architecture",
+                    text_content="Django is a Python web framework",
+                )
+            ]
+        }
+
+        result = agent._run_step("build_knowledge_graph", Path("talk.mp4"), tmp_path)
+
+        kg = result["knowledge_graph"]
+        assert isinstance(kg, KnowledgeGraph)
+        assert "Python" in kg.nodes
+        assert "Alice" in kg.nodes
+        assert len(kg.relationships) >= 1
+        # process_diagrams added a diagram entity from the detected diagram.
+        assert "diagram_0" in kg.nodes
+        # Both the SQLite db and its JSON export are written alongside each other.
+        assert (tmp_path / "results" / "knowledge_graph.db").exists()
+        assert (tmp_path / "results" / "knowledge_graph.json").exists()
+
+    def test_deep_analysis_dispatch_surfaces_insights(self, tmp_path):
+        pm = _make_pm(
+            chat=json.dumps(
+                {
+                    "decisions": ["Use Postgres"],
+                    "risks": ["Tight deadline"],
+                    "follow_ups": [],
+                    "tensions": [],
+                }
+            )
+        )
+        agent = AgentOrchestrator(provider_manager=pm)
+        agent._results["transcribe"] = {"text": "a transcript worth analyzing in depth"}
+
+        result = agent._run_step("deep_analysis", Path("talk.mp4"), tmp_path)
+
+        assert result["decisions"] == ["Use Postgres"]
+        assert any("Postgres" in i for i in agent.insights)
+        assert any("Tight deadline" in i for i in agent.insights)
+
+    def test_screengrab_fallback_returns_empty(self, tmp_path):
+        agent = AgentOrchestrator(provider_manager=_make_pm())
+        assert agent._run_step("screengrab_fallback", Path("talk.mp4"), tmp_path) == {}
+
+    def test_unknown_step_raises(self, tmp_path):
+        agent = AgentOrchestrator(provider_manager=_make_pm())
+        with pytest.raises(ValueError, match="Unknown step"):
+            agent._run_step("not_a_real_step", Path("talk.mp4"), tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# _execute_step — retry and fallback handling
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteStep:
+    def test_retries_then_succeeds(self, tmp_path):
+        pm = _make_pm()
+        # First attempt raises, second succeeds — proves the retry loop re-runs.
+        pm.transcribe_audio.side_effect = [
+            RuntimeError("transient network error"),
+            {"text": "recovered", "segments": []},
+        ]
+        agent = AgentOrchestrator(provider_manager=pm, max_retries=2)
+        agent._results["extract_audio"] = {"audio_path": "/audio/talk.wav"}
+
+        agent._execute_step(
+            {"step": "transcribe", "priority": "required"}, Path("talk.mp4"), tmp_path
+        )
+
+        assert pm.transcribe_audio.call_count == 2
+        assert agent._results["transcribe"] == {"text": "recovered", "segments": []}
+
+    def test_retries_exhausted_records_error(self, tmp_path):
+        pm = _make_pm()
+        pm.transcribe_audio.side_effect = RuntimeError("permanent failure")
+        agent = AgentOrchestrator(provider_manager=pm, max_retries=2)
+        agent._results["extract_audio"] = {"audio_path": "/audio/talk.wav"}
+
+        agent._execute_step(
+            {"step": "transcribe", "priority": "required"}, Path("talk.mp4"), tmp_path
+        )
+
+        # Attempted exactly max_retries times, then the error was recorded.
+        assert pm.transcribe_audio.call_count == 2
+        assert agent._results["transcribe"] == {"error": "permanent failure"}
+
+    def test_falls_back_after_exhausted_retries(self, tmp_path):
+        # detect_diagrams is the only step with a fallback (screengrab_fallback).
+        # A frame path that doesn't exist makes DiagramAnalyzer.process_frames raise
+        # (the content hash opens the file), so every attempt fails and the
+        # orchestrator switches to the fallback, which returns {}.
+        agent = AgentOrchestrator(provider_manager=_make_pm(), max_retries=2)
+        agent._results["extract_frames"] = {"paths": [str(tmp_path / "no_such_frame.jpg")]}
+
+        agent._execute_step(
+            {"step": "detect_diagrams", "priority": "standard"}, Path("talk.mp4"), tmp_path
+        )
+
+        # Error would remain if the fallback hadn't run; {} proves the fallback executed.
+        assert agent._results["detect_diagrams"] == {}
+
+    def test_successful_step_triggers_adaptive_planning(self, tmp_path):
+        # A long transcript should cause _adapt_plan (invoked from _execute_step on
+        # success) to append a deep_analysis step.
+        pm = _make_pm()
+        pm.transcribe_audio.return_value = {"text": "word " * 3000, "segments": []}
+        agent = AgentOrchestrator(provider_manager=pm)
+        agent._results["extract_audio"] = {"audio_path": "/audio/talk.wav"}
+        agent._plan = [{"step": "generate_reports", "priority": "required"}]
+
+        agent._execute_step(
+            {"step": "transcribe", "priority": "required"}, Path("talk.mp4"), tmp_path
+        )
+
+        assert any(s["step"] == "deep_analysis" for s in agent._plan)
+
+
+# ---------------------------------------------------------------------------
+# _cross_reference
+# ---------------------------------------------------------------------------
+
+
+class TestCrossReference:
+    def test_enriches_key_points_with_diagram_links(self, tmp_path):
+        agent = AgentOrchestrator(provider_manager=_make_pm())
+        agent._results["transcribe"] = {"text": "authentication service design discussion"}
+        agent._results["build_knowledge_graph"] = {
+            "knowledge_graph": KnowledgeGraph(provider_manager=None)
+        }
+        kp = KeyPoint(point="authentication service", details="oauth design")
+        agent._results["extract_key_points"] = {"key_points": [kp]}
+        diagram = DiagramResult(
+            frame_index=0,
+            elements=["authentication", "service"],
+            text_content="design oauth flow",
+        )
+        agent._results["detect_diagrams"] = {"diagrams": [diagram]}
+
+        # Route through _run_step to also cover the dispatch branch.
+        result = agent._run_step("cross_reference", Path("talk.mp4"), tmp_path)
+
+        assert result == {"enriched": True}
+        # The key point now links to diagram index 0 (>=2 shared tokens).
+        enriched = agent._results["extract_key_points"]["key_points"][0]
+        assert enriched.related_diagrams == [0]
+
+    def test_no_knowledge_graph_returns_empty(self, tmp_path):
+        agent = AgentOrchestrator(provider_manager=_make_pm())
+        # No build_knowledge_graph result → nothing to cross-reference.
+        assert agent._cross_reference() == {}
+
+
+# ---------------------------------------------------------------------------
+# _generate_reports
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateReports:
+    def test_writes_markdown_with_summary_and_insights(self, tmp_path):
+        pm = _make_pm(chat="This is the generated summary.")
+        agent = AgentOrchestrator(provider_manager=pm)
+        agent._results["transcribe"] = {"text": "the meeting transcript"}
+        agent._results["extract_key_points"] = {
+            "key_points": [KeyPoint(point="Key decision made", details="the details")]
+        }
+        agent._results["detect_diagrams"] = {"diagrams": []}
+        agent._insights = ["Consider re-processing at comprehensive depth"]
+
+        result = agent._run_step("generate_reports", Path("talk.mp4"), tmp_path)
+
+        md_path = Path(result["report_path"])
+        assert md_path.name == "analysis.md"
+        assert md_path.exists()
+        content = md_path.read_text()
+        assert "This is the generated summary." in content
+        assert "Key decision made" in content
+        # Agent insights are appended to the report.
+        assert "## Agent Insights" in content
+        assert "Consider re-processing at comprehensive depth" in content
+
+
+# ---------------------------------------------------------------------------
+# process — end-to-end drive
+#
+# NOTE: process() references self._reflect_and_enrich(), which is not defined
+# anywhere in AgentOrchestrator. The method therefore raises AttributeError
+# after the execute loop finishes. This test pins that current (buggy) behavior
+# while still asserting the real work that happens first: the plan is built,
+# every step's result is recorded (with graceful error entries for the steps
+# that need a real video file), and report generation succeeds. If/when
+# _reflect_and_enrich is implemented, the pytest.raises below should be updated.
+# ---------------------------------------------------------------------------
+
+
+class TestProcess:
+    def test_plan_and_results_recorded_before_missing_reflect_step(self, tmp_path):
+        pm = _make_pm(chat="A concise summary.")
+        agent = AgentOrchestrator(provider_manager=pm, max_retries=1)
+        video = tmp_path / "missing.mp4"  # does not exist → extraction steps fail
+        out = tmp_path / "out"
+
+        with pytest.raises(AttributeError, match="_reflect_and_enrich"):
+            agent.process(video, out, initial_depth="basic")
+
+        # Phase 1: the basic plan was created in the expected order.
+        assert [s["step"] for s in agent._plan] == [
+            "extract_frames",
+            "extract_audio",
+            "transcribe",
+            "extract_key_points",
+            "extract_action_items",
+            "generate_reports",
+        ]
+
+        # Phase 2: steps needing the (missing) video failed gracefully and the
+        # error was recorded rather than aborting the run.
+        assert "error" in agent._results["extract_frames"]
+        assert "error" in agent._results["extract_audio"]
+        assert "error" in agent._results["transcribe"]
+
+        # Downstream steps still executed; report generation produced a file.
+        assert agent._results["extract_key_points"] == {"key_points": []}
+        assert agent._results["extract_action_items"] == {"action_items": []}
+        assert "report_path" in agent._results["generate_reports"]
+        assert (out / "results" / "analysis.md").exists()
+
+    def test_comprehensive_depth_drives_extra_steps(self, tmp_path):
+        # Comprehensive depth adds detect_diagrams, build_knowledge_graph,
+        # deep_analysis and cross_reference to the plan. With no real video these
+        # run against empty upstream results, exercising each step's empty-input
+        # branch before process() hits the same missing _reflect_and_enrich step.
+        pm = _make_pm(chat="A summary.")
+        agent = AgentOrchestrator(provider_manager=pm, max_retries=1)
+        video = tmp_path / "missing.mp4"
+        out = tmp_path / "out"
+
+        with pytest.raises(AttributeError, match="_reflect_and_enrich"):
+            agent.process(video, out, initial_depth="comprehensive")
+
+        assert [s["step"] for s in agent._plan] == [
+            "extract_frames",
+            "extract_audio",
+            "transcribe",
+            "detect_diagrams",
+            "build_knowledge_graph",
+            "extract_key_points",
+            "extract_action_items",
+            "deep_analysis",
+            "cross_reference",
+            "generate_reports",
+        ]
+        # detect_diagrams degrades to empty when frames are unavailable.
+        assert agent._results["detect_diagrams"] == {"diagrams": [], "captures": []}
+        # A knowledge graph object is still constructed (empty transcript).
+        kg = agent._results["build_knowledge_graph"]["knowledge_graph"]
+        assert isinstance(kg, KnowledgeGraph)
+        # deep_analysis on empty text returns nothing; cross_reference still runs.
+        assert agent._results["deep_analysis"] == {}
+        assert agent._results["cross_reference"] == {"enriched": True}

--- a/tests/test_plan_generator.py
+++ b/tests/test_plan_generator.py
@@ -1,0 +1,274 @@
+"""Tests for PlanGenerator — markdown report and batch summary generation.
+
+The LLM boundary (``ProviderManager.chat``) is the only mocked dependency; the
+real templating, key-point/diagram rendering, and knowledge-graph mermaid
+generation all run. Knowledge graphs are real (in-memory) stores and every file
+is written under ``tmp_path``.
+"""
+
+from unittest.mock import MagicMock
+
+from video_processor.integrators.knowledge_graph import KnowledgeGraph
+from video_processor.integrators.plan_generator import PlanGenerator
+from video_processor.models import (
+    ActionItem,
+    DiagramResult,
+    KeyPoint,
+    VideoManifest,
+    VideoMetadata,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pm(chat="Generated text."):
+    pm = MagicMock()
+    pm.chat.return_value = chat
+    return pm
+
+
+def _kg_with_nodes():
+    """A real KnowledgeGraph (in-memory) with two linked technology entities."""
+    return KnowledgeGraph.from_dict(
+        {
+            "nodes": [
+                {"name": "Python", "type": "technology", "descriptions": ["language"]},
+                {"name": "Django", "type": "technology", "descriptions": ["framework"]},
+            ],
+            "relationships": [
+                {"source": "Django", "target": "Python", "type": "uses"},
+            ],
+        }
+    )
+
+
+def _make_manifest(title, *, key_points=None, action_items=None, diagrams=None, duration=None):
+    return VideoManifest(
+        video=VideoMetadata(title=title, duration_seconds=duration),
+        key_points=key_points or [],
+        action_items=action_items or [],
+        diagrams=diagrams or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+
+class TestInit:
+    def test_creates_default_knowledge_graph(self):
+        gen = PlanGenerator(provider_manager=_make_pm())
+        assert isinstance(gen.knowledge_graph, KnowledgeGraph)
+
+    def test_uses_provided_knowledge_graph(self):
+        kg = KnowledgeGraph(provider_manager=None)
+        gen = PlanGenerator(provider_manager=_make_pm(), knowledge_graph=kg)
+        assert gen.knowledge_graph is kg
+
+
+# ---------------------------------------------------------------------------
+# generate_summary
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSummary:
+    def test_summary_from_segments_includes_speakers(self):
+        pm = _make_pm(chat="A three paragraph summary.")
+        gen = PlanGenerator(provider_manager=pm)
+        transcript = {
+            "segments": [
+                {"speaker": "Alice", "text": "We should ship the auth service first."},
+                {"speaker": "Bob", "text": "Agreed, but mind the deadline."},
+            ]
+        }
+
+        summary = gen.generate_summary(transcript)
+
+        assert summary == "A three paragraph summary."
+        prompt = pm.chat.call_args[0][0][0]["content"]
+        assert "Alice: We should ship the auth service first." in prompt
+        assert "Bob: Agreed, but mind the deadline." in prompt
+
+    def test_summary_falls_back_to_plain_text(self):
+        pm = _make_pm(chat="Summary.")
+        gen = PlanGenerator(provider_manager=pm)
+
+        summary = gen.generate_summary({"text": "a plain transcript without segments"})
+
+        assert summary == "Summary."
+        prompt = pm.chat.call_args[0][0][0]["content"]
+        assert "a plain transcript without segments" in prompt
+
+    def test_summary_without_provider_returns_empty(self):
+        gen = PlanGenerator(provider_manager=None)
+        assert gen.generate_summary({"text": "anything"}) == ""
+
+
+# ---------------------------------------------------------------------------
+# generate_markdown
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateMarkdown:
+    def test_full_report_renders_all_sections(self):
+        pm = _make_pm(chat="The overall summary.")
+        gen = PlanGenerator(provider_manager=pm)
+        key_points = [{"point": "Adopt CI", "details": ["run tests", "gate merges"]}]
+        diagrams = [
+            {
+                "description": "System architecture overview",
+                "image_path": "diagrams/diagram_0.jpg",
+                "mermaid": "graph LR\n  A --> B",
+            }
+        ]
+        knowledge_graph = {
+            "nodes": [
+                {"name": "Python", "type": "technology", "descriptions": ["language"]},
+                {"name": "Django", "type": "technology", "descriptions": ["framework"]},
+            ],
+            "relationships": [{"source": "Django", "target": "Python", "type": "uses"}],
+        }
+
+        md = gen.generate_markdown(
+            transcript={"text": "the transcript"},
+            key_points=key_points,
+            diagrams=diagrams,
+            knowledge_graph=knowledge_graph,
+            video_title="Design Review",
+        )
+
+        assert md.startswith("# Design Review")
+        assert "## Summary" in md
+        assert "The overall summary." in md
+        assert "## Key Points" in md
+        assert "- **Adopt CI**" in md
+        assert "  - run tests" in md
+        assert "## Visual Elements" in md
+        assert "### Diagram 1" in md
+        assert "System architecture overview" in md
+        assert "![Diagram 1](diagrams/diagram_0.jpg)" in md
+        assert "```mermaid" in md
+        assert "## Knowledge Graph" in md
+        # KG mermaid is rendered from the reconstructed graph.
+        assert "graph LR" in md
+
+    def test_details_as_string_renders_indented(self):
+        gen = PlanGenerator(provider_manager=_make_pm())
+        md = gen.generate_markdown(
+            transcript={"text": "t"},
+            key_points=[{"point": "One point", "details": "a single detail line"}],
+            diagrams=[],
+            knowledge_graph={},
+        )
+        assert "- **One point**" in md
+        assert "  a single detail line" in md
+
+    def test_string_key_point_uses_str(self):
+        gen = PlanGenerator(provider_manager=_make_pm())
+        md = gen.generate_markdown(
+            transcript={"text": "t"},
+            key_points=["just a raw string point"],
+            diagrams=[],
+            knowledge_graph={},
+        )
+        assert "- **just a raw string point**" in md
+
+    def test_minimal_report_omits_optional_sections(self):
+        gen = PlanGenerator(provider_manager=_make_pm(chat="s"))
+        md = gen.generate_markdown(
+            transcript={"text": "t"},
+            key_points=[],
+            diagrams=[],
+            knowledge_graph={"nodes": []},
+            video_title=None,
+        )
+        assert "# Video Analysis Report" in md  # default title
+        assert "## Visual Elements" not in md
+        assert "## Knowledge Graph" not in md
+
+    def test_writes_file_and_appends_md_suffix(self, tmp_path):
+        gen = PlanGenerator(provider_manager=_make_pm(chat="written summary"))
+        out = tmp_path / "reports" / "analysis"  # no suffix
+
+        md = gen.generate_markdown(
+            transcript={"text": "t"},
+            key_points=[],
+            diagrams=[],
+            knowledge_graph={},
+            output_path=out,
+        )
+
+        written = tmp_path / "reports" / "analysis.md"
+        assert written.exists()
+        assert written.read_text() == md
+        assert "written summary" in md
+
+
+# ---------------------------------------------------------------------------
+# generate_batch_summary
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateBatchSummary:
+    def test_overview_and_per_video_sections(self):
+        gen = PlanGenerator(provider_manager=_make_pm())
+        manifests = [
+            _make_manifest(
+                "Kickoff",
+                key_points=[KeyPoint(point="Scope agreed")],
+                action_items=[
+                    ActionItem(action="Email report", assignee="Alice", deadline="Friday")
+                ],
+                diagrams=[DiagramResult(frame_index=0)],
+                duration=120.0,
+            ),
+            _make_manifest(
+                "Retro",
+                key_points=[KeyPoint(point="Ship faster"), KeyPoint(point="Fewer meetings")],
+            ),
+        ]
+
+        md = gen.generate_batch_summary(manifests, title="Sprint Batch")
+
+        assert md.startswith("# Sprint Batch")
+        assert "- **Videos processed:** 2" in md
+        assert "- **Total diagrams:** 1" in md
+        assert "- **Total key points:** 3" in md
+        assert "- **Total action items:** 1" in md
+        # Per-video sections and duration line.
+        assert "### Kickoff" in md
+        assert "### Retro" in md
+        assert "- Duration: 120s" in md
+        # Aggregated action items carry assignee, deadline and source video title.
+        assert "## All Action Items" in md
+        assert "- **Email report** (Alice) — Friday _Kickoff_" in md
+
+    def test_no_action_items_omits_section(self):
+        gen = PlanGenerator(provider_manager=_make_pm())
+        manifests = [_make_manifest("A", key_points=[KeyPoint(point="p")])]
+        md = gen.generate_batch_summary(manifests)
+        assert "## All Action Items" not in md
+
+    def test_merged_knowledge_graph_section(self):
+        gen = PlanGenerator(provider_manager=_make_pm())
+        manifests = [_make_manifest("A")]
+        md = gen.generate_batch_summary(manifests, kg=_kg_with_nodes())
+        assert "## Merged Knowledge Graph" in md
+        assert "graph LR" in md
+        assert "Python" in md
+
+    def test_without_knowledge_graph_omits_section(self):
+        gen = PlanGenerator(provider_manager=_make_pm())
+        md = gen.generate_batch_summary([_make_manifest("A")], kg=None)
+        assert "## Merged Knowledge Graph" not in md
+
+    def test_writes_file(self, tmp_path):
+        gen = PlanGenerator(provider_manager=_make_pm())
+        out = tmp_path / "batch" / "summary.md"
+        md = gen.generate_batch_summary([_make_manifest("Only")], output_path=out)
+        assert out.exists()
+        assert out.read_text() == md
+        assert "### Only" in out.read_text()

--- a/tests/test_teams_source.py
+++ b/tests/test_teams_source.py
@@ -1,0 +1,340 @@
+"""Tests for the Microsoft Teams meeting-recording source.
+
+Like the M365 source, this connector reaches Microsoft Graph through the `m365`
+CLI (via the shared ``_run_m365`` helper), not the ``requests`` library. The only
+mocked boundary is ``_run_m365`` (imported into this module's namespace) and
+``shutil.which`` for authentication. Real files land in ``tmp_path``.
+"""
+
+import subprocess
+from unittest.mock import patch
+
+from video_processor.sources.base import SourceFile
+from video_processor.sources.teams_recording_source import (
+    TeamsRecordingSource,
+    _vtt_to_text,
+)
+
+TEAMS = "video_processor.sources.teams_recording_source"
+
+
+class TestVttToText:
+    def test_strips_metadata_and_tags(self):
+        vtt = (
+            "WEBVTT\n\n"
+            "NOTE This is a note\n\n"
+            "1\n"
+            "00:00:01.000 --> 00:00:05.000\n"
+            "<v Alice>Hello everyone\n\n"
+            "2\n"
+            "00:00:05.000 --> 00:00:09.000\n"
+            "<v Bob>Good morning\n"
+        )
+        assert _vtt_to_text(vtt) == "Hello everyone\nGood morning"
+
+    def test_empty_input(self):
+        assert _vtt_to_text("") == ""
+
+    def test_deduplicates_consecutive_lines(self):
+        vtt = (
+            "WEBVTT\n\n"
+            "00:00:01.000 --> 00:00:03.000\nSame line\n\n"
+            "00:00:03.000 --> 00:00:05.000\nSame line\n"
+        )
+        assert _vtt_to_text(vtt).count("Same line") == 1
+
+    def test_removes_headers_and_notes(self):
+        vtt = "WEBVTT\nNOTE meta\n00:00:00.000 --> 00:00:01.000\nActual words\n"
+        result = _vtt_to_text(vtt)
+        assert result == "Actual words"
+        assert "WEBVTT" not in result
+        assert "NOTE" not in result
+
+
+class TestTeamsConstructor:
+    def test_default_user(self):
+        assert TeamsRecordingSource().user_id == "me"
+
+    def test_custom_user(self):
+        assert TeamsRecordingSource(user_id="user@example.com").user_id == "user@example.com"
+
+
+class TestTeamsAuthenticate:
+    @patch(f"{TEAMS}.shutil.which", return_value=None)
+    def test_cli_not_installed(self, _which):
+        assert TeamsRecordingSource().authenticate() is False
+
+    @patch(f"{TEAMS}._run_m365")
+    @patch(f"{TEAMS}.shutil.which", return_value="/usr/local/bin/m365")
+    def test_connected_dict(self, _which, mock_run):
+        mock_run.return_value = {"connectedAs": "user@contoso.com"}
+        assert TeamsRecordingSource().authenticate() is True
+
+    @patch(f"{TEAMS}._run_m365")
+    @patch(f"{TEAMS}.shutil.which", return_value="/usr/local/bin/m365")
+    def test_logged_in_string(self, _which, mock_run):
+        mock_run.return_value = "Logged in as someone"
+        assert TeamsRecordingSource().authenticate() is True
+
+    @patch(f"{TEAMS}._run_m365")
+    @patch(f"{TEAMS}.shutil.which", return_value="/usr/local/bin/m365")
+    def test_not_logged_in(self, _which, mock_run):
+        mock_run.return_value = {}
+        assert TeamsRecordingSource().authenticate() is False
+
+    @patch(f"{TEAMS}._run_m365")
+    @patch(f"{TEAMS}.shutil.which", return_value="/usr/local/bin/m365")
+    def test_runtime_error_returns_false(self, _which, mock_run):
+        mock_run.side_effect = RuntimeError("status failed")
+        assert TeamsRecordingSource().authenticate() is False
+
+    @patch(f"{TEAMS}._run_m365")
+    @patch(f"{TEAMS}.shutil.which", return_value="/usr/local/bin/m365")
+    def test_timeout_returns_false(self, _which, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired("m365", 10)
+        assert TeamsRecordingSource().authenticate() is False
+
+
+class TestTeamsListVideos:
+    @patch(f"{TEAMS}._run_m365")
+    def test_approach1_online_meetings(self, mock_run):
+        mock_run.side_effect = [
+            # onlineMeetings listing
+            {
+                "value": [
+                    {"id": "m1", "subject": "Standup", "startDateTime": "2026-01-01T09:00:00Z"}
+                ]
+            },
+            # recordings for m1
+            {"value": [{"id": "rec1", "content.downloadUrl": "https://dl/rec1"}]},
+        ]
+        files = TeamsRecordingSource().list_videos()
+        assert len(files) == 1
+        assert files[0].name == "Standup.mp4"
+        assert files[0].id == "m1:rec1"
+        assert files[0].path == "https://dl/rec1"
+        assert files[0].mime_type == "video/mp4"
+        assert files[0].modified_at == "2026-01-01T09:00:00Z"
+
+    @patch(f"{TEAMS}._run_m365")
+    def test_approach2_teams_meeting_list(self, mock_run):
+        mock_run.side_effect = [
+            RuntimeError("onlineMeetings 404"),  # approach 1 fails
+            [{"id": "m2", "topic": "Retro", "createdDateTime": "2026-02-02T10:00:00Z"}],
+            {"value": [{"id": "rec2", "contentUrl": "https://dl/rec2"}]},  # recordings for m2
+        ]
+        files = TeamsRecordingSource().list_videos()
+        assert len(files) == 1
+        assert files[0].name == "Retro.mp4"
+        assert files[0].id == "m2:rec2"
+        # contentUrl is used when content.downloadUrl is absent.
+        assert files[0].path == "https://dl/rec2"
+        assert files[0].modified_at == "2026-02-02T10:00:00Z"
+
+    @patch(f"{TEAMS}._run_m365")
+    def test_approach3_chat_recording_links(self, mock_run):
+        mock_run.side_effect = [
+            {"value": []},  # approach 1: no meetings
+            [],  # approach 2: no meetings
+            {  # approach 3: chats with messages
+                "value": [
+                    {
+                        "id": "chat1",
+                        "topic": "Project Sync",
+                        "messages": [
+                            {
+                                "id": "msg1",
+                                "createdDateTime": "2026-03-03T00:00:00Z",
+                                "body": {"content": "Here is the recording of our call"},
+                            },
+                            {"id": "msg2", "body": {"content": "no link here"}},
+                        ],
+                    }
+                ]
+            },
+        ]
+        files = TeamsRecordingSource().list_videos()
+        assert len(files) == 1
+        assert files[0].name == "Project Sync.mp4"
+        assert files[0].id == "chat1:msg1"
+        assert files[0].mime_type == "video/mp4"
+        assert files[0].modified_at == "2026-03-03T00:00:00Z"
+
+    @patch(f"{TEAMS}._run_m365")
+    def test_no_recordings_found(self, mock_run):
+        mock_run.side_effect = [
+            {"value": []},
+            [],
+            {"value": []},
+        ]
+        assert TeamsRecordingSource().list_videos() == []
+
+    @patch(f"{TEAMS}._run_m365")
+    def test_all_approaches_error(self, mock_run):
+        mock_run.side_effect = RuntimeError("everything fails")
+        assert TeamsRecordingSource().list_videos() == []
+
+
+class TestTeamsDownload:
+    @patch(f"{TEAMS}._run_m365")
+    def test_download_with_direct_url(self, mock_run, tmp_path):
+        src = TeamsRecordingSource()
+        f = SourceFile(name="Standup.mp4", id="m1:rec1", path="https://dl/rec1")
+        dest = tmp_path / "out" / "Standup.mp4"
+        result = src.download(f, dest)
+        assert result == dest
+        assert dest.parent.is_dir()  # real mkdir happened
+        args = mock_run.call_args[0][0]
+        assert "https://dl/rec1" in args
+        assert "--filePath" in args and str(dest) in args
+
+    @patch(f"{TEAMS}._run_m365")
+    def test_download_with_recording_id(self, mock_run, tmp_path):
+        src = TeamsRecordingSource(user_id="user@example.com")
+        f = SourceFile(name="Standup.mp4", id="m1:rec1")  # no path
+        dest = tmp_path / "Standup.mp4"
+        src.download(f, dest)
+        args = mock_run.call_args[0][0]
+        url = args[args.index("--url") + 1]
+        assert url == (
+            "https://graph.microsoft.com/v1.0/user@example.com"
+            "/onlineMeetings/m1/recordings/rec1/content"
+        )
+
+    @patch(f"{TEAMS}._run_m365")
+    def test_download_resolves_recording_list(self, mock_run, tmp_path):
+        # id with no recording part -> fetch recordings list, use the first entry.
+        mock_run.side_effect = [
+            {"value": [{"id": "recX"}]},  # recordings listing
+            None,  # the content download call
+        ]
+        src = TeamsRecordingSource()
+        f = SourceFile(name="Meeting.mp4", id="m9")
+        src.download(f, tmp_path / "Meeting.mp4")
+        download_args = mock_run.call_args_list[1][0][0]
+        url = download_args[download_args.index("--url") + 1]
+        assert url.endswith("/onlineMeetings/m9/recordings/recX/content")
+
+    @patch(f"{TEAMS}._run_m365")
+    def test_download_empty_recording_list(self, mock_run, tmp_path):
+        mock_run.side_effect = [
+            {"value": []},  # no recordings resolved
+            None,  # download call
+        ]
+        src = TeamsRecordingSource()
+        f = SourceFile(name="Meeting.mp4", id="m9:")  # trailing colon -> empty rec id
+        src.download(f, tmp_path / "Meeting.mp4")
+        download_args = mock_run.call_args_list[1][0][0]
+        url = download_args[download_args.index("--url") + 1]
+        assert url.endswith("/onlineMeetings/m9/recordings")
+
+
+class TestTeamsFetchTranscript:
+    @patch(f"{TEAMS}._run_m365")
+    def test_success_raw_vtt_string(self, mock_run):
+        vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\n<v Alice>Hello team\n"
+        mock_run.side_effect = [
+            {"value": [{"id": "t1"}]},  # transcripts listing
+            vtt,  # transcript content
+        ]
+        assert TeamsRecordingSource().fetch_transcript("m1") == "Hello team"
+
+    @patch(f"{TEAMS}._run_m365")
+    def test_success_dict_with_raw_key(self, mock_run):
+        mock_run.side_effect = [
+            {"value": [{"id": "t1"}]},
+            {"raw": "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nWord\n"},
+        ]
+        assert TeamsRecordingSource().fetch_transcript("m1") == "Word"
+
+    @patch(f"{TEAMS}._run_m365")
+    def test_transcript_list_error_returns_none(self, mock_run):
+        mock_run.side_effect = RuntimeError("list failed")
+        assert TeamsRecordingSource().fetch_transcript("m1") is None
+
+    @patch(f"{TEAMS}._run_m365")
+    def test_no_transcripts_returns_none(self, mock_run):
+        mock_run.return_value = {"value": []}
+        assert TeamsRecordingSource().fetch_transcript("m1") is None
+
+    @patch(f"{TEAMS}._run_m365")
+    def test_content_download_error_returns_none(self, mock_run):
+        mock_run.side_effect = [
+            {"value": [{"id": "t1"}]},
+            RuntimeError("content failed"),
+        ]
+        assert TeamsRecordingSource().fetch_transcript("m1") is None
+
+    @patch(f"{TEAMS}._run_m365")
+    def test_empty_content_returns_none(self, mock_run):
+        mock_run.side_effect = [
+            {"value": [{"id": "t1"}]},
+            "",  # empty transcript body
+        ]
+        assert TeamsRecordingSource().fetch_transcript("m1") is None
+
+
+class TestTeamsExtractHelpers:
+    def test_extract_meetings_list_from_dict(self):
+        src = TeamsRecordingSource()
+        assert src._extract_meetings_list({"value": [{"id": "m1"}]}) == [{"id": "m1"}]
+
+    def test_extract_meetings_list_from_list(self):
+        src = TeamsRecordingSource()
+        assert src._extract_meetings_list([{"id": "m1"}]) == [{"id": "m1"}]
+
+    def test_extract_meetings_list_other_returns_empty(self):
+        assert TeamsRecordingSource()._extract_meetings_list("nope") == []
+
+    def test_extract_value_list_from_dict(self):
+        assert TeamsRecordingSource()._extract_value_list({"value": [1, 2]}) == [1, 2]
+
+    def test_extract_value_list_from_list(self):
+        assert TeamsRecordingSource()._extract_value_list([1, 2]) == [1, 2]
+
+    def test_extract_value_list_other_returns_empty(self):
+        assert TeamsRecordingSource()._extract_value_list(None) == []
+
+
+class TestTeamsGetMeetingRecordings:
+    @patch(f"{TEAMS}._run_m365")
+    def test_builds_source_files(self, mock_run):
+        mock_run.return_value = {
+            "value": [
+                {"id": "rec1", "content.downloadUrl": "https://dl/1"},
+                {"id": "rec2", "contentUrl": "https://dl/2"},
+            ]
+        }
+        meeting = {"id": "m1", "subject": "Planning", "startDateTime": "2026-01-01T00:00:00Z"}
+        files = TeamsRecordingSource()._get_meeting_recordings(meeting)
+        assert len(files) == 2
+        assert files[0].name == "Planning.mp4"
+        assert files[0].id == "m1:rec1"
+        assert files[0].path == "https://dl/1"
+        assert files[0].modified_at == "2026-01-01T00:00:00Z"
+        assert files[1].id == "m1:rec2"
+        assert files[1].path == "https://dl/2"  # contentUrl fallback
+
+    def test_missing_meeting_id_returns_empty(self):
+        assert TeamsRecordingSource()._get_meeting_recordings({}) == []
+
+    @patch(f"{TEAMS}._run_m365")
+    def test_recordings_error_returns_empty(self, mock_run):
+        mock_run.side_effect = RuntimeError("recordings 404")
+        assert TeamsRecordingSource()._get_meeting_recordings({"id": "m1", "subject": "X"}) == []
+
+    @patch(f"{TEAMS}._run_m365")
+    def test_topic_and_created_fallbacks(self, mock_run):
+        mock_run.return_value = {"value": [{"id": "rec1"}]}
+        # No subject -> topic; no startDateTime -> createdDateTime; no url keys -> path None.
+        meeting = {"id": "m1", "topic": "Weekly", "createdDateTime": "2026-05-05T00:00:00Z"}
+        files = TeamsRecordingSource()._get_meeting_recordings(meeting)
+        assert files[0].name == "Weekly.mp4"
+        assert files[0].modified_at == "2026-05-05T00:00:00Z"
+        assert files[0].path is None
+
+    @patch(f"{TEAMS}._run_m365")
+    def test_default_subject(self, mock_run):
+        mock_run.return_value = {"value": [{"id": "rec1"}]}
+        files = TeamsRecordingSource()._get_meeting_recordings({"id": "m1"})
+        assert files[0].name == "Teams Meeting.mp4"

--- a/tests/test_twitter_source.py
+++ b/tests/test_twitter_source.py
@@ -1,0 +1,157 @@
+"""Tests for TwitterSource: auth fallback, fetch, and download.
+
+Complements the import / constructor / authenticate / list_videos cases in
+tests/test_sources.py by exercising the gallery-dl auth branch, download,
+fetch_text routing, the API path, and the gallery-dl path. Network and
+subprocess boundaries are mocked; the real ``requests`` module stays intact so
+its exception types propagate through error handling.
+"""
+
+import json
+import os
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from video_processor.sources.base import SourceFile
+
+
+class TestTwitterAuthenticate:
+    @patch.dict(os.environ, {}, clear=True)
+    def test_authenticate_gallery_dl_available(self):
+        from video_processor.sources.twitter_source import TwitterSource
+
+        fake_gdl = types.ModuleType("gallery_dl")
+        with patch.dict("sys.modules", {"gallery_dl": fake_gdl}):
+            src = TwitterSource(url="https://twitter.com/u/status/1")
+            assert src.authenticate() is True
+
+
+class TestTwitterFetchViaApi:
+    @patch("requests.get")
+    def test_fetch_via_api(self, mock_get):
+        from video_processor.sources.twitter_source import TwitterSource
+
+        resp = MagicMock()
+        resp.json.return_value = {
+            "data": {
+                "text": "Hello tweet",
+                "created_at": "2026-01-01T00:00:00Z",
+                "author_id": "42",
+            }
+        }
+        resp.raise_for_status = MagicMock()
+        mock_get.return_value = resp
+
+        src = TwitterSource(url="https://twitter.com/user/status/1234567890")
+        src._bearer_token = "test_token"
+        text = src.fetch_text()
+
+        assert "Hello tweet" in text
+        assert "2026-01-01T00:00:00Z" in text
+        args, kwargs = mock_get.call_args
+        assert "1234567890" in args[0]
+        assert kwargs["headers"]["Authorization"] == "Bearer test_token"
+
+    def test_fetch_via_api_invalid_url(self):
+        from video_processor.sources.twitter_source import TwitterSource
+
+        src = TwitterSource(url="https://twitter.com/user/profile")  # no /status/
+        src._bearer_token = "token"
+        with pytest.raises(ValueError, match="Could not extract tweet ID"):
+            src.fetch_text()
+
+    @patch("requests.get")
+    def test_fetch_via_api_http_error_propagates(self, mock_get):
+        import requests
+
+        from video_processor.sources.twitter_source import TwitterSource
+
+        resp = MagicMock()
+        resp.raise_for_status.side_effect = requests.HTTPError("401")
+        mock_get.return_value = resp
+
+        src = TwitterSource(url="https://twitter.com/u/status/999")
+        src._bearer_token = "bad"
+        with pytest.raises(requests.HTTPError):
+            src.fetch_text()
+
+
+class TestTwitterFetchViaGalleryDl:
+    @patch("subprocess.run")
+    def test_fetch_via_gallery_dl_list(self, mock_run):
+        from video_processor.sources.twitter_source import TwitterSource
+
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps([{"content": "First tweet"}, {"text": "Second tweet"}]),
+            stderr="",
+        )
+        src = TwitterSource(url="https://twitter.com/u/status/1")  # no bearer token
+        text = src.fetch_text()
+
+        assert "First tweet" in text
+        assert "Second tweet" in text
+
+    @patch("subprocess.run")
+    def test_fetch_via_gallery_dl_single_dict(self, mock_run):
+        from video_processor.sources.twitter_source import TwitterSource
+
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=json.dumps({"content": "Only tweet"}), stderr=""
+        )
+        src = TwitterSource(url="https://twitter.com/u/status/1")
+        assert src.fetch_text() == "Only tweet"
+
+    @patch("subprocess.run")
+    def test_fetch_via_gallery_dl_failure(self, mock_run):
+        from video_processor.sources.twitter_source import TwitterSource
+
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="gallery-dl error")
+        src = TwitterSource(url="https://twitter.com/u/status/1")
+        with pytest.raises(RuntimeError, match="gallery-dl failed"):
+            src.fetch_text()
+
+    @patch("subprocess.run")
+    def test_fetch_via_gallery_dl_no_text(self, mock_run):
+        from video_processor.sources.twitter_source import TwitterSource
+
+        # Non-dict items are skipped, leaving no extractable text.
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout=json.dumps([["not", "a", "dict"], 42]), stderr=""
+        )
+        src = TwitterSource(url="https://twitter.com/u/status/1")
+        assert src.fetch_text() == "No text content extracted."
+
+    def test_fetch_text_no_method_raises(self):
+        from video_processor.sources.twitter_source import TwitterSource
+
+        src = TwitterSource(url="https://twitter.com/u/status/1")
+        with patch.object(
+            TwitterSource, "_fetch_via_gallery_dl", side_effect=ImportError("no gdl")
+        ):
+            with pytest.raises(RuntimeError, match="No Twitter extraction method"):
+                src.fetch_text()
+
+
+class TestTwitterDownload:
+    @patch("requests.get")
+    def test_download_writes_file(self, mock_get, tmp_path):
+        from video_processor.sources.twitter_source import TwitterSource
+
+        resp = MagicMock()
+        resp.json.return_value = {"data": {"text": "Downloaded tweet", "created_at": "2026-02-02"}}
+        resp.raise_for_status = MagicMock()
+        mock_get.return_value = resp
+
+        src = TwitterSource(url="https://twitter.com/u/status/555")
+        src._bearer_token = "token"
+        dest = tmp_path / "out" / "tweet.txt"
+
+        result = src.download(SourceFile(name="tweet", id="x"), dest)
+
+        assert result == dest
+        content = dest.read_text()
+        assert "Downloaded tweet" in content
+        assert "2026-02-02" in content

--- a/tests/test_wiki_generator.py
+++ b/tests/test_wiki_generator.py
@@ -1,0 +1,162 @@
+"""Tests for wiki_generator gaps: entity Sources rendering, JSON artifacts,
+the git push flow, and the skill execute() — none covered by test_agent_skills.py."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from video_processor.agent.skills.base import AgentContext, Artifact
+from video_processor.agent.skills.wiki_generator import (
+    WikiGeneratorSkill,
+    generate_wiki,
+    push_wiki,
+)
+
+_KG = {
+    "nodes": [
+        {
+            "name": "Alice",
+            "type": "person",
+            "descriptions": ["An engineer"],
+            "occurrences": [
+                {"source": "transcript_0", "timestamp": 12.5, "text": "Alice spoke"},
+                {"source": "notes"},
+            ],
+        },
+        {"name": "Python", "type": "technology", "descriptions": ["A language"]},
+        {"name": "", "type": "concept"},  # empty name -> skipped
+    ],
+    "relationships": [{"source": "Alice", "target": "Python", "type": "uses"}],
+}
+
+
+class TestGenerateWiki:
+    def test_entity_page_renders_sources_and_relationships(self):
+        pages = generate_wiki(_KG)
+        alice = pages["Alice"]
+        assert "## Sources" in alice
+        assert "**transcript_0** @ 12.5: _Alice spoke_" in alice
+        assert "**notes**" in alice  # occurrence with no timestamp/text
+        assert "## Relationships" in alice
+        assert "Python" in alice
+        # Python is a relationship target -> "Referenced By" section
+        assert "## Referenced By" in pages["Python"]
+
+    def test_empty_name_node_produces_no_page(self):
+        pages = generate_wiki(_KG)
+        # only Home, _Sidebar, type indexes (Person/Technology), Alice, Python
+        assert "" not in pages
+        assert set(pages) >= {"Home", "_Sidebar", "Person", "Technology", "Alice", "Python"}
+
+    def test_json_artifact_is_fenced_and_invalid_json_falls_back(self):
+        good = Artifact(
+            name="Task List",
+            content=json.dumps([{"t": 1}]),
+            artifact_type="task_list",
+            format="json",
+        )
+        bad = Artifact(name="Broken", content="{not json", artifact_type="task_list", format="json")
+        pages = generate_wiki(_KG, artifacts=[good, bad])
+        assert "```json" in pages["Task-List"]
+        # invalid JSON falls back to the raw content, unfenced
+        assert pages["Broken"] == "# Broken\n\n{not json"
+        # artifacts are linked from Home
+        assert "Planning Artifacts" in pages["Home"]
+
+
+def _fake_git(returncodes):
+    """Build a subprocess.run stand-in keyed on the git subcommand/branch.
+
+    On a successful clone it creates the clone dir (as real git would) so the
+    subsequent page copy has somewhere to write.
+    """
+
+    def run(cmd, **kwargs):
+        rc = 0
+        if cmd[:2] == ["git", "clone"]:
+            rc = returncodes.get("clone", 0)
+            if rc == 0:
+                Path(cmd[3]).mkdir(parents=True, exist_ok=True)
+        elif len(cmd) >= 2 and cmd[1] == "commit":
+            rc = returncodes.get("commit", 0)
+        elif cmd[:3] == ["git", "push", "origin"]:
+            rc = returncodes.get(f"push_{cmd[3]}", 0)
+        return MagicMock(returncode=rc, stdout="", stderr="")
+
+    return run
+
+
+class TestPushWiki:
+    def _wiki_dir(self, tmp_path):
+        d = tmp_path / "wiki"
+        d.mkdir()
+        (d / "Home.md").write_text("# Home")
+        return d
+
+    def test_push_success_master(self, tmp_path):
+        wiki = self._wiki_dir(tmp_path)
+        (wiki / ".wiki_clone").mkdir()  # pre-existing clone dir -> exercises rm -rf
+        with patch(
+            "video_processor.agent.skills.wiki_generator.subprocess.run",
+            side_effect=_fake_git({}),
+        ) as mock_run:
+            assert push_wiki(wiki, "org/repo") is True
+        cmds = [c.args[0] for c in mock_run.call_args_list]
+        assert ["git", "push", "origin", "master"] in cmds
+        # the page was copied into the clone
+        assert (wiki / ".wiki_clone" / "Home.md").read_text() == "# Home"
+
+    def test_clone_failure_initializes_repo(self, tmp_path):
+        wiki = self._wiki_dir(tmp_path)
+        with patch(
+            "video_processor.agent.skills.wiki_generator.subprocess.run",
+            side_effect=_fake_git({"clone": 1}),
+        ) as mock_run:
+            assert push_wiki(wiki, "org/repo") is True
+        cmds = [c.args[0] for c in mock_run.call_args_list]
+        assert ["git", "init"] in cmds
+        assert any(c[:3] == ["git", "remote", "add"] for c in cmds)
+
+    def test_nothing_to_commit_returns_true(self, tmp_path):
+        wiki = self._wiki_dir(tmp_path)
+        with patch(
+            "video_processor.agent.skills.wiki_generator.subprocess.run",
+            side_effect=_fake_git({"commit": 1}),
+        ) as mock_run:
+            assert push_wiki(wiki, "org/repo") is True
+        cmds = [c.args[0] for c in mock_run.call_args_list]
+        # never reaches push when there is nothing to commit
+        assert not any(c[:2] == ["git", "push"] for c in cmds)
+
+    def test_falls_back_to_main_branch(self, tmp_path):
+        wiki = self._wiki_dir(tmp_path)
+        with patch(
+            "video_processor.agent.skills.wiki_generator.subprocess.run",
+            side_effect=_fake_git({"push_master": 1, "push_main": 0}),
+        ) as mock_run:
+            assert push_wiki(wiki, "org/repo") is True
+        cmds = [c.args[0] for c in mock_run.call_args_list]
+        assert ["git", "push", "origin", "main"] in cmds
+
+    def test_push_failure_returns_false(self, tmp_path):
+        wiki = self._wiki_dir(tmp_path)
+        with patch(
+            "video_processor.agent.skills.wiki_generator.subprocess.run",
+            side_effect=_fake_git({"push_master": 1, "push_main": 1}),
+        ):
+            assert push_wiki(wiki, "org/repo") is False
+
+
+class TestWikiGeneratorSkill:
+    def test_execute_returns_summary_with_pages_metadata(self):
+        ctx = AgentContext()
+        ctx.knowledge_graph = MagicMock()
+        ctx.knowledge_graph.to_dict.return_value = _KG
+        ctx.artifacts = []
+        result = WikiGeneratorSkill().execute(ctx, title="My KB")
+        assert result.artifact_type == "wiki"
+        assert "Generated" in result.content
+        assert "Home.md" in result.content
+        # actual page bodies are returned in metadata for write_wiki()
+        assert "Home" in result.metadata["pages"]
+        assert result.metadata["pages"]["Home"].startswith("# My KB")

--- a/tests/test_zoom_source.py
+++ b/tests/test_zoom_source.py
@@ -1,0 +1,470 @@
+"""Tests for the Zoom cloud recordings source (video_processor.sources.zoom_source).
+
+Mocks are applied only at the ``requests`` boundary (plus ``webbrowser``/``input``
+for the interactive PKCE flow). Real token files are written to ``tmp_path`` and
+read back to assert on persisted contents.
+"""
+
+import json
+import os
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from video_processor.sources.base import SourceFile
+from video_processor.sources.zoom_source import ZoomSource
+
+
+def _mock_response(*, json_data=None, text=None, chunks=None, raise_error=None):
+    """Build a MagicMock that mimics the parts of requests.Response we use."""
+    resp = MagicMock()
+    if raise_error is None:
+        resp.raise_for_status.return_value = None
+    else:
+        resp.raise_for_status.side_effect = raise_error
+    if json_data is not None:
+        resp.json.return_value = json_data
+    if text is not None:
+        resp.text = text
+    if chunks is not None:
+        resp.iter_content.return_value = chunks
+    return resp
+
+
+class TestZoomSavedToken:
+    def test_valid_token_sets_access_token(self, tmp_path):
+        token_file = tmp_path / "zoom_token.json"
+        token_file.write_text(
+            json.dumps({"access_token": "valid-token", "expires_at": time.time() + 10_000})
+        )
+        src = ZoomSource(token_path=token_file)
+        assert src._auth_saved_token() is True
+        assert src._access_token == "valid-token"
+        assert src._token_data["access_token"] == "valid-token"
+
+    def test_expired_with_refresh_token_delegates_to_refresh(self, tmp_path):
+        token_file = tmp_path / "zoom_token.json"
+        token_file.write_text(
+            json.dumps({"access_token": "old", "expires_at": 0, "refresh_token": "rt"})
+        )
+        src = ZoomSource(token_path=token_file)
+        with patch.object(src, "_refresh_token", return_value=True) as mock_refresh:
+            assert src._auth_saved_token() is True
+            mock_refresh.assert_called_once()
+
+    def test_expired_without_refresh_token_returns_false(self, tmp_path):
+        token_file = tmp_path / "zoom_token.json"
+        token_file.write_text(json.dumps({"access_token": "old", "expires_at": 0}))
+        src = ZoomSource(token_path=token_file)
+        assert src._auth_saved_token() is False
+        assert src._access_token is None
+
+    def test_missing_file_returns_false(self, tmp_path):
+        src = ZoomSource(token_path=tmp_path / "does-not-exist.json")
+        assert src._auth_saved_token() is False
+
+    def test_malformed_json_returns_false(self, tmp_path):
+        token_file = tmp_path / "zoom_token.json"
+        token_file.write_text("not valid json {{{")
+        src = ZoomSource(token_path=token_file)
+        assert src._auth_saved_token() is False
+
+
+class TestZoomServerToServer:
+    @patch.dict(os.environ, {}, clear=True)
+    def test_missing_credentials_returns_false(self):
+        src = ZoomSource(client_id=None, client_secret=None, account_id="acct")
+        assert src._auth_server_to_server() is False
+
+    @patch("video_processor.sources.zoom_source.requests.post")
+    def test_success_persists_token(self, mock_post, tmp_path):
+        token_file = tmp_path / ".planopticon" / "zoom_token.json"
+        mock_post.return_value = _mock_response(
+            json_data={
+                "access_token": "s2s-token",
+                "expires_in": 3600,
+                "token_type": "bearer",
+            }
+        )
+        src = ZoomSource(
+            client_id="cid",
+            client_secret="sec",
+            account_id="acct",
+            token_path=token_file,
+        )
+        assert src._auth_server_to_server() is True
+        assert src._access_token == "s2s-token"
+        saved = json.loads(token_file.read_text())
+        assert saved["access_token"] == "s2s-token"
+        assert "refresh_token" not in saved
+        _, kwargs = mock_post.call_args
+        assert kwargs["auth"] == ("cid", "sec")
+        assert kwargs["params"]["grant_type"] == "account_credentials"
+        assert kwargs["params"]["account_id"] == "acct"
+
+    @patch("video_processor.sources.zoom_source.requests.post")
+    def test_http_error_returns_false(self, mock_post, tmp_path):
+        token_file = tmp_path / "zoom_token.json"
+        mock_post.return_value = _mock_response(raise_error=requests.HTTPError("500"))
+        src = ZoomSource(
+            client_id="cid",
+            client_secret="sec",
+            account_id="acct",
+            token_path=token_file,
+        )
+        assert src._auth_server_to_server() is False
+        assert src._access_token is None
+        assert not token_file.exists()
+
+
+class TestZoomOAuthPKCE:
+    @patch.dict(os.environ, {}, clear=True)
+    def test_missing_client_id_returns_false(self):
+        src = ZoomSource(client_id=None)
+        assert src._auth_oauth_pkce() is False
+
+    @patch("video_processor.sources.zoom_source.requests.post")
+    @patch("builtins.input", return_value="the-auth-code")
+    @patch("video_processor.sources.zoom_source.webbrowser.open")
+    def test_success_persists_token(self, mock_open, mock_input, mock_post, tmp_path):
+        token_file = tmp_path / "zoom_token.json"
+        mock_post.return_value = _mock_response(
+            json_data={
+                "access_token": "pkce-token",
+                "refresh_token": "pkce-refresh",
+                "expires_in": 3600,
+                "token_type": "bearer",
+            }
+        )
+        src = ZoomSource(client_id="cid", client_secret="csec", token_path=token_file)
+        assert src._auth_oauth_pkce() is True
+        assert src._access_token == "pkce-token"
+        mock_open.assert_called_once()
+        mock_input.assert_called_once()
+        saved = json.loads(token_file.read_text())
+        assert saved["access_token"] == "pkce-token"
+        assert saved["refresh_token"] == "pkce-refresh"
+        assert saved["client_id"] == "cid"
+        _, kwargs = mock_post.call_args
+        assert kwargs["data"]["grant_type"] == "authorization_code"
+        assert kwargs["data"]["code"] == "the-auth-code"
+
+    @patch("video_processor.sources.zoom_source.requests.post")
+    @patch("builtins.input", return_value="code2")
+    @patch(
+        "video_processor.sources.zoom_source.webbrowser.open",
+        side_effect=Exception("no browser available"),
+    )
+    def test_browser_open_failure_is_ignored(self, mock_open, mock_input, mock_post, tmp_path):
+        token_file = tmp_path / "zoom_token.json"
+        mock_post.return_value = _mock_response(
+            json_data={"access_token": "tok", "expires_in": 3600}
+        )
+        src = ZoomSource(client_id="cid", token_path=token_file)
+        assert src._auth_oauth_pkce() is True
+        assert src._access_token == "tok"
+        mock_input.assert_called_once()
+
+    @patch("video_processor.sources.zoom_source.requests.post")
+    @patch("builtins.input", return_value="the-auth-code")
+    @patch("video_processor.sources.zoom_source.webbrowser.open")
+    def test_token_exchange_error_returns_false(self, mock_open, mock_input, mock_post, tmp_path):
+        token_file = tmp_path / "zoom_token.json"
+        mock_post.return_value = _mock_response(raise_error=requests.HTTPError("bad code"))
+        src = ZoomSource(client_id="cid", client_secret="csec", token_path=token_file)
+        assert src._auth_oauth_pkce() is False
+        assert src._access_token is None
+        assert not token_file.exists()
+
+
+class TestZoomRefreshToken:
+    @patch("video_processor.sources.zoom_source.requests.post")
+    def test_success_rewrites_token(self, mock_post, tmp_path):
+        token_file = tmp_path / "zoom_token.json"
+        token_file.write_text(
+            json.dumps(
+                {
+                    "access_token": "old",
+                    "refresh_token": "old-refresh",
+                    "client_id": "cid",
+                    "client_secret": "sec",
+                    "expires_at": 0,
+                }
+            )
+        )
+        mock_post.return_value = _mock_response(
+            json_data={
+                "access_token": "refreshed",
+                "refresh_token": "new-refresh",
+                "expires_in": 3600,
+            }
+        )
+        src = ZoomSource(token_path=token_file)
+        assert src._refresh_token() is True
+        assert src._access_token == "refreshed"
+        saved = json.loads(token_file.read_text())
+        assert saved["access_token"] == "refreshed"
+        assert saved["refresh_token"] == "new-refresh"
+        _, kwargs = mock_post.call_args
+        assert kwargs["data"]["grant_type"] == "refresh_token"
+        assert kwargs["auth"] == ("cid", "sec")
+
+    @patch("video_processor.sources.zoom_source.requests.post")
+    def test_keeps_old_refresh_token_when_response_omits_it(self, mock_post, tmp_path):
+        token_file = tmp_path / "zoom_token.json"
+        token_file.write_text(
+            json.dumps({"refresh_token": "old-refresh", "client_id": "cid", "client_secret": "sec"})
+        )
+        mock_post.return_value = _mock_response(
+            json_data={"access_token": "refreshed", "expires_in": 3600}
+        )
+        src = ZoomSource(token_path=token_file)
+        assert src._refresh_token() is True
+        saved = json.loads(token_file.read_text())
+        assert saved["refresh_token"] == "old-refresh"
+
+    def test_missing_refresh_token_returns_false(self, tmp_path):
+        token_file = tmp_path / "zoom_token.json"
+        token_file.write_text(json.dumps({"client_id": "cid"}))
+        src = ZoomSource(token_path=token_file)
+        assert src._refresh_token() is False
+
+    @patch("video_processor.sources.zoom_source.requests.post")
+    def test_http_error_returns_false(self, mock_post, tmp_path):
+        token_file = tmp_path / "zoom_token.json"
+        token_file.write_text(
+            json.dumps({"refresh_token": "rt", "client_id": "cid", "client_secret": "sec"})
+        )
+        mock_post.return_value = _mock_response(raise_error=requests.HTTPError("bad"))
+        src = ZoomSource(token_path=token_file)
+        assert src._refresh_token() is False
+
+
+class TestZoomAuthenticateDispatch:
+    def test_saved_token_path(self, tmp_path):
+        token_file = tmp_path / "zoom_token.json"
+        token_file.write_text(json.dumps({"access_token": "x", "expires_at": 0}))
+        src = ZoomSource(token_path=token_file)
+        with patch.object(src, "_auth_saved_token", return_value=True) as mock_saved:
+            assert src.authenticate() is True
+            mock_saved.assert_called_once()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_account_id_path(self, tmp_path):
+        src = ZoomSource(account_id="acct", token_path=tmp_path / "none.json")
+        with patch.object(src, "_auth_server_to_server", return_value=True) as mock_s2s:
+            assert src.authenticate() is True
+            mock_s2s.assert_called_once()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_pkce_path(self, tmp_path):
+        src = ZoomSource(token_path=tmp_path / "none.json")
+        with patch.object(src, "_auth_oauth_pkce", return_value=True) as mock_pkce:
+            assert src.authenticate() is True
+            mock_pkce.assert_called_once()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_saved_token_failure_falls_back_to_account(self, tmp_path):
+        token_file = tmp_path / "zoom_token.json"
+        token_file.write_text(json.dumps({"access_token": "x", "expires_at": 0}))
+        src = ZoomSource(account_id="acct", token_path=token_file)
+        with (
+            patch.object(src, "_auth_saved_token", return_value=False),
+            patch.object(src, "_auth_server_to_server", return_value=True) as mock_s2s,
+        ):
+            assert src.authenticate() is True
+            mock_s2s.assert_called_once()
+
+
+class TestZoomApiGet:
+    def test_not_authenticated_raises(self):
+        src = ZoomSource()
+        with pytest.raises(RuntimeError, match="Not authenticated"):
+            src._api_get("users/me/recordings")
+
+    @patch("video_processor.sources.zoom_source.requests.get")
+    def test_authenticated_returns_response(self, mock_get):
+        resp = _mock_response(json_data={"ok": True})
+        mock_get.return_value = resp
+        src = ZoomSource()
+        src._access_token = "tok"
+        result = src._api_get("/users/me/recordings", params={"a": "b"})
+        assert result is resp
+        url = mock_get.call_args.args[0]
+        assert url.endswith("/users/me/recordings")
+        _, kwargs = mock_get.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer tok"
+        assert kwargs["params"] == {"a": "b"}
+
+
+class TestZoomListVideos:
+    def test_not_authenticated_raises(self):
+        src = ZoomSource()
+        with pytest.raises(RuntimeError, match="Not authenticated"):
+            src.list_videos()
+
+    @patch("video_processor.sources.zoom_source.requests.get")
+    def test_pagination_and_parsing(self, mock_get):
+        page1 = _mock_response(
+            json_data={
+                "meetings": [
+                    {
+                        "id": 111,
+                        "topic": "Standup",
+                        "start_time": "2026-01-01T00:00:00Z",
+                        "recording_files": [
+                            {
+                                "file_type": "MP4",
+                                "file_extension": "MP4",
+                                "file_size": 1000,
+                                "download_url": "https://dl/1",
+                            },
+                            {
+                                "file_type": "M4A",
+                                "file_extension": "M4A",
+                                "file_size": 500,
+                                "download_url": "https://dl/2",
+                            },
+                        ],
+                    }
+                ],
+                "next_page_token": "PAGE2",
+            }
+        )
+        page2 = _mock_response(
+            json_data={
+                "meetings": [
+                    {
+                        "id": 222,
+                        "topic": "Retro",
+                        "recording_files": [
+                            {
+                                "file_type": "TRANSCRIPT",
+                                "file_extension": "VTT",
+                                "download_url": "https://dl/3",
+                            }
+                        ],
+                    }
+                ],
+                "next_page_token": "",
+            }
+        )
+        mock_get.side_effect = [page1, page2]
+        src = ZoomSource()
+        src._access_token = "tok"
+        files = src.list_videos()
+        assert mock_get.call_count == 2
+        assert [f.name for f in files] == ["Standup.mp4", "Standup.m4a", "Retro.vtt"]
+        assert [f.mime_type for f in files] == ["video/mp4", "audio/mp4", "text/vtt"]
+        assert [f.path for f in files] == ["https://dl/1", "https://dl/2", "https://dl/3"]
+        assert [f.id for f in files] == ["111", "111", "222"]
+        assert mock_get.call_args_list[1].kwargs["params"]["next_page_token"] == "PAGE2"
+
+    @patch("video_processor.sources.zoom_source.requests.get")
+    def test_pattern_filter_excludes_non_matching(self, mock_get):
+        mock_get.return_value = _mock_response(
+            json_data={
+                "meetings": [
+                    {
+                        "id": 5,
+                        "topic": "Sync",
+                        "recording_files": [
+                            {
+                                "file_type": "MP4",
+                                "file_extension": "mp4",
+                                "download_url": "https://dl/a",
+                            },
+                            {
+                                "file_type": "TRANSCRIPT",
+                                "file_extension": "vtt",
+                                "download_url": "https://dl/b",
+                            },
+                        ],
+                    }
+                ],
+                "next_page_token": "",
+            }
+        )
+        src = ZoomSource()
+        src._access_token = "tok"
+        files = src.list_videos(patterns=["*.mp4"])
+        assert len(files) == 1
+        assert files[0].name == "Sync.mp4"
+
+
+class TestZoomDownload:
+    def test_not_authenticated_raises(self, tmp_path):
+        src = ZoomSource()
+        f = SourceFile(name="x.mp4", id="1", path="https://dl/x")
+        with pytest.raises(RuntimeError, match="Not authenticated"):
+            src.download(f, tmp_path / "x.mp4")
+
+    def test_missing_download_url_raises_value_error(self, tmp_path):
+        src = ZoomSource()
+        src._access_token = "tok"
+        f = SourceFile(name="x.mp4", id="1")
+        with pytest.raises(ValueError, match="No download URL"):
+            src.download(f, tmp_path / "x.mp4")
+
+    @patch("video_processor.sources.zoom_source.requests.get")
+    def test_success_streams_chunks_to_file(self, mock_get, tmp_path):
+        mock_get.return_value = _mock_response(chunks=[b"aaa", b"bbb"])
+        src = ZoomSource()
+        src._access_token = "tok"
+        f = SourceFile(name="x.mp4", id="1", path="https://dl/x")
+        dest = tmp_path / "sub" / "x.mp4"
+        result = src.download(f, dest)
+        assert result == dest
+        assert dest.read_bytes() == b"aaabbb"
+        _, kwargs = mock_get.call_args
+        assert kwargs["stream"] is True
+        assert kwargs["headers"]["Authorization"] == "Bearer tok"
+
+
+class TestZoomFetchTranscript:
+    def test_not_authenticated_raises(self):
+        src = ZoomSource()
+        with pytest.raises(RuntimeError, match="Not authenticated"):
+            src.fetch_transcript("m1")
+
+    @patch("video_processor.sources.zoom_source.requests.get")
+    def test_transcript_present_returns_text(self, mock_get):
+        api_resp = _mock_response(
+            json_data={
+                "recording_files": [{"file_type": "TRANSCRIPT", "download_url": "https://t"}]
+            }
+        )
+        dl_resp = _mock_response(text="WEBVTT\nhello")
+        mock_get.side_effect = [api_resp, dl_resp]
+        src = ZoomSource()
+        src._access_token = "tok"
+        assert src.fetch_transcript("m1") == "WEBVTT\nhello"
+        assert mock_get.call_count == 2
+
+    @patch("video_processor.sources.zoom_source.requests.get")
+    def test_transcript_present_without_url_returns_none(self, mock_get):
+        mock_get.return_value = _mock_response(
+            json_data={"recording_files": [{"file_type": "TRANSCRIPT"}]}
+        )
+        src = ZoomSource()
+        src._access_token = "tok"
+        assert src.fetch_transcript("m1") is None
+        assert mock_get.call_count == 1
+
+    @patch("video_processor.sources.zoom_source.requests.get")
+    def test_no_transcript_returns_none(self, mock_get):
+        mock_get.return_value = _mock_response(
+            json_data={"recording_files": [{"file_type": "MP4", "download_url": "x"}]}
+        )
+        src = ZoomSource()
+        src._access_token = "tok"
+        assert src.fetch_transcript("m1") is None
+
+    @patch("video_processor.sources.zoom_source.requests.get")
+    def test_exception_returns_none(self, mock_get):
+        mock_get.side_effect = requests.RequestException("boom")
+        src = ZoomSource()
+        src._access_token = "tok"
+        assert src.fetch_transcript("m1") is None


### PR DESCRIPTION
## Summary

Third and final slice for #141 — clears the 80% floor.

Meaningful tests across the biggest remaining core gaps: CLI command paths (CliRunner against real SQLite graphs), source connectors (HTTP/SDK boundary mocks, real parsing/mapping), exchange round-trips and merge dedup, agent orchestrator/skills, auth manager, and the companion REPL. Real database throughout; mocks only at LLM/network boundaries.

TOTAL: 67% → **85%** (floor 80%, next stop 90%).

One real bug found during testing (agent orchestrator `_reflect_and_enrich`) — being filed as its own issue, not fixed here.

## Test plan

Full suite 1553 passed, 0 failures, ruff clean.