### PR TITLE
Implement missing _reflect_and_enrich orchestrator phase

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,6 +131,42 @@ class TestAgentAnalyzeHelp:
         assert "--provider" in result.output
 
 
+class TestAgentAnalyzeRun:
+    def test_completes_and_writes_manifest(self, tmp_path):
+        """Regression for #151: agent-analyze must complete and write manifest.json.
+
+        Previously ``process()`` called the undefined ``_reflect_and_enrich()`` and
+        the command's try/except exited 1 with no output. The provider is mocked so
+        the real orchestration runs against a dummy (non-video) input whose
+        extraction steps degrade gracefully, and the run reaches the manifest.
+        """
+        from unittest.mock import MagicMock, patch
+
+        video = tmp_path / "clip.mp4"
+        video.write_bytes(b"not really a video")  # must exist for click.Path(exists=True)
+        out = tmp_path / "out"
+
+        pm = MagicMock()
+        pm.chat.return_value = "A concise summary."
+        pm.transcribe_audio.return_value = {"text": "", "segments": []}
+        pm.get_models_used.return_value = {"chat": "mock-chat"}
+
+        runner = CliRunner()
+        with patch("video_processor.providers.manager.ProviderManager", return_value=pm):
+            result = runner.invoke(
+                cli,
+                ["agent-analyze", "-i", str(video), "-o", str(out), "--depth", "basic"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert (out / "manifest.json").exists()
+        # The written manifest round-trips as a VideoManifest.
+        from video_processor.output_structure import read_video_manifest
+
+        manifest = read_video_manifest(out)
+        assert manifest.video.source_path == str(video)
+
+
 class TestListModelsHelp:
     def test_help(self):
         runner = CliRunner()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -20,7 +20,7 @@ import pytest
 
 from video_processor.agent.orchestrator import AgentOrchestrator
 from video_processor.integrators.knowledge_graph import KnowledgeGraph
-from video_processor.models import DiagramResult, KeyPoint
+from video_processor.models import ActionItem, DiagramResult, KeyPoint, VideoManifest
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -334,27 +334,144 @@ class TestGenerateReports:
 
 
 # ---------------------------------------------------------------------------
-# process — end-to-end drive
+# _reflect_and_enrich — Phase 3 consolidation pass
 #
-# NOTE: process() references self._reflect_and_enrich(), which is not defined
-# anywhere in AgentOrchestrator. The method therefore raises AttributeError
-# after the execute loop finishes. This test pins that current (buggy) behavior
-# while still asserting the real work that happens first: the plan is built,
-# every step's result is recorded (with graceful error entries for the steps
-# that need a real video file), and report generation succeeds. If/when
-# _reflect_and_enrich is implemented, the pytest.raises below should be updated.
+# Reflection runs one LLM pass over a compact summary of the executed steps and
+# merges consolidated insight strings into self._insights (deduped). It is
+# best-effort: any LLM/parse failure is swallowed so process() can still build
+# the manifest with the insights already accumulated during execution.
 # ---------------------------------------------------------------------------
 
 
+class TestReflectAndEnrich:
+    def test_merges_and_dedupes_new_insights(self, tmp_path):
+        # The reflection response mixes a duplicate of an existing insight, an
+        # empty string and a non-string entry among two genuinely new insights.
+        pm = _make_pm(
+            chat=json.dumps(
+                [
+                    "Theme: the team keeps circling back to onboarding",
+                    "",  # empty → skipped
+                    42,  # non-string → skipped
+                    "Existing insight",  # duplicate → deduped
+                    "Risk: the Q3 deadline has no owner",
+                ]
+            )
+        )
+        agent = AgentOrchestrator(provider_manager=pm)
+        agent._insights = ["Existing insight"]
+        agent._results["transcribe"] = {"text": "a transcript worth reflecting on"}
+        agent._results["extract_key_points"] = {"key_points": [KeyPoint(point="Adopt SSO")]}
+        agent._results["extract_action_items"] = {
+            "action_items": [ActionItem(action="Assign a deadline owner")]
+        }
+
+        agent._reflect_and_enrich(tmp_path)
+
+        pm.chat.assert_called_once()
+        # Duplicate/empty/non-string dropped; the two new insights appended in order.
+        assert agent.insights == [
+            "Existing insight",
+            "Theme: the team keeps circling back to onboarding",
+            "Risk: the Q3 deadline has no owner",
+        ]
+
+    def test_summary_covers_key_points_and_action_items(self, tmp_path):
+        # The compact summary the LLM reflects over includes the extracted point
+        # and action text, so reflection reasons over real step output.
+        pm = _make_pm(chat="[]")
+        agent = AgentOrchestrator(provider_manager=pm)
+        agent._results["transcribe"] = {"text": "transcript body"}
+        agent._results["extract_key_points"] = {"key_points": [KeyPoint(point="Adopt SSO")]}
+        agent._results["extract_action_items"] = {
+            "action_items": [ActionItem(action="Email the runbook")]
+        }
+
+        agent._reflect_and_enrich(tmp_path)
+
+        prompt = pm.chat.call_args.args[0][0]["content"]
+        assert "Adopt SSO" in prompt
+        assert "Email the runbook" in prompt
+        assert "transcript body" in prompt
+
+    def test_chat_error_preserves_insights(self, tmp_path):
+        # An LLM failure during reflection must not raise or lose prior insights.
+        pm = _make_pm()
+        pm.chat.side_effect = RuntimeError("provider exploded")
+        agent = AgentOrchestrator(provider_manager=pm)
+        agent._insights = ["Pre-reflection insight"]
+        agent._results["transcribe"] = {"text": "a transcript worth reflecting on"}
+
+        agent._reflect_and_enrich(tmp_path)  # no exception propagates
+
+        assert agent.insights == ["Pre-reflection insight"]
+
+    def test_malformed_json_preserves_insights(self, tmp_path):
+        # A response that is not JSON parses to None → nothing merged, no crash.
+        pm = _make_pm(chat="Sorry, I could not produce structured output.")
+        agent = AgentOrchestrator(provider_manager=pm)
+        agent._insights = ["Pre-reflection insight"]
+        agent._results["transcribe"] = {"text": "a transcript worth reflecting on"}
+
+        agent._reflect_and_enrich(tmp_path)
+
+        assert agent.insights == ["Pre-reflection insight"]
+
+    def test_skips_llm_when_nothing_extracted(self, tmp_path):
+        # No transcript / points / items / prior insights → no reason to reflect,
+        # so the LLM is not called at all.
+        pm = _make_pm()
+        agent = AgentOrchestrator(provider_manager=pm)
+
+        agent._reflect_and_enrich(tmp_path)
+
+        pm.chat.assert_not_called()
+        assert agent.insights == []
+
+
+# ---------------------------------------------------------------------------
+# process — end-to-end drive
+#
+# process() runs plan → execute → reflect → manifest and returns a
+# VideoManifest. With a missing video the extraction steps degrade gracefully
+# (their errors are recorded), the downstream steps run against empty input, and
+# reflection is skipped (nothing was extracted). The dedicated reflection cases
+# below seed insights so Phase 3 actually runs inside a full process() call.
+# ---------------------------------------------------------------------------
+
+
+def _reflection_chat(reflection_response):
+    """side_effect that answers the reflection prompt distinctly from the rest.
+
+    Every other chat call (e.g. report-summary generation) returns a short
+    string; the reflection call is matched on its stable prompt preamble.
+    ``reflection_response`` may be a value to return or an exception to raise.
+    """
+
+    def _chat(messages, *args, **kwargs):
+        content = messages[0]["content"] if messages else ""
+        if "reflecting on the results" in content:
+            if isinstance(reflection_response, Exception):
+                raise reflection_response
+            return reflection_response
+        return "A concise summary."
+
+    return _chat
+
+
 class TestProcess:
-    def test_plan_and_results_recorded_before_missing_reflect_step(self, tmp_path):
+    def test_returns_manifest_with_basic_plan(self, tmp_path):
         pm = _make_pm(chat="A concise summary.")
         agent = AgentOrchestrator(provider_manager=pm, max_retries=1)
         video = tmp_path / "missing.mp4"  # does not exist → extraction steps fail
         out = tmp_path / "out"
 
-        with pytest.raises(AttributeError, match="_reflect_and_enrich"):
-            agent.process(video, out, initial_depth="basic")
+        manifest = agent.process(video, out, initial_depth="basic")
+
+        # Phase 4: process() now completes and returns a manifest.
+        assert isinstance(manifest, VideoManifest)
+        assert manifest.video.source_path == str(video)
+        assert manifest.stats.duration_seconds >= 0
 
         # Phase 1: the basic plan was created in the expected order.
         assert [s["step"] for s in agent._plan] == [
@@ -382,15 +499,15 @@ class TestProcess:
         # Comprehensive depth adds detect_diagrams, build_knowledge_graph,
         # deep_analysis and cross_reference to the plan. With no real video these
         # run against empty upstream results, exercising each step's empty-input
-        # branch before process() hits the same missing _reflect_and_enrich step.
+        # branch before process() reflects (a no-op here) and builds the manifest.
         pm = _make_pm(chat="A summary.")
         agent = AgentOrchestrator(provider_manager=pm, max_retries=1)
         video = tmp_path / "missing.mp4"
         out = tmp_path / "out"
 
-        with pytest.raises(AttributeError, match="_reflect_and_enrich"):
-            agent.process(video, out, initial_depth="comprehensive")
+        manifest = agent.process(video, out, initial_depth="comprehensive")
 
+        assert isinstance(manifest, VideoManifest)
         assert [s["step"] for s in agent._plan] == [
             "extract_frames",
             "extract_audio",
@@ -411,3 +528,34 @@ class TestProcess:
         # deep_analysis on empty text returns nothing; cross_reference still runs.
         assert agent._results["deep_analysis"] == {}
         assert agent._results["cross_reference"] == {"enriched": True}
+
+    def test_process_surfaces_reflection_insights(self, tmp_path):
+        # A seeded insight makes Phase 3 run inside process(); the reflection
+        # response's insights are surfaced through agent.insights on the returned run.
+        pm = _make_pm()
+        pm.chat.side_effect = _reflection_chat(
+            json.dumps(["Reflected: the timeline needs an owner"])
+        )
+        agent = AgentOrchestrator(provider_manager=pm, max_retries=1)
+        agent._insights = ["Seed insight from execution"]
+        out = tmp_path / "out"
+
+        manifest = agent.process(tmp_path / "missing.mp4", out, initial_depth="basic")
+
+        assert isinstance(manifest, VideoManifest)
+        assert "Reflected: the timeline needs an owner" in agent.insights
+        assert "Seed insight from execution" in agent.insights
+
+    def test_process_completes_when_reflection_fails(self, tmp_path):
+        # Reflection raising must not break the run: process() still returns a
+        # manifest and the pre-reflection insights are left intact.
+        pm = _make_pm()
+        pm.chat.side_effect = _reflection_chat(RuntimeError("reflection provider down"))
+        agent = AgentOrchestrator(provider_manager=pm, max_retries=1)
+        agent._insights = ["Seed insight from execution"]
+        out = tmp_path / "out"
+
+        manifest = agent.process(tmp_path / "missing.mp4", out, initial_depth="basic")
+
+        assert isinstance(manifest, VideoManifest)
+        assert agent.insights == ["Seed insight from execution"]

--- a/video_processor/agent/orchestrator.py
+++ b/video_processor/agent/orchestrator.py
@@ -375,6 +375,79 @@ class AgentOrchestrator:
 
         return {"report_path": str(md_path)}
 
+    def _reflect_and_enrich(self, output_dir: Path) -> None:
+        """Phase 3: reflect over the executed steps and consolidate insights.
+
+        Runs a single LLM pass over a compact summary of what the pipeline
+        produced — a transcript excerpt, the extracted key points and action
+        items, the diagram count, and the insights gathered so far — asking for
+        consolidated, cross-cutting takeaways. Parsed insight strings are merged
+        into ``self._insights``, deduped against what is already there.
+
+        Reflection is best-effort: it enriches a run but must never break one.
+        Any failure (LLM error, unparseable response) is caught and logged, and
+        ``self._insights`` keeps whatever it accumulated during execution so
+        ``process`` can still build the manifest. ``output_dir`` is accepted for
+        phase-signature symmetry; like ``_deep_analysis`` this phase surfaces its
+        results through ``self._insights`` rather than writing its own artifact.
+        """
+        transcript = self._results.get("transcribe", {})
+        text = transcript.get("text", "") if isinstance(transcript, dict) else ""
+
+        kp_result = self._results.get("extract_key_points", {})
+        key_points = kp_result.get("key_points", []) if isinstance(kp_result, dict) else []
+        ai_result = self._results.get("extract_action_items", {})
+        action_items = ai_result.get("action_items", []) if isinstance(ai_result, dict) else []
+        diagram_result = self._results.get("detect_diagrams", {})
+        diagrams = diagram_result.get("diagrams", []) if isinstance(diagram_result, dict) else []
+
+        # Nothing was extracted — skip the round-trip rather than reflect on nothing.
+        if not any([text, key_points, action_items, diagrams, self._insights]):
+            return
+
+        kp_lines = "\n".join(f"- {kp.point}" for kp in key_points) or "(none)"
+        ai_lines = "\n".join(f"- {item.action}" for item in action_items) or "(none)"
+        prior = "\n".join(f"- {insight}" for insight in self._insights) or "(none)"
+
+        summary = (
+            f"TRANSCRIPT (excerpt):\n{text[:8000]}\n\n"
+            f"KEY POINTS:\n{kp_lines}\n\n"
+            f"ACTION ITEMS:\n{ai_lines}\n\n"
+            f"DIAGRAMS DETECTED: {len(diagrams)}\n\n"
+            f"OBSERVATIONS SO FAR:\n{prior}"
+        )
+
+        prompt = (
+            "You are reflecting on the results of an automated video analysis. "
+            "Consolidate the most important cross-cutting insights a reader should "
+            "take away: recurring themes, notable gaps, risks, or follow-ups that "
+            "span the extracted points and action items. Be specific and do not "
+            "restate the observations already listed.\n\n"
+            f"{summary}\n\n"
+            'Return a JSON array of concise insight strings: ["insight one", ...]\n'
+            "Return ONLY the JSON array."
+        )
+
+        try:
+            from video_processor.utils.json_parsing import parse_json_from_response
+
+            raw = self.pm.chat([{"role": "user", "content": prompt}], temperature=0.4)
+            parsed = parse_json_from_response(raw)
+            if isinstance(parsed, list):
+                seen = set(self._insights)
+                added = 0
+                for item in parsed:
+                    if not isinstance(item, str):
+                        continue
+                    insight = item.strip()
+                    if insight and insight not in seen:
+                        self._insights.append(insight)
+                        seen.add(insight)
+                        added += 1
+                logger.info(f"Agent reflection: +{added} insights ({len(self._insights)} total)")
+        except Exception as e:
+            logger.warning(f"Reflection failed: {e}")
+
     def _build_manifest(
         self,
         input_path: Path,


### PR DESCRIPTION
## Summary

Fixes #151. `agent-analyze` has been broken on every invocation since the orchestrator was written — `process()` called a Phase 3 method that didn't exist. This implements it, modeled on the `_deep_analysis` sibling: one consolidating LLM pass over the executed step results (transcript excerpt, key points, action items, diagram count, prior insights) asking for cross-cutting takeaways, merged into `self._insights` with dedupe. Any reflection failure logs and degrades — the run always reaches the manifest — and the LLM call is skipped when there's nothing to reflect on.

## Test plan

2 regression tests flipped from `pytest.raises(AttributeError)` to asserting the returned `VideoManifest`; 8 added, including the issue's literal repro at the CLI (`agent-analyze` now exits 0 and writes a round-trippable `manifest.json`). Full suite 1575 passed, 0 failures; coverage 86% (orchestrator.py 97%). Ruff clean.